### PR TITLE
[Feature] 내 리뷰 삭제 API 구현 및 테스트 완료

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
@@ -13,6 +13,7 @@ import org.hibernate.validator.constraints.Range;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -65,5 +66,14 @@ public class ReviewController {
         accommodationId, cursor, size);
 
     return ResponseEntity.ok(response);
+  }
+
+  @DeleteMapping("/users/reviews/{reviewId}")
+  public ResponseEntity<Void> deleteReview(@PathVariable Long reviewId,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+    reviewService.deleteReview(reviewId, userDetails.getId());
+
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
   ACCOUNT_DELETED(HttpStatus.FORBIDDEN, "현재 계정 상태는 삭제 상태입니다."),
   ACCOUNT_PENDING(HttpStatus.FORBIDDEN, "관리자 승인 대기 중입니다."),
   REVIEW_CREATION_NOT_ALLOWED (HttpStatus.FORBIDDEN, "리뷰 작성 가능 기간이 만료되었습니다."),
+  REVIEW_NOT_AUTHORIZED (HttpStatus.FORBIDDEN, "해당 리뷰를 삭제할 권한이 없습니다."),
 
   // 404  NOT FOUND
   NOT_EXISTS_HOST(HttpStatus.NOT_FOUND, "존재하지 않는 호스트입니다."),
@@ -51,6 +52,7 @@ public enum ErrorCode {
   ACCOMMODATION_NOT_FOUND(HttpStatus.NOT_FOUND, "숙소가 존재하지 않습니다."),
   ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "객실이 존재하지 않습니다."),
   RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약이 존재하지 않습니다."),
+  REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰가 존재하지 않습니다."),
 
   // 409 Conflict
   ROOM_ALREADY_RESERVED(HttpStatus.CONFLICT, "객실이 이미 예약되었습니다."),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewImageRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewImageRepository.java
@@ -1,6 +1,7 @@
 package com.meongnyangerang.meongnyangerang.repository;
 
 import com.meongnyangerang.meongnyangerang.domain.review.ReviewImage;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
 
   ReviewImage findByReviewId(Long reviewId);
+
+  List<ReviewImage> findAllByReviewId(Long reviewId);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
@@ -155,4 +155,19 @@ public class ReviewService {
         .createdAt(review.getCreatedAt().format(dateFormatter))
         .build();
   }
+
+  public void deleteReview(Long reviewId, Long userId) {
+    // 리뷰 조회
+    Review review = reviewRepository.findById(reviewId)
+        .orElseThrow(() -> new MeongnyangerangException(ErrorCode.REVIEW_NOT_FOUND));
+
+    // 요청한 사용자가 작성자인지 확인
+    if (!review.getUser().getId().equals(userId)) {
+      throw new MeongnyangerangException(ErrorCode.REVIEW_NOT_AUTHORIZED);
+    }
+
+    // 리뷰 & 리뷰 이미지 삭제
+    reviewRepository.delete(review);
+    reviewImageRepository.deleteAll(reviewImageRepository.findAllByReviewId(reviewId));
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
@@ -167,7 +167,7 @@ public class ReviewService {
     }
 
     // 리뷰 & 리뷰 이미지 삭제
-    reviewRepository.delete(review);
     reviewImageRepository.deleteAll(reviewImageRepository.findAllByReviewId(reviewId));
+    reviewRepository.delete(review);
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
@@ -424,7 +424,7 @@ class ReservationServiceTest {
 
     // then
     verify(reservationRepository, times(1)).findById(reservation.getId());
-    assertEquals(ReservationStatus.CANCELLED, reservation.getStatus());
+    assertEquals(ReservationStatus.CANCELED, reservation.getStatus());
   }
 
   @Test
@@ -496,7 +496,7 @@ class ReservationServiceTest {
 
     Reservation reservation = Reservation.builder()
         .id(1L)
-        .status(ReservationStatus.CANCELLED)
+        .status(ReservationStatus.CANCELED)
         .user(user)
         .room(room)
         .checkInDate(LocalDate.of(2025, 1, 1))


### PR DESCRIPTION
## 📌 관련 이슈
- close #52 

## 📝 변경 사항
### AS-IS
- 리뷰 삭제 기능이 존재하지 않음
- 사용자가 본인이 작성한 리뷰를 삭제할 수 없음

### TO-BE
- 로그인한 사용자가 본인이 작성한 리뷰를 삭제할 수 있도록 기능 구현
- 삭제 시 리뷰 이미지 먼저 삭제 후 리뷰 삭제
- 리뷰 작성자가 아닌 경우 예외 발생 (`403 Forbidden`)
- 존재하지 않는 리뷰를 삭제하려 할 경우 예외 발생 (`404 Not Found`)
- 테스트 코드 작성
  - 리뷰 삭제 성공 테스트 (`deleteReview_success`)
  - 작성자가 아닌 경우 예외 테스트 (`deleteReview_review_not_found`)
  - 존재하지 않는 리뷰 삭제 시 예외 테스트 (`deleteReview_review_not_authorized`)

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 성공
![내 리뷰 삭제 200 반환](https://github.com/user-attachments/assets/c5dd1a89-5d5e-4cdd-bd00-c5a25b40c5a1)
- 리뷰 존재 X
![내 리뷰 삭제 - 존재하지 않는 경우 404](https://github.com/user-attachments/assets/4a30e469-5e79-4b54-9c94-65cfad652e7e)
- 리뷰 작성자가 아닐 때
![내 리뷰 삭제 - 로그인한 사용자가 리뷰 작성자가 아닌 경우 403](https://github.com/user-attachments/assets/650a09ee-3a9f-47e0-b595-0b0c05af49a3)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.