### PR TITLE
[Feature] 숙소 수정 API 숙소 ID 받지 않도록 수정 및 숙소 관련 컨트롤러 회원 정보 받도록 수정

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationController.java
@@ -3,12 +3,14 @@ package com.meongnyangerang.meongnyangerang.controller;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationCreateRequest;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationResponse;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationUpdateRequest;
+import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.AccommodationService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -27,44 +29,40 @@ public class AccommodationController {
   /**
    * 숙소 등록 API 숙소 정보와 이미지 파일을 함께 등록
    */
-  // TODO: UserDetails 구현이 완료되면 주석 해제
-  // TODO: host만 호출할 수 있도록 수정
   @PostMapping
   public ResponseEntity<Void> createAccommodation(
-      //@AuthenticationPrincipal UserDetail userDetail,
+      @AuthenticationPrincipal UserDetailsImpl userDetail,
       @Valid @RequestPart AccommodationCreateRequest request,
       @RequestPart MultipartFile thumbnail,
       @RequestPart(required = false) List<MultipartFile> additionalImages
   ) {
-    accommodationService.createAccommodation(1L, request, thumbnail, additionalImages);
+    accommodationService.createAccommodation(
+        userDetail.getId(), request, thumbnail, additionalImages);
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
   /**
    * 숙소 조회 API
    */
-  // TODO: UserDetails 구현이 완료되면 주석 해제
-  // TODO: host만 호출할 수 있도록 수정
   @GetMapping
   public ResponseEntity<AccommodationResponse> getAccommodation(
-      //@AuthenticationPrincipal UserDetail userDetail
-  ){
-    return ResponseEntity.ok(accommodationService.getAccommodation(1L));
+      @AuthenticationPrincipal UserDetailsImpl userDetail
+  ) {
+    return ResponseEntity.ok(accommodationService.getAccommodation(userDetail.getId()));
   }
 
   /**
    * 숙소 수정 API
    */
-  // TODO: UserDetails 구현이 완료되면 주석 해제
-  // TODO: host만 호출할 수 있도록 수정
   @PutMapping
   public ResponseEntity<AccommodationResponse> updateAccommodation(
-      //@AuthenticationPrincipal UserDetail userDetail,
+      @AuthenticationPrincipal UserDetailsImpl userDetail,
       @Valid @RequestPart AccommodationUpdateRequest request,
       @RequestPart(required = false) MultipartFile newThumbnail,
       @RequestPart(required = false) List<MultipartFile> newAdditionalImages
-  ){
+  ) {
     return ResponseEntity.ok(
-        accommodationService.updateAccommodation(1L, request, newThumbnail, newAdditionalImages));
+        accommodationService.updateAccommodation(
+            userDetail.getId(), request, newThumbnail, newAdditionalImages));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/room/Room.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/room/Room.java
@@ -78,5 +78,5 @@ public class Room {
 
   @LastModifiedDate
   @Column(nullable = false)
-  private LocalDateTime updateAt;
+  private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationCreateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationCreateRequest.java
@@ -10,44 +10,37 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class AccommodationCreateRequest {
+public record AccommodationCreateRequest(
 
-  @NotBlank(message = "숙소 이름을 입력해 주세요.")
-  private String name;
+    @NotBlank(message = "숙소 이름을 입력해 주세요.")
+    String name,
 
-  @NotNull(message = "숙소 유형을 선택해 주세요.")
-  private AccommodationType type;
+    @NotNull(message = "숙소 유형을 선택해 주세요.")
+    AccommodationType type,
 
-  @NotBlank(message = "숙소 주소를 입력해 주세요.")
-  private String address;
+    @NotBlank(message = "숙소 주소를 입력해 주세요.")
+    String address,
 
-  private String detailedAddress;
+    String detailedAddress,
 
-  private String description;
+    String description,
 
-  @NotNull(message = "숙소의 위치 정보를 제공해 주세요.")
-  private Double latitude;
+    @NotNull(message = "숙소의 위치 정보를 제공해 주세요.")
+    Double latitude,
 
-  @NotNull(message = "숙소의 위치 정보를 제공해 주세요.")
-  private Double longitude;
+    @NotNull(message = "숙소의 위치 정보를 제공해 주세요.")
+    Double longitude,
 
-  @NotEmpty(message = "숙소 편의시설을 하나 이상 선택해 주세요.")
-  private List<AccommodationFacilityType> facilityTypes;
+    @NotEmpty(message = "숙소 편의시설을 하나 이상 선택해 주세요.")
+    List<AccommodationFacilityType> facilityTypes,
 
-  @NotEmpty(message = "반려동물 편의시설을 하나 이상 선택해 주세요.")
-  private List<AccommodationPetFacilityType> petFacilityTypes;
+    @NotEmpty(message = "반려동물 편의시설을 하나 이상 선택해 주세요.")
+    List<AccommodationPetFacilityType> petFacilityTypes,
 
-  @NotEmpty(message = "허용 가능한 반려동물 유형을 하나 이상 선택해 주세요.")
-  private List<PetType> allowPetTypes;
+    @NotEmpty(message = "허용 가능한 반려동물 유형을 하나 이상 선택해 주세요.")
+    List<PetType> allowPetTypes
+) {
 
   public Accommodation toEntity(Host host, String thumbnailUrl) {
     return Accommodation.builder()

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationUpdateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationUpdateRequest.java
@@ -11,9 +11,6 @@ import java.util.List;
 
 public record AccommodationUpdateRequest(
 
-    @NotNull(message = "숙소 ID를 요청해 주세요.")
-    Long accommodationId,
-
     @NotBlank(message = "숙소 이름을 입력해 주세요.")
     String name,
 
@@ -44,7 +41,6 @@ public record AccommodationUpdateRequest(
 ) {
 
   public static AccommodationUpdateRequest of(
-      Long accommodationId,
       String name,
       AccommodationType type,
       String address,
@@ -57,7 +53,6 @@ public record AccommodationUpdateRequest(
       List<PetType> allowPetTypes
   ) {
     return new AccommodationUpdateRequest(
-        accommodationId,
         name,
         type,
         address,

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
@@ -81,9 +81,9 @@ public class AccommodationService {
       List<String> newAdditionalImageUrls
   ) {
     accommodationRepository.save(accommodation);
-    saveAccommodationFacilities(request.getFacilityTypes(), accommodation);
-    saveAccommodationPetFacilities(request.getPetFacilityTypes(), accommodation);
-    saveAllowPets(request.getAllowPetTypes(), accommodation);
+    saveAccommodationFacilities(request.facilityTypes(), accommodation);
+    saveAccommodationPetFacilities(request.petFacilityTypes(), accommodation);
+    saveAllowPets(request.allowPetTypes(), accommodation);
     saveAdditionalImages(newAdditionalImageUrls, accommodation);
   }
 
@@ -105,8 +105,7 @@ public class AccommodationService {
       MultipartFile thumbnail,
       List<MultipartFile> newAdditionalImages
   ) {
-    Accommodation accommodation =
-        validateAccommodationAuthorized(hostId, request.accommodationId());
+    Accommodation accommodation = findAccommodationByHostId(hostId);
     newAdditionalImages = initAdditionalImages(newAdditionalImages);
 
     List<String> trackingList = new ArrayList<>(); // 업로드 성공한 이미지 추적 (롤백 위함)
@@ -114,7 +113,7 @@ public class AccommodationService {
 
     try {
       String newThumbnailUrl = processThumbnailUpdate(
-          accommodation, thumbnail, trackingList, oldImageUrlsToDelete);
+          accommodation.getThumbnailUrl(), thumbnail, trackingList, oldImageUrlsToDelete);
 
       List<String> newAdditionalImageUrls = processAdditionalImagesUpdate(
           accommodation, newAdditionalImages, trackingList, oldImageUrlsToDelete);
@@ -122,7 +121,7 @@ public class AccommodationService {
       updateEntities(accommodation, request, newThumbnailUrl, newAdditionalImageUrls);
       imageService.registerImagesForDeletion(oldImageUrlsToDelete);
 
-      log.info("숙소 수정 성공, 숙소 ID : {}", request.accommodationId());
+      log.info("숙소 수정 성공, 숙소 ID : {}", accommodation.getId());
       return createAccommodationResponse(accommodation);
     } catch (Exception e) {
       log.error("숙소 수정 에러 발생, S3에 업로드된 이미지 삭제 처리, 원인: {}", e.getMessage());
@@ -138,16 +137,16 @@ public class AccommodationService {
   }
 
   private String processThumbnailUpdate(
-      Accommodation accommodation,
+      String oldThumbnailUrl,
       MultipartFile newThumbnail,
       List<String> trackingList,
       List<String> oldImageUrlsToDelete
   ) {
-    String newThumbnailUrl = accommodation.getThumbnailUrl();
+    String newThumbnailUrl = oldThumbnailUrl;
 
     if (newThumbnail != null && !newThumbnail.isEmpty()) {
       newThumbnailUrl = uploadImage(newThumbnail, trackingList);
-      oldImageUrlsToDelete.add(accommodation.getThumbnailUrl());
+      oldImageUrlsToDelete.add(oldThumbnailUrl);
     }
 
     return newThumbnailUrl;
@@ -208,14 +207,12 @@ public class AccommodationService {
       String newThumbnailUrl,
       List<String> newAdditionalImageUrls
   ) {
-    Long accommodationId = request.accommodationId();
+    Long accommodationId = accommodation.getId();
 
     accommodation.updateAccommodation(request, newThumbnailUrl);
-
     updateFacilities(accommodationId, request.facilityTypes(), accommodation);
 
     updatePetFacilities(accommodationId, request.petFacilityTypes(), accommodation);
-
     updateAllowPets(accommodationId, request.allowPetTypes(), accommodation);
 
     if (!newAdditionalImageUrls.isEmpty()) {
@@ -318,16 +315,6 @@ public class AccommodationService {
     validateNotExistsAccommodation(hostId);
 
     return host;
-  }
-
-  private Accommodation validateAccommodationAuthorized(Long hostId, Long accommodationId) {
-    Accommodation accommodation = findAccommodationByHostId(hostId);
-
-    if (!accommodation.getId().equals(accommodationId)) {
-      throw new MeongnyangerangException(ErrorCode.INVALID_AUTHORIZED);
-    }
-
-    return accommodation;
   }
 
   private List<MultipartFile> initAdditionalImages(List<MultipartFile> additionalImages) {

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationServiceTest.java
@@ -132,7 +132,6 @@ class AccommodationServiceTest {
     );
 
     updateRequest = AccommodationUpdateRequest.of(
-        accommodation.getId(),
         "test-name",
         AccommodationType.PENSION,
         "test-address",

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationServiceTest.java
@@ -118,18 +118,18 @@ class AccommodationServiceTest {
         .thumbnailUrl(THUMBNAIL_URL)
         .build();
 
-    request = AccommodationCreateRequest.builder()
-        .name("test-name")
-        .type(AccommodationType.DETACHED_HOUSE)
-        .address("test-address")
-        .detailedAddress("test-detailedAddress")
-        .description("test-description")
-        .latitude(37.123)
-        .longitude(127.123)
-        .facilityTypes(FACILITY_TYPES)
-        .petFacilityTypes(PET_FACILITY_TYPES)
-        .allowPetTypes(PET_TYPES)
-        .build();
+    request = new AccommodationCreateRequest(
+        "test-name",
+        AccommodationType.DETACHED_HOUSE,
+        "test-address",
+        "test-detailedAddress",
+        "test-description",
+        37.123,
+        127.123,
+        FACILITY_TYPES,
+        PET_FACILITY_TYPES,
+        PET_TYPES
+    );
 
     updateRequest = AccommodationUpdateRequest.of(
         accommodation.getId(),


### PR DESCRIPTION
## 📌 관련 이슈
- close #58

## 📝 변경 사항
### AS-IS
- 숙소 수정 API에서 숙소 ID를 요청으로 받고 있음
- 회원 정보 받지 않고 있어서 누구나 API 요청 가능

### TO-BE
- 숙소 수정 APi 숙소 ID 받지 않고 호스트 ID로 숙소를 검색하여 숙소 식별
- 유저 주석 해제하여 유저 정보 식별하도록 수정

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
