### PR TITLE
[Feature] 호스트가 본인의 객실 목록을 조회하는 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/RoomController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/RoomController.java
@@ -1,13 +1,20 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
 import com.meongnyangerang.meongnyangerang.dto.room.RoomCreateRequest;
+import com.meongnyangerang.meongnyangerang.dto.room.RoomListResponse;
+import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.RoomService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Range;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -24,10 +31,25 @@ public class RoomController {
    */
   @PostMapping
   public ResponseEntity<Void> createRoom(
+      @AuthenticationPrincipal UserDetailsImpl userDetail,
       @Valid @RequestPart RoomCreateRequest request,
       @RequestPart MultipartFile image
   ) {
-    roomService.createRoom(request, image);
+    roomService.createRoom(userDetail.getId(), request, image);
     return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
+  /**
+   * 객실 목록 조회
+   */
+  @GetMapping("/{accommodationId}")
+  public ResponseEntity<RoomListResponse> getRoomList(
+      @AuthenticationPrincipal UserDetailsImpl userDetail,
+      @PathVariable Long accommodationId,
+      @RequestParam(required = false) Long cursorId,
+      @RequestParam(defaultValue = "20") @Range(min = 1, max = 100) int pageSize
+  ) {
+    return ResponseEntity.ok(
+        roomService.getRoomList(userDetail.getId(), accommodationId, cursorId, pageSize));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/room/Room.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/room/Room.java
@@ -78,5 +78,5 @@ public class Room {
 
   @LastModifiedDate
   @Column(nullable = false)
-  private LocalDateTime updateAt;
+  private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomCreateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomCreateRequest.java
@@ -2,7 +2,6 @@ package com.meongnyangerang.meongnyangerang.dto.room;
 
 import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
 import com.meongnyangerang.meongnyangerang.domain.room.Room;
-import com.meongnyangerang.meongnyangerang.domain.room.facility.Hashtag;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.HashtagType;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomFacilityType;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomPetFacilityType;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomListResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomListResponse.java
@@ -1,0 +1,19 @@
+package com.meongnyangerang.meongnyangerang.dto.room;
+
+import com.meongnyangerang.meongnyangerang.domain.room.Room;
+import java.util.List;
+
+public record RoomListResponse(
+    List<RoomSummary> content,
+    Long nextCursor,
+    Boolean hasNext
+) {
+
+  public static RoomListResponse of(List<Room> rooms, Long nextCursor, boolean hasNext) {
+    List<RoomSummary> content = rooms.stream()
+        .map(RoomSummary::of)
+        .toList();
+
+    return new RoomListResponse(content, nextCursor, hasNext);
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomSummary.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomSummary.java
@@ -1,0 +1,30 @@
+package com.meongnyangerang.meongnyangerang.dto.room;
+
+import com.meongnyangerang.meongnyangerang.domain.room.Room;
+
+public record RoomSummary(
+    Long roomId,
+    String name,
+    String description,
+    String imageUrl,
+    Long price,
+    Integer standardPeopleCount,
+    Integer maxPeopleCount,
+    Integer standardPetCount,
+    Integer maxPetCount
+) {
+
+  public static RoomSummary of(Room room) {
+    return new RoomSummary(
+        room.getId(),
+        room.getName(),
+        room.getDescription(),
+        room.getImageUrl(),
+        room.getPrice(),
+        room.getStandardPeopleCount(),
+        room.getMaxPeopleCount(),
+        room.getStandardPetCount(),
+        room.getMaxPetCount()
+    );
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/RoomRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/RoomRepository.java
@@ -1,10 +1,22 @@
 package com.meongnyangerang.meongnyangerang.repository;
 
 import com.meongnyangerang.meongnyangerang.domain.room.Room;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
+  @Query("SELECT r FROM Room r " +
+      "WHERE r.accommodation.id = :accommodationId " +
+      "AND (:cursorId IS NULL OR r.id < :cursorId) ")
+  List<Room> findRoomsWithCursor(
+      @Param("accommodationId") Long accommodationId,
+      @Param("cursorId") Long cursorId,
+      Pageable pageable
+  );
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
@@ -106,7 +106,7 @@ public class AccommodationService {
       List<MultipartFile> newAdditionalImages
   ) {
     Accommodation accommodation =
-        validateAccommodationAuthorized(hostId, request.accommodationId());
+        getAuthorizedAccommodation(hostId, request.accommodationId());
     newAdditionalImages = initAdditionalImages(newAdditionalImages);
 
     List<String> trackingList = new ArrayList<>(); // 업로드 성공한 이미지 추적 (롤백 위함)
@@ -320,7 +320,7 @@ public class AccommodationService {
     return host;
   }
 
-  private Accommodation validateAccommodationAuthorized(Long hostId, Long accommodationId) {
+  private Accommodation getAuthorizedAccommodation(Long hostId, Long accommodationId) {
     Accommodation accommodation = findAccommodationByHostId(hostId);
 
     if (!accommodation.getId().equals(accommodationId)) {

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationServiceTest.java
@@ -349,11 +349,11 @@ class AccommodationServiceTest {
     }
 
     // 추가 이미지 목록 검증
-//    assertThat(response.additionalImageUrls()).hasSize(accommodationImages.size());
-//    for (int i = 0; i < accommodationImages.size(); i++) {
-//      assertThat(response.additionalImageUrls().get(i))
-//          .isEqualTo(accommodationImages.get(i).getImageUrl());
-//    }
+    assertThat(response.additionalImageUrls()).hasSize(accommodationImages.size());
+    for (int i = 0; i < accommodationImages.size(); i++) {
+      assertThat(response.additionalImageUrls().get(i))
+          .isEqualTo(accommodationImages.get(i).getImageUrl());
+    }
 
     verify(accommodationRepository, times(1))
         .findByHostId(host.getId());

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
@@ -424,7 +424,7 @@ class ReservationServiceTest {
 
     // then
     verify(reservationRepository, times(1)).findById(reservation.getId());
-    assertEquals(ReservationStatus.CANCELLED, reservation.getStatus());
+    assertEquals(ReservationStatus.CANCELED, reservation.getStatus());
   }
 
   @Test
@@ -496,7 +496,7 @@ class ReservationServiceTest {
 
     Reservation reservation = Reservation.builder()
         .id(1L)
-        .status(ReservationStatus.CANCELLED)
+        .status(ReservationStatus.CANCELED)
         .user(user)
         .room(room)
         .checkInDate(LocalDate.of(2025, 1, 1))


### PR DESCRIPTION
## 📌 관련 이슈
- close #54

## 📝 변경 사항
### AS-IS
- 호스트가 본인의 객실 목록을 조회하는 API 부재

### TO-BE
- 호스트가 본인의 객실 목록을 조회하는 API 구현

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 첫 요청
![first_request](https://github.com/user-attachments/assets/88e5ae61-7c4d-4454-a37f-ef89cd23b79f)

- 이후 요청
![after_request](https://github.com/user-attachments/assets/f0adbbf6-0c9a-45ab-aee4-005e30e4fcea)

- 다음 페이지 없음
![no_have_next_page](https://github.com/user-attachments/assets/f639eca4-c587-4ce2-845a-58921a1b13f0)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.