### PR TITLE
[Feature] 이메일, 닉네임 중복 확인 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AuthController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
 import com.meongnyangerang.meongnyangerang.dto.EmailRequest;
+import com.meongnyangerang.meongnyangerang.dto.NicknameRequest;
 import com.meongnyangerang.meongnyangerang.dto.VerifyCodeRequest;
 import com.meongnyangerang.meongnyangerang.service.AuthService;
 import jakarta.validation.Valid;
@@ -39,6 +40,13 @@ public class AuthController {
   @GetMapping("/email/check")
   public ResponseEntity<Void> checkEmail(@Valid @RequestBody EmailRequest request) {
     authService.checkEmail(request.getEmail());
+    return ResponseEntity.status(HttpStatus.OK).build();
+  }
+
+  // 닉네임 중복 확인 API
+  @GetMapping("/nickname/check")
+  public ResponseEntity<Void> checkNickname(@Valid @RequestBody NicknameRequest request) {
+    authService.checkNickname(request.getNickname());
     return ResponseEntity.status(HttpStatus.OK).build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AuthController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AuthController.java
@@ -7,9 +7,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -30,6 +32,13 @@ public class AuthController {
   @PostMapping("/email/verify-code")
   public ResponseEntity<Void> verifyCode(@Valid @RequestBody VerifyCodeRequest request) {
     authService.verifyCode(request.getEmail(), request.getCode());
+    return ResponseEntity.status(HttpStatus.OK).build();
+  }
+
+  // 이메일 중복 확인 API
+  @GetMapping("/email/check")
+  public ResponseEntity<Void> checkEmail(@Valid @RequestBody EmailRequest request) {
+    authService.checkEmail(request.getEmail());
     return ResponseEntity.status(HttpStatus.OK).build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/NicknameRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/NicknameRequest.java
@@ -1,0 +1,20 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NicknameRequest {
+
+  @Size(min = 2, max = 20)
+  @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+  private String nickname;
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
   // 400 BAD REQUEST (잘못된 요청)
   INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
   DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다"),
+  DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 등록된 닉네임입니다."),
   EXPIRED_AUTH_CODE(HttpStatus.BAD_REQUEST, "인증코드가 만료되었습니다. 다시 발급받아주세요"),
   INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "인증코드가 일치하지 않습니다"),
   AUTH_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "인증코드를 찾을 수 없습니다. 인증코드 받기를 다시 실행해주세요"),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/HostRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/HostRepository.java
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface HostRepository extends JpaRepository<Host, Long> {
   boolean existsByEmail(String email);
+
+  boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/UserRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/UserRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
   boolean existsByEmail(String email);
+
+  boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AuthService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AuthService.java
@@ -2,6 +2,7 @@ package com.meongnyangerang.meongnyangerang.service;
 
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.AUTH_CODE_NOT_FOUND;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_EMAIL;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_NICKNAME;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.EXPIRED_AUTH_CODE;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.INVALID_AUTH_CODE;
 
@@ -13,6 +14,7 @@ import com.meongnyangerang.meongnyangerang.repository.HostRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -80,6 +82,15 @@ public class AuthService {
     // 사용자, 호스트 이메일 중복 동시 체크
     if (userRepository.existsByEmail(email) || hostRepository.existsByEmail(email)) {
       throw new MeongnyangerangException(DUPLICATE_EMAIL);
+    }
+  }
+
+  // 닉네임 중복 확인
+  public void checkNickname(String nickname) {
+
+    // 사용자, 호스트 이메일 중복 동시 체크
+    if (userRepository.existsByNickname(nickname) || hostRepository.existsByNickname(nickname)) {
+      throw new MeongnyangerangException(DUPLICATE_NICKNAME);
     }
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AuthService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AuthService.java
@@ -35,7 +35,7 @@ public class AuthService {
   public void sendVerificationCode(String email) {
 
     // 중복 가입 방지
-    if (userRepository.existsByEmail(email)) {
+    if (userRepository.existsByEmail(email) || hostRepository.existsByEmail(email)) {
       throw new MeongnyangerangException(DUPLICATE_EMAIL);
     }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AuthService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AuthService.java
@@ -34,10 +34,8 @@ public class AuthService {
   @Transactional
   public void sendVerificationCode(String email) {
 
-    // 중복 가입 방지
-    if (userRepository.existsByEmail(email) || hostRepository.existsByEmail(email)) {
-      throw new MeongnyangerangException(DUPLICATE_EMAIL);
-    }
+    // 이메일 중복 검증 메서드
+    checkEmail(email);
 
     // 6자리 랜덤 숫자 생성(Math.random()은 예측 가능한 난수 생성 → 보안 취약 → SecureRandom 사용)
     String code = String.format("%06d", new SecureRandom().nextInt(900_000));

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AuthService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AuthService.java
@@ -9,7 +9,10 @@ import com.meongnyangerang.meongnyangerang.component.MailComponent;
 import com.meongnyangerang.meongnyangerang.domain.auth.AuthenticationCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.AuthenticationCodeRepository;
+import com.meongnyangerang.meongnyangerang.repository.HostRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
   private final UserRepository userRepository;
+  private final HostRepository hostRepository;
   private final AuthenticationCodeRepository authenticationCodeRepository;
   private final MailComponent mailComponent;
 
@@ -70,4 +74,12 @@ public class AuthService {
     authenticationCodeRepository.delete(authCode);
   }
 
+  // 이메일 중복 확인
+  public void checkEmail(String email) {
+
+    // 사용자, 호스트 이메일 중복 동시 체크
+    if (userRepository.existsByEmail(email) || hostRepository.existsByEmail(email)) {
+      throw new MeongnyangerangException(DUPLICATE_EMAIL);
+    }
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -8,6 +8,7 @@ import com.meongnyangerang.meongnyangerang.dto.HostSignupRequest;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.AuthenticationCodeRepository;
 import com.meongnyangerang.meongnyangerang.repository.HostRepository;
+import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,14 +18,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class HostService {
 
+  private final UserRepository userRepository;
   private final HostRepository hostRepository;
   private final AuthenticationCodeRepository authenticationCodeRepository;
 
   // 호스트 회원가입
   public void registerHost(HostSignupRequest request) {
 
-    // 중복 가입 방지
-    if (hostRepository.existsByEmail(request.getEmail())) {
+    // 이메일 중복 가입 방지
+    if (userRepository.existsByEmail(request.getEmail()) ||
+        hostRepository.existsByEmail(request.getEmail())) {
       throw new MeongnyangerangException(DUPLICATE_EMAIL);
     }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -6,7 +6,6 @@ import com.meongnyangerang.meongnyangerang.domain.host.Host;
 import com.meongnyangerang.meongnyangerang.domain.host.HostStatus;
 import com.meongnyangerang.meongnyangerang.dto.HostSignupRequest;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
-import com.meongnyangerang.meongnyangerang.repository.AuthenticationCodeRepository;
 import com.meongnyangerang.meongnyangerang.repository.HostRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +19,6 @@ public class HostService {
 
   private final UserRepository userRepository;
   private final HostRepository hostRepository;
-  private final AuthenticationCodeRepository authenticationCodeRepository;
 
   // 호스트 회원가입
   public void registerHost(HostSignupRequest request) {

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -1,11 +1,13 @@
 package com.meongnyangerang.meongnyangerang.service;
 
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_EMAIL;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.USER_ALREADY_EXISTS;
 
 import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
 import com.meongnyangerang.meongnyangerang.dto.UserSignupRequest;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import com.meongnyangerang.meongnyangerang.repository.HostRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,13 +17,15 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
   private final UserRepository userRepository;
+  private final HostRepository hostRepository;
 
   // 사용자 회원가입
   public void registerUser(UserSignupRequest request) {
 
     // 중복 가입 확인
-    if (userRepository.existsByEmail(request.getEmail())) {
-      throw new MeongnyangerangException(USER_ALREADY_EXISTS);
+    if (userRepository.existsByEmail(request.getEmail()) ||
+        hostRepository.existsByEmail(request.getEmail())) {
+      throw new MeongnyangerangException(DUPLICATE_EMAIL);
     }
 
     // 유저 저장


### PR DESCRIPTION
## 📌 관련 이슈
- close #18 

## 📝 변경 사항
### AS-IS
- 이메일, 닉네임 중복 검증 미구현.
- 인증 코드 발송 및 검증 API에서 중복 검증이 분리되어 있었음.

### TO-BE
- 사용자와 호스트의 이메일 및 닉네임 중복 검증을 통합하여 하나의 중복 확인 로직으로 구현.
- 이메일 중복 확인 API (`GET /api/v1/users/email/check`) 구현:
  - 사용자와 호스트의 이메일을 모두 확인하여 중복 여부를 반환.
- 닉네임 중복 확인 API (`GET /api/v1/users/nickname/check`) 구현:
  - 사용자와 호스트의 닉네임을 모두 확인하여 중복 여부를 반환.
- 성공 시 HTTP 상태 코드 `200 OK` 반환, 중복된 경우 HTTP 상태 코드 `400` 반환.

## 🔍 테스트
- [ ] 테스트 코드 작성:
- [x] API 테스트:
  - Postman을 활용하여 이메일 및 닉네임 중복 확인 API 테스트 완료.
- [x] 로컬 테스트:
  - 로컬 환경에서 정상적으로 동작 확인.

## 📸 스크린샷
// UI 변경사항이 없는 경우 생략

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 리뷰어가 집중해서 봐야 하는 부분:
  - AuthService의 `checkEmail`, `checkNickname` 메서드가 올바르게 검증하는지 확인해주세요.
  - UserController에서 HTTP 상태 코드 반환 로직이 적절한지 확인해주세요.
