### PR TITLE
[Feature] 사용자, 호스트 소프트 삭제 및 하드 삭제 스케줄링 기능 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
@@ -48,6 +48,6 @@ public class HostController {
   @DeleteMapping("/me")
   public ResponseEntity<Void> deleteHost(@AuthenticationPrincipal UserDetailsImpl userDetails) {
     hostService.deleteHost(userDetails.getId());
-    return ResponseEntity.status(HttpStatus.OK).build();
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
@@ -3,12 +3,15 @@ package com.meongnyangerang.meongnyangerang.controller;
 import com.meongnyangerang.meongnyangerang.dto.HostSignupRequest;
 import com.meongnyangerang.meongnyangerang.dto.LoginRequest;
 import com.meongnyangerang.meongnyangerang.dto.LoginResponse;
+import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.HostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -39,5 +42,12 @@ public class HostController {
   @PostMapping("/login")
   public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
     return ResponseEntity.ok(new LoginResponse(hostService.login(request)));
+  }
+
+  // 호스트 회원 탈퇴 API
+  @DeleteMapping("/me")
+  public ResponseEntity<Void> deleteHost(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    hostService.deleteHost(userDetails.getId());
+    return ResponseEntity.status(HttpStatus.OK).build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserController.java
@@ -44,8 +44,8 @@ public class UserController {
 
   // 사용자 회원 탈퇴 API
   @DeleteMapping("/me")
-  public ResponseEntity<String> deleteUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+  public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
     userService.deleteUser(userDetails.getId());
-    return ResponseEntity.ok("회원 탈퇴가 완료되었습니다.");
+    return ResponseEntity.status(HttpStatus.OK).build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserController.java
@@ -46,6 +46,6 @@ public class UserController {
   @DeleteMapping("/me")
   public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
     userService.deleteUser(userDetails.getId());
-    return ResponseEntity.status(HttpStatus.OK).build();
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserController.java
@@ -3,12 +3,15 @@ package com.meongnyangerang.meongnyangerang.controller;
 import com.meongnyangerang.meongnyangerang.dto.LoginRequest;
 import com.meongnyangerang.meongnyangerang.dto.LoginResponse;
 import com.meongnyangerang.meongnyangerang.dto.UserSignupRequest;
+import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,5 +40,12 @@ public class UserController {
   @PostMapping("/login")
   public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
     return ResponseEntity.ok(new LoginResponse(userService.login(request)));
+  }
+
+  // 사용자 회원 탈퇴 API
+  @DeleteMapping("/me")
+  public ResponseEntity<String> deleteUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    userService.deleteUser(userDetails.getId());
+    return ResponseEntity.ok("회원 탈퇴가 완료되었습니다.");
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
   INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "인증코드가 일치하지 않습니다"),
   AUTH_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "인증코드를 찾을 수 없습니다. 인증코드 받기를 다시 실행해주세요"),
   USER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 등록된 회원입니다."),
+  RESERVED_RESERVATION_EXISTS(HttpStatus.BAD_REQUEST, "이용 전 예약 상태가 존재합니다"),
   INVALID_FILENAME(HttpStatus.BAD_REQUEST, "파일명이 유효하지 않습니다."),
   INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "파일 확장자가 유효하지 않습니다."),
   NOT_SUPPORTED_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/HostRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/HostRepository.java
@@ -1,6 +1,9 @@
 package com.meongnyangerang.meongnyangerang.repository;
 
 import com.meongnyangerang.meongnyangerang.domain.host.Host;
+import com.meongnyangerang.meongnyangerang.domain.host.HostStatus;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -12,4 +15,6 @@ public interface HostRepository extends JpaRepository<Host, Long> {
   boolean existsByNickname(String nickname);
 
   Optional<Host> findByEmail(String email);
+
+  List<Host> findAllByStatusAndDeletedAtBefore(HostStatus status, LocalDateTime cutoff);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/HostRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/HostRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HostRepository extends JpaRepository<Host, Long> {
+
   boolean existsByEmail(String email);
 
   boolean existsByNickname(String nickname);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReservationRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReservationRepository.java
@@ -1,6 +1,7 @@
 package com.meongnyangerang.meongnyangerang.repository;
 
 import com.meongnyangerang.meongnyangerang.domain.reservation.Reservation;
+import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -35,4 +36,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
       @Param("cursorId") Long cursorId,
       @Param("size") int size,
       @Param("status") String status);
+
+  boolean existsByUserIdAndStatus(Long userId, ReservationStatus status);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReservationRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReservationRepository.java
@@ -38,4 +38,12 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
       @Param("status") String status);
 
   boolean existsByUserIdAndStatus(Long userId, ReservationStatus status);
+
+  @Query("""
+        SELECT CASE WHEN COUNT(r) > 0 THEN true ELSE false END
+        FROM Reservation r
+        WHERE r.room.accommodation.host.id = :hostId
+        AND r.status = :status
+    """)
+  boolean existsByHostIdAndStatus(Long hostId, ReservationStatus status);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/UserRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/UserRepository.java
@@ -1,6 +1,9 @@
 package com.meongnyangerang.meongnyangerang.repository;
 
 import com.meongnyangerang.meongnyangerang.domain.user.User;
+import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -13,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   boolean existsByNickname(String nickname);
 
   Optional<User> findByEmail(String email);
+
+  List<User> findAllByStatusAndDeletedAtBefore(UserStatus status, LocalDateTime cutoff);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccountCleanupService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccountCleanupService.java
@@ -1,0 +1,39 @@
+package com.meongnyangerang.meongnyangerang.service;
+
+import com.meongnyangerang.meongnyangerang.domain.host.Host;
+import com.meongnyangerang.meongnyangerang.domain.host.HostStatus;
+import com.meongnyangerang.meongnyangerang.domain.user.User;
+import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
+import com.meongnyangerang.meongnyangerang.repository.HostRepository;
+import com.meongnyangerang.meongnyangerang.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AccountCleanupService {
+
+  private final UserRepository userRepository;
+  private final HostRepository hostRepository;
+
+  @Scheduled(cron = "0 0 3 * * ?") // 매일 새벽 3시에 실행
+  @Transactional
+  public void deleteExpiredSoftDeletedUsers() {
+    LocalDateTime cutoff = LocalDateTime.now().minusDays(30);
+
+    List<User> usersToDelete = userRepository.findAllByStatusAndDeletedAtBefore(UserStatus.DELETED, cutoff);
+    userRepository.deleteAll(usersToDelete);
+    log.info("하드 삭제된 사용자 수: {}", usersToDelete.size());
+
+    List<Host> hostsToDelete = hostRepository.findAllByStatusAndDeletedAtBefore(HostStatus.DELETED, cutoff);
+    hostRepository.deleteAll(hostsToDelete);
+    log.info("하드 삭제된 호스트 수: {}", hostsToDelete.size());
+  }
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccountCleanupService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccountCleanupService.java
@@ -27,11 +27,13 @@ public class AccountCleanupService {
   public void deleteExpiredSoftDeletedUsers() {
     LocalDateTime cutoff = LocalDateTime.now().minusDays(30);
 
-    List<User> usersToDelete = userRepository.findAllByStatusAndDeletedAtBefore(UserStatus.DELETED, cutoff);
+    List<User> usersToDelete = userRepository.findAllByStatusAndDeletedAtBefore(UserStatus.DELETED,
+        cutoff);
     userRepository.deleteAll(usersToDelete);
     log.info("하드 삭제된 사용자 수: {}", usersToDelete.size());
 
-    List<Host> hostsToDelete = hostRepository.findAllByStatusAndDeletedAtBefore(HostStatus.DELETED, cutoff);
+    List<Host> hostsToDelete = hostRepository.findAllByStatusAndDeletedAtBefore(HostStatus.DELETED,
+        cutoff);
     hostRepository.deleteAll(hostsToDelete);
     log.info("하드 삭제된 호스트 수: {}", hostsToDelete.size());
   }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -98,6 +98,7 @@ public class HostService {
   }
 
   // 호스트 회원 탈퇴
+  @Transactional
   public void deleteHost(Long hostId) {
 
     Host host = hostRepository.findById(hostId)

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -104,7 +104,7 @@ public class HostService {
         .orElseThrow(() -> new MeongnyangerangException(ErrorCode.NOT_EXIST_ACCOUNT));
 
     // 호스트가 등록한 숙소 중 예약 상태가 RESERVED인 것이 있으면 탈퇴 불가
-    boolean hasReserved = reservationRepository.existsByHostIdAndReservationStatus(hostId, RESERVED);
+    boolean hasReserved = reservationRepository.existsByHostIdAndStatus(hostId, RESERVED);
     if (hasReserved) {
       throw new MeongnyangerangException(RESERVED_RESERVATION_EXISTS);
     }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -3,13 +3,16 @@ package com.meongnyangerang.meongnyangerang.service;
 import static com.meongnyangerang.meongnyangerang.domain.host.HostStatus.PENDING;
 import static com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus.RESERVED;
 import static com.meongnyangerang.meongnyangerang.domain.user.Role.ROLE_HOST;
-import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.*;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOUNT_DELETED;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOUNT_PENDING;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_EMAIL;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.FILE_IS_EMPTY;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.INVALID_PASSWORD;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_ACCOUNT;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.RESERVED_RESERVATION_EXISTS;
 
 import com.meongnyangerang.meongnyangerang.domain.host.Host;
 import com.meongnyangerang.meongnyangerang.domain.host.HostStatus;
-import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
 import com.meongnyangerang.meongnyangerang.dto.HostSignupRequest;
 import com.meongnyangerang.meongnyangerang.dto.LoginRequest;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -104,8 +104,7 @@ public class HostService {
         .orElseThrow(() -> new MeongnyangerangException(ErrorCode.NOT_EXIST_ACCOUNT));
 
     // 호스트가 등록한 숙소 중 예약 상태가 RESERVED인 것이 있으면 탈퇴 불가
-    boolean hasReserved = reservationRepository.existsByHostIdAndStatus(hostId, RESERVED);
-    if (hasReserved) {
+    if (reservationRepository.existsByHostIdAndStatus(hostId, RESERVED)) {
       throw new MeongnyangerangException(RESERVED_RESERVATION_EXISTS);
     }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -1,20 +1,18 @@
 package com.meongnyangerang.meongnyangerang.service;
 
 import static com.meongnyangerang.meongnyangerang.domain.user.Role.ROLE_USER;
-import static com.meongnyangerang.meongnyangerang.domain.user.UserStatus.*;
 import static com.meongnyangerang.meongnyangerang.domain.user.UserStatus.ACTIVE;
-import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.*;
+import static com.meongnyangerang.meongnyangerang.domain.user.UserStatus.DELETED;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOUNT_DELETED;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_EMAIL;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.INVALID_PASSWORD;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_ACCOUNT;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.RESERVED_RESERVATION_EXISTS;
 
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
-import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
 import com.meongnyangerang.meongnyangerang.dto.LoginRequest;
 import com.meongnyangerang.meongnyangerang.dto.UserSignupRequest;
-import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.jwt.JwtTokenProvider;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -90,7 +90,7 @@ public class UserService {
 
     // 예약 상태 확인
     if (reservationRepository.existsByUserIdAndStatus(userId, ReservationStatus.RESERVED)) {
-      throw new MeongnyangerangException(ErrorCode.RESERVATION_EXISTS);
+      throw new MeongnyangerangException(RESERVED_RESERVATION_EXISTS);
     }
 
     user.setStatus(DELETED);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -1,21 +1,27 @@
 package com.meongnyangerang.meongnyangerang.service;
 
 import static com.meongnyangerang.meongnyangerang.domain.user.Role.ROLE_USER;
+import static com.meongnyangerang.meongnyangerang.domain.user.UserStatus.*;
 import static com.meongnyangerang.meongnyangerang.domain.user.UserStatus.ACTIVE;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.*;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOUNT_DELETED;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_EMAIL;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.INVALID_PASSWORD;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_ACCOUNT;
 
+import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
 import com.meongnyangerang.meongnyangerang.dto.LoginRequest;
 import com.meongnyangerang.meongnyangerang.dto.UserSignupRequest;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.jwt.JwtTokenProvider;
+import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.service.image.ImageService;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -29,6 +35,7 @@ public class UserService {
   private final PasswordEncoder passwordEncoder;
   private final JwtTokenProvider jwtTokenProvider;
   private final ImageService imageService;
+  private final ReservationRepository reservationRepository;
 
   // 사용자 회원가입
   public void registerUser(UserSignupRequest request, MultipartFile profileImage) {
@@ -68,11 +75,25 @@ public class UserService {
     }
 
     // 사용자 상태 검증
-    if (user.getStatus() == UserStatus.DELETED) {
+    if (user.getStatus() == DELETED) {
       throw new MeongnyangerangException(ACCOUNT_DELETED);
     }
 
     return jwtTokenProvider.createToken(user.getId(), user.getEmail(), user.getRole().name(),
         user.getStatus());
+  }
+
+  // 사용자 회원 탈퇴
+  public void deleteUser(Long userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
+
+    // 예약 상태 확인
+    if (reservationRepository.existsByUserIdAndStatus(userId, ReservationStatus.RESERVED)) {
+      throw new MeongnyangerangException(ErrorCode.RESERVATION_EXISTS);
+    }
+
+    user.setStatus(DELETED);
+    user.setDeletedAt(LocalDateTime.now());
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -84,6 +85,7 @@ public class UserService {
   }
 
   // 사용자 회원 탈퇴
+  @Transactional
   public void deleteUser(Long userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/image/ImageService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/image/ImageService.java
@@ -75,7 +75,7 @@ public class ImageService {
 
   // TODO: 젠킨스 사용 고려
   //@Scheduled(cron = "0 0/10 * * * ?") // 10분마다 실행
-  @Scheduled(cron = "0/10 * * * * ?") // 10초마다 실행 (테스트)
+//  @Scheduled(cron = "0/10 * * * * ?") // 10초마다 실행 (테스트)
   @Transactional
   public void processImageDeletionQueue() {
     log.info("이미지 삭제 큐 처리 시작");

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccountCleanupServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccountCleanupServiceTest.java
@@ -1,0 +1,50 @@
+package com.meongnyangerang.meongnyangerang.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.meongnyangerang.meongnyangerang.domain.host.Host;
+import com.meongnyangerang.meongnyangerang.domain.host.HostStatus;
+import com.meongnyangerang.meongnyangerang.domain.user.User;
+import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
+import com.meongnyangerang.meongnyangerang.repository.HostRepository;
+import com.meongnyangerang.meongnyangerang.repository.UserRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AccountCleanupServiceTest {
+
+  @InjectMocks
+  private AccountCleanupService accountCleanupService;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private HostRepository hostRepository;
+
+  @Test
+  @DisplayName("30일 경과된 사용자 및 호스트 하드 삭제")
+  void deleteExpiredSoftDeletedAccounts() {
+    List<User> expiredUsers = List.of(User.builder().id(1L).build());
+    List<Host> expiredHosts = List.of(Host.builder().id(1L).build());
+
+    when(userRepository.findAllByStatusAndDeletedAtBefore(eq(UserStatus.DELETED), any()))
+        .thenReturn(expiredUsers);
+    when(hostRepository.findAllByStatusAndDeletedAtBefore(eq(HostStatus.DELETED), any()))
+        .thenReturn(expiredHosts);
+
+    accountCleanupService.deleteExpiredSoftDeletedUsers();
+
+    verify(userRepository).deleteAll(expiredUsers);
+    verify(hostRepository).deleteAll(expiredHosts);
+  }
+}

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccountCleanupServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccountCleanupServiceTest.java
@@ -11,6 +11,7 @@ import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
 import com.meongnyangerang.meongnyangerang.repository.HostRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,16 +35,21 @@ class AccountCleanupServiceTest {
   @Test
   @DisplayName("30일 경과된 사용자 및 호스트 하드 삭제")
   void deleteExpiredSoftDeletedAccounts() {
+    // given
+    LocalDateTime cutoff = LocalDateTime.now().minusDays(30);
+
     List<User> expiredUsers = List.of(User.builder().id(1L).build());
     List<Host> expiredHosts = List.of(Host.builder().id(1L).build());
 
-    when(userRepository.findAllByStatusAndDeletedAtBefore(eq(UserStatus.DELETED), any()))
+    when(userRepository.findAllByStatusAndDeletedAtBefore(UserStatus.DELETED, cutoff))
         .thenReturn(expiredUsers);
-    when(hostRepository.findAllByStatusAndDeletedAtBefore(eq(HostStatus.DELETED), any()))
+    when(hostRepository.findAllByStatusAndDeletedAtBefore(HostStatus.DELETED, cutoff))
         .thenReturn(expiredHosts);
 
+    // when
     accountCleanupService.deleteExpiredSoftDeletedUsers();
 
+    // then
     verify(userRepository).deleteAll(expiredUsers);
     verify(hostRepository).deleteAll(expiredHosts);
   }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -110,4 +110,13 @@ class HostServiceTest {
     assertEquals(HostStatus.DELETED, host.getStatus());
     assertNotNull(host.getDeletedAt());
   }
+
+  @Test
+  @DisplayName("호스트 탈퇴 실패 - 예약 존재")
+  void deleteHostFailDueToReservation() {
+    when(hostRepository.findById(anyLong())).thenReturn(Optional.of(new Host()));
+    when(reservationRepository.existsByHostIdAndStatus(anyLong(), eq(ReservationStatus.RESERVED))).thenReturn(true);
+
+    assertThrows(MeongnyangerangException.class, () -> hostService.deleteHost(1L));
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
@@ -424,7 +424,7 @@ class ReservationServiceTest {
 
     // then
     verify(reservationRepository, times(1)).findById(reservation.getId());
-    assertEquals(ReservationStatus.CANCELLED, reservation.getStatus());
+    assertEquals(ReservationStatus.CANCELED, reservation.getStatus());
   }
 
   @Test
@@ -496,7 +496,7 @@ class ReservationServiceTest {
 
     Reservation reservation = Reservation.builder()
         .id(1L)
-        .status(ReservationStatus.CANCELLED)
+        .status(ReservationStatus.CANCELED)
         .user(user)
         .room(room)
         .checkInDate(LocalDate.of(2025, 1, 1))

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
@@ -51,13 +51,18 @@ class UserServiceTest {
   @DisplayName("사용자 회원가입 성공 테스트 - 프로필 이미지 없음")
   void registerUserSuccessWithoutImage() {
     // given
-    UserSignupRequest request = new UserSignupRequest();
-    request.setEmail("user@example.com");
-    request.setNickname("nickname");
-    request.setPassword("password123!");
+    String email = "user@example.com";
+    String nickname = "nickname";
+    String password = "password123!";
+    String encodedPassword = "encodedPassword";
 
-    when(userRepository.existsByEmail(any())).thenReturn(false);
-    when(passwordEncoder.encode(any())).thenReturn("encodedPassword");
+    UserSignupRequest request = new UserSignupRequest();
+    request.setEmail(email);
+    request.setNickname(nickname);
+    request.setPassword(password);
+
+    when(userRepository.existsByEmail(email)).thenReturn(false);
+    when(passwordEncoder.encode(password)).thenReturn(encodedPassword);
 
     // when & then
     assertDoesNotThrow(() -> userService.registerUser(request, null));
@@ -68,18 +73,24 @@ class UserServiceTest {
   @DisplayName("사용자 회원가입 성공 테스트 - 프로필 이미지 포함")
   void registerUserSuccessWithImage() throws IOException {
     // given
+    String email = "user@example.com";
+    String nickname = "nickname";
+    String password = "password123!";
+    String encodedPassword = "encodedPassword";
+    String imageUrl = "https://s3.bucket/image/test.png";
+
     UserSignupRequest request = new UserSignupRequest();
-    request.setEmail("user@example.com");
-    request.setNickname("nickname");
-    request.setPassword("password123!");
+    request.setEmail(email);
+    request.setNickname(nickname);
+    request.setPassword(password);
 
     MockMultipartFile imageFile = new MockMultipartFile(
         "profileImage", "test.png", "image/png", "dummy".getBytes()
     );
 
-    when(userRepository.existsByEmail(any())).thenReturn(false);
-    when(passwordEncoder.encode(any())).thenReturn("encodedPassword");
-    when(imageService.storeImage(any())).thenReturn("https://s3.bucket/image/test.png");
+    when(userRepository.existsByEmail(email)).thenReturn(false);
+    when(passwordEncoder.encode(password)).thenReturn(encodedPassword);
+    when(imageService.storeImage(imageFile)).thenReturn(imageUrl);
 
     // when & then
     assertDoesNotThrow(() -> userService.registerUser(request, imageFile));
@@ -90,27 +101,36 @@ class UserServiceTest {
   @DisplayName("중복 이메일 회원가입 실패 테스트")
   void registerUserDuplicateEmail() {
     // given
-    when(userRepository.existsByEmail(any())).thenReturn(true);
+    String email = "duplicate@example.com";
+
+    UserSignupRequest request = new UserSignupRequest();
+    request.setEmail(email);
+
+    when(userRepository.existsByEmail(email)).thenReturn(true);
 
     // when & then
     assertThrows(MeongnyangerangException.class,
-        () -> userService.registerUser(new UserSignupRequest(), null));
+        () -> userService.registerUser(request, null));
   }
 
   @Test
   @DisplayName("사용자 탈퇴 성공")
   void deleteUserSuccess() {
+    // given
+    Long userId = 1L;
     User user = User.builder()
-        .id(1L)
+        .id(userId)
         .email("user@example.com")
         .status(UserStatus.ACTIVE)
         .build();
 
-    when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
-    when(reservationRepository.existsByUserIdAndStatus(anyLong(), eq(ReservationStatus.RESERVED))).thenReturn(false);
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(reservationRepository.existsByUserIdAndStatus(userId, ReservationStatus.RESERVED)).thenReturn(false);
 
-    userService.deleteUser(1L);
+    // when
+    userService.deleteUser(userId);
 
+    // then
     assertEquals(UserStatus.DELETED, user.getStatus());
     assertNotNull(user.getDeletedAt());
   }
@@ -118,9 +138,13 @@ class UserServiceTest {
   @Test
   @DisplayName("사용자 탈퇴 실패 - 예약 존재")
   void deleteUserFailDueToReservation() {
-    when(userRepository.findById(anyLong())).thenReturn(Optional.of(new User()));
-    when(reservationRepository.existsByUserIdAndStatus(anyLong(), eq(ReservationStatus.RESERVED))).thenReturn(true);
+    // given
+    Long userId = 1L;
 
-    assertThrows(MeongnyangerangException.class, () -> userService.deleteUser(1L));
+    when(userRepository.findById(userId)).thenReturn(Optional.of(new User()));
+    when(reservationRepository.existsByUserIdAndStatus(userId, ReservationStatus.RESERVED)).thenReturn(true);
+
+    // when & then
+    assertThrows(MeongnyangerangException.class, () -> userService.deleteUser(userId));
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
@@ -1,17 +1,25 @@
 package com.meongnyangerang.meongnyangerang.service;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
+import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
 import com.meongnyangerang.meongnyangerang.dto.UserSignupRequest;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.service.image.ImageService;
 import java.io.IOException;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,6 +43,9 @@ class UserServiceTest {
 
   @Mock
   private ImageService imageService;
+
+  @Mock
+  private ReservationRepository reservationRepository;
 
   @Test
   @DisplayName("사용자 회원가입 성공 테스트 - 프로필 이미지 없음")
@@ -85,4 +96,23 @@ class UserServiceTest {
     assertThrows(MeongnyangerangException.class,
         () -> userService.registerUser(new UserSignupRequest(), null));
   }
+
+  @Test
+  @DisplayName("사용자 탈퇴 성공")
+  void deleteUserSuccess() {
+    User user = User.builder()
+        .id(1L)
+        .email("user@example.com")
+        .status(UserStatus.ACTIVE)
+        .build();
+
+    when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+    when(reservationRepository.existsByUserIdAndStatus(anyLong(), eq(ReservationStatus.RESERVED))).thenReturn(false);
+
+    userService.deleteUser(1L);
+
+    assertEquals(UserStatus.DELETED, user.getStatus());
+    assertNotNull(user.getDeletedAt());
+  }
+
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
@@ -115,4 +115,12 @@ class UserServiceTest {
     assertNotNull(user.getDeletedAt());
   }
 
+  @Test
+  @DisplayName("사용자 탈퇴 실패 - 예약 존재")
+  void deleteUserFailDueToReservation() {
+    when(userRepository.findById(anyLong())).thenReturn(Optional.of(new User()));
+    when(reservationRepository.existsByUserIdAndStatus(anyLong(), eq(ReservationStatus.RESERVED))).thenReturn(true);
+
+    assertThrows(MeongnyangerangException.class, () -> userService.deleteUser(1L));
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #55 

## 📝 변경 사항
### AS-IS
- 탈퇴 기능 미구현
- 사용자와 호스트 데이터는 수동으로 삭제하거나 직접 상태 변경 필요
- 삭제 계정에 대한 정리 작업 없음

### TO-BE
- 사용자 및 호스트 탈퇴 시 status를 DELETED로 변경하고 deletedAt 시간 저장
- Reservation 상태가 RESERVED인 경우 예외 처리
- 매일 3시에 실행되는 스케줄러로 30일 이상 삭제 상태 유지된 사용자/호스트 하드 삭제
- 서비스 로직에 대한 단위 테스트 코드 작성 완료

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
(없음)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- Soft Delete → 하드 삭제 흐름이 자연스러운지  
- 예약 상태 확인 로직이 명확한지  
