### PR TITLE
[Feature] 숙소 수정 API 구현 및 S3 이미지 배치 처리 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/MeongnyangerangApplication.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/MeongnyangerangApplication.java
@@ -3,7 +3,9 @@ package com.meongnyangerang.meongnyangerang;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class MeongnyangerangApplication {

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationController.java
@@ -2,6 +2,7 @@ package com.meongnyangerang.meongnyangerang.controller;
 
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationCreateRequest;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationResponse;
+import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationUpdateRequest;
 import com.meongnyangerang.meongnyangerang.service.AccommodationService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -10,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,7 +31,7 @@ public class AccommodationController {
   // TODO: host만 호출할 수 있도록 수정
   @PostMapping
   public ResponseEntity<Void> createAccommodation(
-      //@AuthenticationPrincipal UserDetail userDetail
+      //@AuthenticationPrincipal UserDetail userDetail,
       @Valid @RequestPart AccommodationCreateRequest request,
       @RequestPart MultipartFile thumbnail,
       @RequestPart(required = false) List<MultipartFile> additionalImages
@@ -48,5 +50,18 @@ public class AccommodationController {
       //@AuthenticationPrincipal UserDetail userDetail
   ){
     return ResponseEntity.ok(accommodationService.getAccommodation(1L));
+  }
+
+  /**
+   * 숙소 수정 API
+   */
+  @PutMapping
+  public ResponseEntity<AccommodationResponse> updateAccommodation(
+      @Valid @RequestPart AccommodationUpdateRequest request,
+      @RequestPart MultipartFile newThumbnail,
+      @RequestPart(required = false) List<MultipartFile> newAdditionalImages
+  ){
+    return ResponseEntity.ok(
+        accommodationService.updateAccommodation(request, newThumbnail, newAdditionalImages));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/accommodation/Accommodation.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/accommodation/Accommodation.java
@@ -1,6 +1,8 @@
 package com.meongnyangerang.meongnyangerang.domain.accommodation;
 
 import com.meongnyangerang.meongnyangerang.domain.host.Host;
+import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationCreateRequest;
+import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -67,4 +69,15 @@ public class Accommodation {
   @LastModifiedDate
   @Column(nullable = false)
   private LocalDateTime updatedAt;
+
+  public void updateAccommodation(AccommodationUpdateRequest request, String thumbnailUrl) {
+    this.name = request.getName();
+    this.description = request.getDescription();
+    this.address = request.getAddress();
+    this.detailedAddress = request.getDetailedAddress();
+    this.latitude = request.getLatitude();
+    this.longitude = request.getLongitude();
+    this.type = request.getType();
+    this.thumbnailUrl = thumbnailUrl;
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/accommodation/Accommodation.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/accommodation/Accommodation.java
@@ -71,13 +71,13 @@ public class Accommodation {
   private LocalDateTime updatedAt;
 
   public void updateAccommodation(AccommodationUpdateRequest request, String thumbnailUrl) {
-    this.name = request.getName();
-    this.description = request.getDescription();
-    this.address = request.getAddress();
-    this.detailedAddress = request.getDetailedAddress();
-    this.latitude = request.getLatitude();
-    this.longitude = request.getLongitude();
-    this.type = request.getType();
+    this.name = request.name();
+    this.description = request.description();
+    this.address = request.address();
+    this.detailedAddress = request.detailedAddress();
+    this.latitude = request.latitude();
+    this.longitude = request.longitude();
+    this.type = request.type();
     this.thumbnailUrl = thumbnailUrl;
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/host/HostStatus.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/host/HostStatus.java
@@ -1,7 +1,5 @@
 package com.meongnyangerang.meongnyangerang.domain.host;
 
-import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
-import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -14,10 +12,4 @@ public enum HostStatus {
   DELETED("삭제됨");
 
   private final String value;
-
-  public static void isStatusByCreateAccommodation(HostStatus status){
-    if (status != HostStatus.ACTIVE) {
-      throw new MeongnyangerangException(ErrorCode.INVALID_AUTHORIZED);
-    }
-  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/image/ImageDeletionQueue.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/image/ImageDeletionQueue.java
@@ -1,0 +1,30 @@
+package com.meongnyangerang.meongnyangerang.domain.image;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ImageDeletionQueue {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String imageUrl;
+
+  @Column(nullable = false)
+  private LocalDateTime registeredAt;
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationCreateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationCreateRequest.java
@@ -41,13 +41,13 @@ public class AccommodationCreateRequest {
   private Double longitude;
 
   @NotEmpty(message = "숙소 편의시설을 하나 이상 선택해 주세요.")
-  private List<AccommodationFacilityType> facilities;
+  private List<AccommodationFacilityType> facilityTypes;
 
   @NotEmpty(message = "반려동물 편의시설을 하나 이상 선택해 주세요.")
-  private List<AccommodationPetFacilityType> petFacilities;
+  private List<AccommodationPetFacilityType> petFacilityTypes;
 
   @NotEmpty(message = "허용 가능한 반려동물 유형을 하나 이상 선택해 주세요.")
-  private List<PetType> allowPets;
+  private List<PetType> allowPetTypes;
 
   public Accommodation toEntity(Host host, String thumbnailUrl) {
     return Accommodation.builder()

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationResponse.java
@@ -17,9 +17,9 @@ public record AccommodationResponse(
     Double latitude,
     Double longitude,
     String thumbnailUrl,
-    List<String> facilities,
-    List<String> petFacilities,
-    List<String> allowPets,
+    List<String> facilityTypes,
+    List<String> petFacilityTypes,
+    List<String> allowPetTypes,
     List<String> additionalImageUrls
 ) {
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationResponse.java
@@ -20,7 +20,7 @@ public record AccommodationResponse(
     List<String> facilities,
     List<String> petFacilities,
     List<String> allowPets,
-    List<String> additionalImages
+    List<String> additionalImageUrls
 ) {
 
   public static AccommodationResponse of(

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationUpdateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationUpdateRequest.java
@@ -1,0 +1,58 @@
+package com.meongnyangerang.meongnyangerang.dto.accommodation;
+
+import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationType;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.PetType;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.facility.AccommodationFacilityType;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.facility.AccommodationPetFacilityType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AccommodationUpdateRequest {
+
+  @NotNull(message = "숙소 ID를 요청해 주세요.")
+  private Long accommodationId;
+
+  @NotBlank(message = "숙소 이름을 입력해 주세요.")
+  private String name;
+
+  @NotNull(message = "숙소 유형을 선택해 주세요.")
+  private AccommodationType type;
+
+  @NotBlank(message = "숙소 주소를 입력해 주세요.")
+  private String address;
+
+  private String detailedAddress;
+
+  private String description;
+
+  @NotNull(message = "숙소의 위치 정보를 제공해 주세요.")
+  private Double latitude;
+
+  @NotNull(message = "숙소의 위치 정보를 제공해 주세요.")
+  private Double longitude;
+
+  @NotEmpty(message = "기존 대표 이미지의 URL은 비어 있을 수 없습니다.")
+  private String oldThumbnailUrl;
+
+  private final List<String> oldAdditionalImageUrls = new ArrayList<>();
+
+  @NotEmpty(message = "숙소 편의시설을 하나 이상 선택해 주세요.")
+  private List<AccommodationFacilityType> facilities;
+
+  @NotEmpty(message = "반려동물 편의시설을 하나 이상 선택해 주세요.")
+  private List<AccommodationPetFacilityType> petFacilities;
+
+  @NotEmpty(message = "허용 가능한 반려동물 유형을 하나 이상 선택해 주세요.")
+  private List<PetType> allowPets;
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationUpdateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationUpdateRequest.java
@@ -9,50 +9,71 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.util.Optional;
 
-@Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class AccommodationUpdateRequest {
+public record AccommodationUpdateRequest(
 
-  @NotNull(message = "숙소 ID를 요청해 주세요.")
-  private Long accommodationId;
+    @NotNull(message = "숙소 ID를 요청해 주세요.")
+    Long accommodationId,
 
-  @NotBlank(message = "숙소 이름을 입력해 주세요.")
-  private String name;
+    @NotBlank(message = "숙소 이름을 입력해 주세요.")
+    String name,
 
-  @NotNull(message = "숙소 유형을 선택해 주세요.")
-  private AccommodationType type;
+    @NotNull(message = "숙소 유형을 선택해 주세요.")
+    AccommodationType type,
 
-  @NotBlank(message = "숙소 주소를 입력해 주세요.")
-  private String address;
+    @NotBlank(message = "숙소 주소를 입력해 주세요.")
+    String address,
 
-  private String detailedAddress;
+    String detailedAddress,
 
-  private String description;
+    String description,
 
-  @NotNull(message = "숙소의 위치 정보를 제공해 주세요.")
-  private Double latitude;
+    @NotNull(message = "숙소의 위치 정보를 제공해 주세요.")
+    Double latitude,
 
-  @NotNull(message = "숙소의 위치 정보를 제공해 주세요.")
-  private Double longitude;
+    @NotNull(message = "숙소의 위치 정보를 제공해 주세요.")
+    Double longitude,
 
-  @NotEmpty(message = "기존 대표 이미지의 URL은 비어 있을 수 없습니다.")
-  private String oldThumbnailUrl;
+    @NotEmpty(message = "대표 이미지의 URL은 비어 있을 수 없습니다.")
+    String oldThumbnailUrl,
 
-  private final List<String> oldAdditionalImageUrls = new ArrayList<>();
+    List<String> oldAdditionalImageUrls,
 
-  @NotEmpty(message = "숙소 편의시설을 하나 이상 선택해 주세요.")
-  private List<AccommodationFacilityType> facilityTypes;
+    @NotEmpty(message = "숙소 편의시설을 하나 이상 선택해 주세요.")
+    List<AccommodationFacilityType> facilityTypes,
 
-  @NotEmpty(message = "반려동물 편의시설을 하나 이상 선택해 주세요.")
-  private List<AccommodationPetFacilityType> petFacilityTypes;
+    @NotEmpty(message = "반려동물 편의시설을 하나 이상 선택해 주세요.")
+    List<AccommodationPetFacilityType> petFacilityTypes,
 
-  @NotEmpty(message = "허용 가능한 반려동물 유형을 하나 이상 선택해 주세요.")
-  private List<PetType> allowPetTypes;
+    @NotEmpty(message = "허용 가능한 반려동물 유형을 하나 이상 선택해 주세요.")
+    List<PetType> allowPetTypes
+) {
+
+  public AccommodationUpdateRequest {
+    oldAdditionalImageUrls = Optional.ofNullable(oldAdditionalImageUrls)
+        .orElseGet(ArrayList::new);
+  }
+
+  public static AccommodationUpdateRequest of(
+      Long accommodationId,
+      String name,
+      AccommodationType type,
+      String address,
+      String detailedAddress,
+      String description,
+      Double latitude,
+      Double longitude,
+      String oldThumbnailUrl,
+      List<String> oldAdditionalImageUrls,
+      List<AccommodationFacilityType> facilityTypes,
+      List<AccommodationPetFacilityType> petFacilityTypes,
+      List<PetType> allowPetTypes
+  ) {
+    return new AccommodationUpdateRequest(
+        accommodationId, name, type, address, detailedAddress,
+        description, latitude, longitude, oldThumbnailUrl,
+        oldAdditionalImageUrls, facilityTypes, petFacilityTypes, allowPetTypes
+    );
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationUpdateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationUpdateRequest.java
@@ -48,11 +48,11 @@ public class AccommodationUpdateRequest {
   private final List<String> oldAdditionalImageUrls = new ArrayList<>();
 
   @NotEmpty(message = "숙소 편의시설을 하나 이상 선택해 주세요.")
-  private List<AccommodationFacilityType> facilities;
+  private List<AccommodationFacilityType> facilityTypes;
 
   @NotEmpty(message = "반려동물 편의시설을 하나 이상 선택해 주세요.")
-  private List<AccommodationPetFacilityType> petFacilities;
+  private List<AccommodationPetFacilityType> petFacilityTypes;
 
   @NotEmpty(message = "허용 가능한 반려동물 유형을 하나 이상 선택해 주세요.")
-  private List<PetType> allowPets;
+  private List<PetType> allowPetTypes;
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -46,7 +46,8 @@ public enum ErrorCode {
   EMAIL_NOT_SEND(HttpStatus.INTERNAL_SERVER_ERROR, "이메일이 정상적으로 전송되지 않았습니다."),
   AMAZON_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "아마존 서비스 오류"),
   INVALID_IO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 IO 오류"),
-  REGISTRATION_ACCOMMODATION(HttpStatus.INTERNAL_SERVER_ERROR, "숙소 등록 오류")
+  REGISTRATION_ACCOMMODATION(HttpStatus.INTERNAL_SERVER_ERROR, "숙소 등록 오류"),
+  UPDATE_ACCOMMODATION(HttpStatus.INTERNAL_SERVER_ERROR, "숙소 수정 오류"),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/ImageDeletionQueueRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/ImageDeletionQueueRepository.java
@@ -1,0 +1,13 @@
+package com.meongnyangerang.meongnyangerang.repository;
+
+import com.meongnyangerang.meongnyangerang.domain.image.ImageDeletionQueue;
+import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ImageDeletionQueueRepository extends JpaRepository<ImageDeletionQueue, Long> {
+
+  List<ImageDeletionQueue> findAllByOrderByRegisteredAtAsc(PageRequest of);
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/accommodation/AccommodationFacilityRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/accommodation/AccommodationFacilityRepository.java
@@ -10,4 +10,6 @@ public interface AccommodationFacilityRepository extends
     JpaRepository<AccommodationFacility, Long> {
 
   List<AccommodationFacility> findAllByAccommodationId(Long accommodationId);
+
+  void deleteAllByAccommodationId(Long accommodationId);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/accommodation/AccommodationImageRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/accommodation/AccommodationImageRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface AccommodationImageRepository extends JpaRepository<AccommodationImage, Long> {
 
   List<AccommodationImage> findAllByAccommodationId(Long accommodationId);
+
+  void deleteAllByAccommodationId(Long accommodationId);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/accommodation/AccommodationPetFacilityRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/accommodation/AccommodationPetFacilityRepository.java
@@ -10,4 +10,6 @@ public interface AccommodationPetFacilityRepository extends
     JpaRepository<AccommodationPetFacility, Long> {
 
   List<AccommodationPetFacility> findAllByAccommodationId(Long accommodationId);
+
+  void deleteAllByAccommodationId(Long accommodationId);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/accommodation/AllowPetRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/accommodation/AllowPetRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface AllowPetRepository extends JpaRepository<AllowPet, Long> {
 
   List<AllowPet> findAllByAccommodationId(Long accommodationId);
+
+  void deleteAllByAccommodationId(Long accommodationId);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
@@ -85,9 +85,9 @@ public class AccommodationService {
       List<String> imageUrls
   ) {
     accommodationRepository.save(accommodation);
-    saveAccommodationFacilities(request.getFacilities(), accommodation);
-    saveAccommodationPetFacilities(request.getPetFacilities(), accommodation);
-    saveAllowPets(request.getAllowPets(), accommodation);
+    saveAccommodationFacilities(request.getFacilityTypes(), accommodation);
+    saveAccommodationPetFacilities(request.getPetFacilityTypes(), accommodation);
+    saveAllowPets(request.getAllowPetTypes(), accommodation);
     saveAdditionalImages(imageUrls, accommodation);
   }
 
@@ -141,10 +141,10 @@ public class AccommodationService {
       AccommodationResponse accommodationResponse = updateData(request, thumbnailUrl, imageUrls);
 
       List<String> oldImages =
-          imagesDeleted(request.getOldThumbnailUrl(), request.getOldAdditionalImageUrls());
+          imagesDeleted(request.oldThumbnailUrl(), request.oldAdditionalImageUrls());
       imageService.registerImagesForDeletion(oldImages);
 
-      log.info("숙소 수정 성공, 숙소 ID : {}", request.getAccommodationId());
+      log.info("숙소 수정 성공, 숙소 ID : {}", request.accommodationId());
       return accommodationResponse;
 
     } catch (MeongnyangerangException e) {
@@ -162,7 +162,7 @@ public class AccommodationService {
       String thumbnailUrl,
       List<String> imageUrls
   ) {
-    Long accommodationId = request.getAccommodationId();
+    Long accommodationId = request.accommodationId();
 
     Accommodation accommodation = accommodationRepository.findById(accommodationId)
         .orElseThrow(() -> new MeongnyangerangException(ErrorCode.ACCOMMODATION_NOT_FOUND));
@@ -170,14 +170,14 @@ public class AccommodationService {
 
     accommodationFacilityRepository.deleteAllByAccommodationId(accommodationId);
     List<AccommodationFacility> facilities =
-        saveAccommodationFacilities(request.getFacilityTypes(), accommodation);
+        saveAccommodationFacilities(request.facilityTypes(), accommodation);
 
     accommodationPetFacilityRepository.deleteAllByAccommodationId(accommodationId);
     List<AccommodationPetFacility> petFacilities =
-        saveAccommodationPetFacilities(request.getPetFacilityTypes(), accommodation);
+        saveAccommodationPetFacilities(request.petFacilityTypes(), accommodation);
 
     allowPetRepository.deleteAllByAccommodationId(accommodationId);
-    List<AllowPet> allowPets = saveAllowPets(request.getAllowPetTypes(), accommodation);
+    List<AllowPet> allowPets = saveAllowPets(request.allowPetTypes(), accommodation);
 
     accommodationImageRepository.deleteAllByAccommodationId(accommodationId);
     List<AccommodationImage> accommodationImages = saveAdditionalImages(imageUrls, accommodation);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
@@ -170,14 +170,14 @@ public class AccommodationService {
 
     accommodationFacilityRepository.deleteAllByAccommodationId(accommodationId);
     List<AccommodationFacility> facilities =
-        saveAccommodationFacilities(request.getFacilities(), accommodation);
+        saveAccommodationFacilities(request.getFacilityTypes(), accommodation);
 
     accommodationPetFacilityRepository.deleteAllByAccommodationId(accommodationId);
     List<AccommodationPetFacility> petFacilities =
-        saveAccommodationPetFacilities(request.getPetFacilities(), accommodation);
+        saveAccommodationPetFacilities(request.getPetFacilityTypes(), accommodation);
 
     allowPetRepository.deleteAllByAccommodationId(accommodationId);
-    List<AllowPet> allowPets = saveAllowPets(request.getAllowPets(), accommodation);
+    List<AllowPet> allowPets = saveAllowPets(request.getAllowPetTypes(), accommodation);
 
     accommodationImageRepository.deleteAllByAccommodationId(accommodationId);
     List<AccommodationImage> accommodationImages = saveAdditionalImages(imageUrls, accommodation);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
@@ -9,9 +9,9 @@ import com.meongnyangerang.meongnyangerang.domain.accommodation.facility.Accommo
 import com.meongnyangerang.meongnyangerang.domain.accommodation.facility.AccommodationPetFacility;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.facility.AccommodationPetFacilityType;
 import com.meongnyangerang.meongnyangerang.domain.host.Host;
-import com.meongnyangerang.meongnyangerang.domain.host.HostStatus;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationCreateRequest;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationResponse;
+import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationUpdateRequest;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.HostRepository;
@@ -23,10 +23,8 @@ import com.meongnyangerang.meongnyangerang.repository.accommodation.AllowPetRepo
 import com.meongnyangerang.meongnyangerang.service.image.ImageService;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,39 +48,47 @@ public class AccommodationService {
   /**
    * 숙소 등록
    */
-  @Transactional
   public void createAccommodation(
       Long hostId,
       AccommodationCreateRequest request,
       MultipartFile thumbnail,
       List<MultipartFile> additionalImages
   ) {
-    additionalImages = additionalImages == null ? Collections.emptyList() : additionalImages;
     Host host = validateHost(hostId);
+    additionalImages = initAdditionalImages(additionalImages);
 
     List<String> uploadedImageUrls = new ArrayList<>(); // 업로드 성공한 이미지 추적
 
     try {
       String thumbnailUrl = imageService.storeImage(thumbnail);
       uploadedImageUrls.add(thumbnailUrl);
-
-      Map<String, MultipartFile> imageUrlMap =
-          createImageUrlMap(additionalImages, uploadedImageUrls);
+      List<String> imageUrls = storeImages(additionalImages, uploadedImageUrls);
 
       Accommodation accommodation = request.toEntity(host, thumbnailUrl);
-      accommodationRepository.save(accommodation);
+      saveData(request, accommodation, imageUrls);
 
-      saveAccommodationFacilities(request.getFacilities(), accommodation);
-      saveAccommodationPetFacilities(request.getPetFacilities(), accommodation);
-      saveAllowPets(request.getAllowPets(), accommodation);
-      saveAdditionalImages(imageUrlMap.keySet(), accommodation);
-
-      log.info("숙소 등록 완료: 호스트 ID={}, 숙소 ID={}", hostId, accommodation.getId());
+      log.info("숙소 등록 성공, 호스트 ID : {}, 숙소 ID : {}", hostId, accommodation.getId());
+    } catch (MeongnyangerangException e) {
+      imageService.deleteImages(uploadedImageUrls);
+      throw e;
     } catch (Exception e) {
-      log.error("숙소 등록 에러 발생, S3에 업로드된 이미지 삭제");
+      log.error("숙소 등록 에러 발생, S3에 업로드된 이미지 삭제, 원인: {}", e.getMessage());
       imageService.deleteImages(uploadedImageUrls);
       throw new MeongnyangerangException(ErrorCode.REGISTRATION_ACCOMMODATION);
     }
+  }
+
+  @Transactional
+  public void saveData(
+      AccommodationCreateRequest request,
+      Accommodation accommodation,
+      List<String> imageUrls
+  ) {
+    accommodationRepository.save(accommodation);
+    saveAccommodationFacilities(request.getFacilities(), accommodation);
+    saveAccommodationPetFacilities(request.getPetFacilities(), accommodation);
+    saveAllowPets(request.getAllowPets(), accommodation);
+    saveAdditionalImages(imageUrls, accommodation);
   }
 
   /**
@@ -92,7 +98,7 @@ public class AccommodationService {
     Accommodation accommodation = accommodationRepository.findByHostId(hostId)
         .orElseThrow(() -> new MeongnyangerangException(ErrorCode.ACCOMMODATION_NOT_FOUND));
 
-   Long accommodationId = accommodation.getId();
+    Long accommodationId = accommodation.getId();
 
     List<AccommodationFacility> facilities = accommodationFacilityRepository
         .findAllByAccommodationId(accommodationId);
@@ -114,47 +120,93 @@ public class AccommodationService {
     );
   }
 
-  private Map<String, MultipartFile> createImageUrlMap(
+  /**
+   * 숙소 수정
+   */
+  @Transactional
+  public AccommodationResponse updateAccommodation(
+      AccommodationUpdateRequest request,
+      MultipartFile thumbnail,
+      List<MultipartFile> additionalImages
+  ) {
+    additionalImages = initAdditionalImages(additionalImages);
+
+    List<String> uploadedImageUrls = new ArrayList<>(); // 업로드 성공한 이미지 추적
+
+    try {
+      String thumbnailUrl = imageService.storeImage(thumbnail);
+      uploadedImageUrls.add(thumbnailUrl);
+      List<String> imageUrls = storeImages(additionalImages, uploadedImageUrls);
+
+      AccommodationResponse accommodationResponse = updateData(request, thumbnailUrl, imageUrls);
+
+      List<String> oldImages =
+          imagesDeleted(request.getOldThumbnailUrl(), request.getOldAdditionalImageUrls());
+      imageService.registerImagesForDeletion(oldImages);
+
+      log.info("숙소 수정 성공, 숙소 ID : {}", request.getAccommodationId());
+      return accommodationResponse;
+
+    } catch (MeongnyangerangException e) {
+      imageService.deleteImages(uploadedImageUrls);
+      throw e;
+    } catch (Exception e) {
+      log.error("숙소 수정 에러 발생, S3에 업로드된 이미지 삭제 처리, 원인: {}", e.getMessage());
+      imageService.deleteImages(uploadedImageUrls);
+      throw new MeongnyangerangException(ErrorCode.REGISTRATION_ACCOMMODATION);
+    }
+  }
+
+  private AccommodationResponse updateData(
+      AccommodationUpdateRequest request,
+      String thumbnailUrl,
+      List<String> imageUrls
+  ) {
+    Long accommodationId = request.getAccommodationId();
+
+    Accommodation accommodation = accommodationRepository.findById(accommodationId)
+        .orElseThrow(() -> new MeongnyangerangException(ErrorCode.ACCOMMODATION_NOT_FOUND));
+    accommodation.updateAccommodation(request, thumbnailUrl);
+
+    accommodationFacilityRepository.deleteAllByAccommodationId(accommodationId);
+    List<AccommodationFacility> facilities =
+        saveAccommodationFacilities(request.getFacilities(), accommodation);
+
+    accommodationPetFacilityRepository.deleteAllByAccommodationId(accommodationId);
+    List<AccommodationPetFacility> petFacilities =
+        saveAccommodationPetFacilities(request.getPetFacilities(), accommodation);
+
+    allowPetRepository.deleteAllByAccommodationId(accommodationId);
+    List<AllowPet> allowPets = saveAllowPets(request.getAllowPets(), accommodation);
+
+    accommodationImageRepository.deleteAllByAccommodationId(accommodationId);
+    List<AccommodationImage> accommodationImages = saveAdditionalImages(imageUrls, accommodation);
+
+    return AccommodationResponse.of(
+        accommodation,
+        facilities,
+        petFacilities,
+        allowPets,
+        accommodationImages
+    );
+  }
+
+  private List<String> storeImages(
       List<MultipartFile> additionalImages,
       List<String> uploadedImageUrls
   ) {
-    Map<String, MultipartFile> imageUrlMap = new HashMap<>();
+    List<String> imageUrls = new ArrayList<>();
 
     for (MultipartFile image : additionalImages) {
       String imageUrl = imageService.storeImage(image);
-      imageUrlMap.put(imageUrl, image);
+      imageUrls.add(imageUrl);
       uploadedImageUrls.add(imageUrl);
     }
-    return imageUrlMap;
+
+    return imageUrls;
   }
 
-  private Host validateHost(Long hostId) {
-    // 호스트 존재하는지 검증
-    Host host = hostRepository.findById(hostId)
-        .orElseThrow(() -> new MeongnyangerangException(ErrorCode.NOT_EXISTS_HOST));
-
-    // 유효한 호스트 상태인지 검증
-    HostStatus.isStatusByCreateAccommodation(host.getStatus());
-
-    // 개설한 숙소가 있는지 검증
-    if (accommodationRepository.existsByHostId(hostId)) {
-      throw new MeongnyangerangException(ErrorCode.ACCOMMODATION_ALREADY_EXISTS);
-    }
-    return host;
-  }
-
-  private void saveAdditionalImages(Set<String> filenames, Accommodation accommodation) {
-    List<AccommodationImage> accommodationImages = filenames.stream()
-        .map(filename -> AccommodationImage.builder()
-            .accommodation(accommodation)
-            .imageUrl(filename)
-            .build())
-        .toList();
-
-    accommodationImageRepository.saveAll(accommodationImages);
-  }
-
-  private void saveAccommodationFacilities(
+  private List<AccommodationFacility> saveAccommodationFacilities(
       List<AccommodationFacilityType> facilityTypes, Accommodation accommodation
   ) {
     List<AccommodationFacility> facilities = facilityTypes.stream()
@@ -164,10 +216,10 @@ public class AccommodationService {
             .build())
         .collect(Collectors.toList());
 
-    accommodationFacilityRepository.saveAll(facilities);
+    return accommodationFacilityRepository.saveAll(facilities);
   }
 
-  private void saveAccommodationPetFacilities(
+  private List<AccommodationPetFacility> saveAccommodationPetFacilities(
       List<AccommodationPetFacilityType> petFacilityTypes, Accommodation accommodation
   ) {
     List<AccommodationPetFacility> petFacilities = petFacilityTypes.stream()
@@ -177,10 +229,10 @@ public class AccommodationService {
             .build())
         .collect(Collectors.toList());
 
-    accommodationPetFacilityRepository.saveAll(petFacilities);
+    return accommodationPetFacilityRepository.saveAll(petFacilities);
   }
 
-  private void saveAllowPets(List<PetType> petTypes, Accommodation accommodation) {
+  private List<AllowPet> saveAllowPets(List<PetType> petTypes, Accommodation accommodation) {
     List<AllowPet> allowPets = petTypes.stream()
         .map(petType -> AllowPet.builder()
             .accommodation(accommodation)
@@ -188,6 +240,49 @@ public class AccommodationService {
             .build())
         .collect(Collectors.toList());
 
-    allowPetRepository.saveAll(allowPets);
+    return allowPetRepository.saveAll(allowPets);
+  }
+
+  private List<AccommodationImage> saveAdditionalImages(List<String> filenames,
+      Accommodation accommodation) {
+    List<AccommodationImage> accommodationImages = filenames.stream()
+        .map(filename -> AccommodationImage.builder()
+            .accommodation(accommodation)
+            .imageUrl(filename)
+            .build())
+        .toList();
+
+    return accommodationImageRepository.saveAll(accommodationImages);
+  }
+
+  private static List<MultipartFile> initAdditionalImages(List<MultipartFile> additionalImages) {
+    return Optional.ofNullable(additionalImages)
+        .orElseGet(Collections::emptyList);
+  }
+
+  private static List<String> imagesDeleted(String oldThumbnailUrl,
+      List<String> oldAdditionalImageUrls) {
+    List<String> oldImages = new ArrayList<>();
+    oldImages.add(oldThumbnailUrl);
+    oldImages.addAll(oldAdditionalImageUrls);
+    return oldImages;
+  }
+
+  private Host validateHost(Long hostId) {
+    Host host = getHost(hostId);
+    validateNotExistsAccommodation(hostId);
+
+    return host;
+  }
+
+  private void validateNotExistsAccommodation(Long hostId) {
+    if (accommodationRepository.existsByHostId(hostId)) {
+      throw new MeongnyangerangException(ErrorCode.ACCOMMODATION_ALREADY_EXISTS);
+    }
+  }
+
+  private Host getHost(Long hostId) {
+    return hostRepository.findById(hostId)
+        .orElseThrow(() -> new MeongnyangerangException(ErrorCode.NOT_EXISTS_HOST));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
@@ -256,12 +256,12 @@ public class AccommodationService {
     return accommodationImageRepository.saveAll(accommodationImages);
   }
 
-  private static List<MultipartFile> initAdditionalImages(List<MultipartFile> additionalImages) {
+  private List<MultipartFile> initAdditionalImages(List<MultipartFile> additionalImages) {
     return Optional.ofNullable(additionalImages)
         .orElseGet(Collections::emptyList);
   }
 
-  private static List<String> imagesDeleted(
+  private List<String> imagesDeleted(
       String oldThumbnailUrl, List<String> oldAdditionalImageUrls
   ) {
     List<String> oldImages = new ArrayList<>();

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
@@ -243,8 +243,9 @@ public class AccommodationService {
     return allowPetRepository.saveAll(allowPets);
   }
 
-  private List<AccommodationImage> saveAdditionalImages(List<String> filenames,
-      Accommodation accommodation) {
+  private List<AccommodationImage> saveAdditionalImages(
+      List<String> filenames, Accommodation accommodation
+  ) {
     List<AccommodationImage> accommodationImages = filenames.stream()
         .map(filename -> AccommodationImage.builder()
             .accommodation(accommodation)
@@ -260,8 +261,9 @@ public class AccommodationService {
         .orElseGet(Collections::emptyList);
   }
 
-  private static List<String> imagesDeleted(String oldThumbnailUrl,
-      List<String> oldAdditionalImageUrls) {
+  private static List<String> imagesDeleted(
+      String oldThumbnailUrl, List<String> oldAdditionalImageUrls
+  ) {
     List<String> oldImages = new ArrayList<>();
     oldImages.add(oldThumbnailUrl);
     oldImages.addAll(oldAdditionalImageUrls);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/image/ImageService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/image/ImageService.java
@@ -73,6 +73,7 @@ public class ImageService {
 
   // TODO: 젠킨스 사용 고려
   @Scheduled(cron = "0 0/10 * * * ?") // 10분마다 실행
+  //@Scheduled(cron = "0/10 * * * * ?") // 10초마다 실행 (테스트)
   @Transactional
   public void processImageDeletionQueue() {
     log.info("이미지 삭제 큐 처리 시작");
@@ -90,8 +91,8 @@ public class ImageService {
           .toList();
 
       deleteImages(imageUrls);
-      deleteImageQueue(images);
 
+      imageDeletionQueueRepository.deleteAll(images);
       log.info("이미지 삭제 큐 처리 완료");
     } catch (Exception e) {
       log.error("이미지 삭제 큐 처리 중 오류 발생: {}", e.getMessage(), e);
@@ -101,10 +102,6 @@ public class ImageService {
   private List<ImageDeletionQueue> fetchPendingImages() {
     return imageDeletionQueueRepository
         .findAllByOrderByRegisteredAtAsc(PageRequest.of(0, BATCH_SIZE));
-  }
-
-  private void deleteImageQueue(List<ImageDeletionQueue> images) {
-    imageDeletionQueueRepository.deleteAll(images);
   }
 
   /**

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/image/ImageService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/image/ImageService.java
@@ -1,12 +1,18 @@
 package com.meongnyangerang.meongnyangerang.service.image;
 
+import com.meongnyangerang.meongnyangerang.domain.image.ImageDeletionQueue;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import com.meongnyangerang.meongnyangerang.repository.ImageDeletionQueueRepository;
 import com.meongnyangerang.meongnyangerang.service.adptor.ImageStorage;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
@@ -15,6 +21,9 @@ import org.springframework.web.multipart.MultipartFile;
 public class ImageService {
 
   private final ImageStorage imageStorage;
+  private final ImageDeletionQueueRepository imageDeletionQueueRepository;
+
+  private static final int BATCH_SIZE = 100;
 
   /**
    * 이미지 업로드
@@ -44,6 +53,58 @@ public class ImageService {
       throw new MeongnyangerangException(ErrorCode.FILE_NOT_EMPTY);
     }
     imageStorage.deleteFiles(fileUrls);
+  }
+
+  /**
+   * 이미지 삭제를 배치 처리하기 위해 삭제할 데이터 저장
+   */
+  public void registerImagesForDeletion(List<String> imageUrls) {
+    List<ImageDeletionQueue> deletionEntries = imageUrls.stream()
+        .filter(url -> !url.isEmpty())
+        .map(url -> ImageDeletionQueue.builder()
+            .imageUrl(url)
+            .registeredAt(LocalDateTime.now())
+            .build())
+        .toList();
+
+    imageDeletionQueueRepository.saveAll(deletionEntries);
+    log.info("이미지 삭제 큐에 {}개 항목 등록 완료", deletionEntries.size());
+  }
+
+  // TODO: 젠킨스 사용 고려
+  @Scheduled(cron = "0 0/10 * * * ?") // 10분마다 실행
+  @Transactional
+  public void processImageDeletionQueue() {
+    log.info("이미지 삭제 큐 처리 시작");
+
+    try {
+      List<ImageDeletionQueue> images = fetchPendingImages();
+
+      if (images.isEmpty()) {
+        log.info("처리할 삭제 대기 이미지가 없습니다.");
+        return;
+      }
+
+      List<String> imageUrls = images.stream()
+          .map(ImageDeletionQueue::getImageUrl)
+          .toList();
+
+      deleteImages(imageUrls);
+      deleteImageQueue(images);
+
+      log.info("이미지 삭제 큐 처리 완료");
+    } catch (Exception e) {
+      log.error("이미지 삭제 큐 처리 중 오류 발생: {}", e.getMessage(), e);
+    }
+  }
+
+  private List<ImageDeletionQueue> fetchPendingImages() {
+    return imageDeletionQueueRepository
+        .findAllByOrderByRegisteredAtAsc(PageRequest.of(0, BATCH_SIZE));
+  }
+
+  private void deleteImageQueue(List<ImageDeletionQueue> images) {
+    imageDeletionQueueRepository.deleteAll(images);
   }
 
   /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,11 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
   jpa:
     show-sql: true
     database: mysql

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationServiceTest.java
@@ -94,7 +94,6 @@ class AccommodationServiceTest {
   private List<AccommodationPetFacility> petFacilities;
   private List<AllowPet> allowPets;
   private List<AccommodationImage> accommodationImages;
-  private List<String> oldAdditionalImageUrls;
 
   @BeforeEach
   void setUp() {
@@ -127,27 +126,26 @@ class AccommodationServiceTest {
         .description("test-description")
         .latitude(37.123)
         .longitude(127.123)
-        .facilities(FACILITY_TYPES)
-        .petFacilities(PET_FACILITY_TYPES)
-        .allowPets(PET_TYPES)
-        .build();
-
-    updateRequest = AccommodationUpdateRequest.builder()
-        .accommodationId(accommodation.getId())
-        .name("test-name")
-        .type(AccommodationType.PENSION)
-        .address("test-address")
-        .detailedAddress("test-detailedAddress")
-        .description("test-description")
-        .latitude(37.123)
-        .longitude(127.123)
-        .oldThumbnailUrl(OLD_THUMBNAIL_URL)
         .facilityTypes(FACILITY_TYPES)
         .petFacilityTypes(PET_FACILITY_TYPES)
         .allowPetTypes(PET_TYPES)
         .build();
 
-    oldAdditionalImageUrls = Arrays.asList("old-url-1", "old-url-2");
+    updateRequest = AccommodationUpdateRequest.of(
+        accommodation.getId(),
+        "test-name",
+        AccommodationType.PENSION,
+        "test-address",
+        "test-detailedAddress",
+        "test-description",
+        37.123,
+        127.123,
+        OLD_THUMBNAIL_URL,
+        null,  // oldAdditionalImageUrls
+        FACILITY_TYPES,
+        PET_FACILITY_TYPES,
+        PET_TYPES
+    );
 
     facilities = Arrays.asList(AccommodationFacility.builder()
             .id(1L)
@@ -348,7 +346,8 @@ class AccommodationServiceTest {
     // 허용 반려동물 목록 검증
     assertThat(response.allowPetTypes()).hasSize(allowPets.size());
     for (int i = 0; i < allowPets.size(); i++) {
-      assertThat(response.allowPetTypes().get(i)).isEqualTo(allowPets.get(i).getPetType().getValue());
+      assertThat(response.allowPetTypes().get(i)).isEqualTo(
+          allowPets.get(i).getPetType().getValue());
     }
 
     // 추가 이미지 목록 검증

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationServiceTest.java
@@ -142,9 +142,9 @@ class AccommodationServiceTest {
         .latitude(37.123)
         .longitude(127.123)
         .oldThumbnailUrl(OLD_THUMBNAIL_URL)
-        .facilities(FACILITY_TYPES)
-        .petFacilities(PET_FACILITY_TYPES)
-        .allowPets(PET_TYPES)
+        .facilityTypes(FACILITY_TYPES)
+        .petFacilityTypes(PET_FACILITY_TYPES)
+        .allowPetTypes(PET_TYPES)
         .build();
 
     oldAdditionalImageUrls = Arrays.asList("old-url-1", "old-url-2");
@@ -333,22 +333,22 @@ class AccommodationServiceTest {
     assertThat(response.thumbnailUrl()).isEqualTo(accommodation.getThumbnailUrl());
 
     // 시설 목록 검증
-    assertThat(response.facilities()).hasSize(facilities.size());
+    assertThat(response.facilityTypes()).hasSize(facilities.size());
     for (int i = 0; i < facilities.size(); i++) {
-      assertThat(response.facilities().get(i)).isEqualTo(facilities.get(i).getType().getValue());
+      assertThat(response.facilityTypes().get(i)).isEqualTo(facilities.get(i).getType().getValue());
     }
 
     // 반려동물 시설 목록 검증
-    assertThat(response.petFacilities()).hasSize(petFacilities.size());
+    assertThat(response.petFacilityTypes()).hasSize(petFacilities.size());
     for (int i = 0; i < petFacilities.size(); i++) {
-      assertThat(response.petFacilities().get(i))
+      assertThat(response.petFacilityTypes().get(i))
           .isEqualTo(petFacilities.get(i).getType().getValue());
     }
 
     // 허용 반려동물 목록 검증
-    assertThat(response.allowPets()).hasSize(allowPets.size());
+    assertThat(response.allowPetTypes()).hasSize(allowPets.size());
     for (int i = 0; i < allowPets.size(); i++) {
-      assertThat(response.allowPets().get(i)).isEqualTo(allowPets.get(i).getPetType().getValue());
+      assertThat(response.allowPetTypes().get(i)).isEqualTo(allowPets.get(i).getPetType().getValue());
     }
 
     // 추가 이미지 목록 검증

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/image/ImageServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/image/ImageServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.service.adptor.ImageStorage;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/image/ImageServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/image/ImageServiceTest.java
@@ -1,16 +1,32 @@
 package com.meongnyangerang.meongnyangerang.service.image;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.meongnyangerang.meongnyangerang.domain.image.ImageDeletionQueue;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import com.meongnyangerang.meongnyangerang.repository.ImageDeletionQueueRepository;
 import com.meongnyangerang.meongnyangerang.service.adptor.ImageStorage;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.mock.web.MockMultipartFile;
 
 @ExtendWith(MockitoExtension.class)
@@ -19,8 +35,22 @@ class ImageServiceTest {
   @Mock
   private ImageStorage imageStorage;
 
+  @Mock
+  private ImageDeletionQueueRepository imageDeletionQueueRepository;
+
+  @Spy
   @InjectMocks
   private ImageService imageService;
+
+  private List<String> imageUrls;
+  private final String IMAGE_URL_1 = "http://example.com/image1.jpg";
+  private final String IMAGE_URL_2 = "http://example.com/image2.jpg";
+
+
+  @BeforeEach
+  void setUp() {
+    imageUrls = Arrays.asList(IMAGE_URL_1, IMAGE_URL_2);
+  }
 
   @Test
   @DisplayName("단일 이미지 업로드 실패 - 지원하지 않는 파일 유형")
@@ -38,5 +68,121 @@ class ImageServiceTest {
     assertThatThrownBy(() -> imageService.storeImage(image))
         .isInstanceOf(MeongnyangerangException.class)
         .hasFieldOrPropertyWithValue("ErrorCode", ErrorCode.NOT_SUPPORTED_TYPE);
+  }
+
+  @Test
+  @DisplayName("이미지 URL 등록 - 성공")
+  void registerImagesForDeletion_Success() {
+    // given
+    // when
+    imageService.registerImagesForDeletion(imageUrls);
+
+    // then
+    ArgumentCaptor<List<ImageDeletionQueue>> queueCaptor = ArgumentCaptor.forClass(List.class);
+    verify(imageDeletionQueueRepository).saveAll(queueCaptor.capture());
+
+    List<ImageDeletionQueue> capturedEntries = queueCaptor.getValue();
+    assertThat(capturedEntries).hasSize(2);
+    assertThat(capturedEntries.get(0).getImageUrl()).isEqualTo(IMAGE_URL_1);
+    assertThat(capturedEntries.get(1).getImageUrl()).isEqualTo(IMAGE_URL_2);
+  }
+
+  @Test
+  @DisplayName("이미지 URL 등록 - 빈 문자열 필터링")
+  void registerImagesForDeletion_FilterEmptyStrings() {
+    // given
+    List<String> imageUrls = Arrays.asList(
+        IMAGE_URL_1,
+        "",
+        IMAGE_URL_2
+    );
+
+    // when
+    imageService.registerImagesForDeletion(imageUrls);
+
+    // then
+    ArgumentCaptor<List<ImageDeletionQueue>> queueCaptor = ArgumentCaptor.forClass(List.class);
+    verify(imageDeletionQueueRepository).saveAll(queueCaptor.capture());
+
+    List<ImageDeletionQueue> capturedEntries = queueCaptor.getValue();
+    assertThat(capturedEntries).hasSize(2); // 빈 문자열은 필터링됨
+    assertThat(capturedEntries.get(0).getImageUrl())
+        .isEqualTo(IMAGE_URL_1);
+    assertThat(capturedEntries.get(1).getImageUrl())
+        .isEqualTo(IMAGE_URL_2);
+  }
+
+  @Test
+  @DisplayName("이미지 삭제 큐 처리 - 성공")
+  void processImageDeletionQueue_Success() {
+    // given
+    List<ImageDeletionQueue> mockImages = Arrays.asList(
+        createMockImageDeletionQueue(IMAGE_URL_1),
+        createMockImageDeletionQueue(IMAGE_URL_2)
+    );
+
+    when(imageDeletionQueueRepository
+        .findAllByOrderByRegisteredAtAsc(PageRequest.of(0, 100)))
+        .thenReturn(mockImages);
+
+    // when
+    imageService.processImageDeletionQueue();
+
+    // then
+    ArgumentCaptor<List<String>> urlsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(imageService, times(1)).deleteImages(urlsCaptor.capture());
+
+    List<String> capturedUrls = urlsCaptor.getValue();
+    assertThat(capturedUrls).containsExactly(IMAGE_URL_1, IMAGE_URL_2);
+    verify(imageDeletionQueueRepository, times(1)).deleteAll(mockImages);
+  }
+
+  @Test
+  @DisplayName("이미지 삭제 큐 처리 - 빈 큐")
+  void processImageDeletionQueue_EmptyQueue() {
+    // given
+    List<ImageDeletionQueue> mockImages = Collections.emptyList();
+
+    when(imageDeletionQueueRepository
+        .findAllByOrderByRegisteredAtAsc(PageRequest.of(0, 100)))
+        .thenReturn(mockImages);
+
+    // when
+    imageService.processImageDeletionQueue();
+
+    // then
+    verify(imageService, never()).deleteImages(Collections.emptyList());
+    verify(imageDeletionQueueRepository, never()).deleteAll(mockImages);
+  }
+
+  @Test
+  @DisplayName("이미지 삭제 큐 처리 - 삭제 실패해도 큐에서 제거")
+  void processImageDeletionQueue_DeleteFailedButStillRemoveFromQueue() {
+    // given
+    List<ImageDeletionQueue> mockImages = List.of(
+        createMockImageDeletionQueue(IMAGE_URL_1),
+        createMockImageDeletionQueue(IMAGE_URL_2)
+    );
+
+    when(imageDeletionQueueRepository
+        .findAllByOrderByRegisteredAtAsc(PageRequest.of(0, 100)))
+        .thenReturn(mockImages);
+
+    doThrow(new MeongnyangerangException(ErrorCode.FILE_NOT_EMPTY))
+        .when(imageService).deleteImages(imageUrls);
+
+    // when
+    imageService.processImageDeletionQueue();
+
+    // then
+    verify(imageService, times(1)).deleteImages(imageUrls);
+    verify(imageDeletionQueueRepository, never()).deleteAll(mockImages);
+  }
+
+  private ImageDeletionQueue createMockImageDeletionQueue(String imageUrl) {
+    return ImageDeletionQueue.builder()
+        .imageUrl(imageUrl)
+        .registeredAt(LocalDateTime.now())
+        .build();
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #32
- close #33 

## 📝 변경 사항
### AS-IS
- 호스트 본인의 숙소 수정 기능 부재
- S3 이미지 제거 즉각 처리

### TO-BE
- 호스트 본인의 숙소 수정 기능 추가
- S3 이미지 배치 처리

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 성공
![success](https://github.com/user-attachments/assets/b1a11e5f-d3e1-4a1e-8618-8799d7227a7b)

- 지원하지 않는 파일 형식일 때 400
![error_2](https://github.com/user-attachments/assets/b23454a5-7c6a-4562-acb5-30a77ca296ba)

- 숙소가 존재하지 않을 때 404
![error_3](https://github.com/user-attachments/assets/00a56b03-30d3-4575-b055-3fd0d90e17da)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.