### PR TITLE
[Feature] 객실 생성 API, 객실 목록 조회 API에서 숙소 ID 요청으로 받지 않도록 수정

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/RoomController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/RoomController.java
@@ -45,11 +45,9 @@ public class RoomController {
   @GetMapping("/{accommodationId}")
   public ResponseEntity<RoomListResponse> getRoomList(
       @AuthenticationPrincipal UserDetailsImpl userDetail,
-      @PathVariable Long accommodationId,
       @RequestParam(required = false) Long cursorId,
       @RequestParam(defaultValue = "20") @Range(min = 1, max = 100) int pageSize
   ) {
-    return ResponseEntity.ok(
-        roomService.getRoomList(userDetail.getId(), accommodationId, cursorId, pageSize));
+    return ResponseEntity.ok(roomService.getRoomList(userDetail.getId(), cursorId, pageSize));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomCreateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomCreateRequest.java
@@ -14,9 +14,6 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 public record RoomCreateRequest(
 
-    @NotNull(message = "숙소 ID를 요청해 주세요.")
-    Long accommodationId,
-
     @NotBlank(message = "객실 이름을 입력해 주세요.")
     String name,
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
@@ -31,7 +31,7 @@ public class RoomService {
    * 객실 등록
    */
   public void createRoom(Long hostId, RoomCreateRequest request, MultipartFile images) {
-    Accommodation accommodation = getAuthorizedAccommodation(hostId, request.accommodationId());
+    Accommodation accommodation = findAccommodationByHostId(hostId);
     String imageUrl = imageService.storeImage(images);
 
     Room room = request.toEntity(accommodation, imageUrl);
@@ -41,13 +41,8 @@ public class RoomService {
   /**
    * 객실 목록 조회
    */
-  public RoomListResponse getRoomList(
-      Long hostId,
-      Long accommodationId,
-      Long cursorId,
-      int pageSize
-  ) {
-    Accommodation accommodation = getAuthorizedAccommodation(hostId, accommodationId);
+  public RoomListResponse getRoomList(Long hostId, Long cursorId, int pageSize) {
+    Accommodation accommodation = findAccommodationByHostId(hostId);
     Pageable pageable = PageRequest.of(
         0, pageSize + 1, Sort.by(Sort.Direction.DESC, "id"));
     // 다음 페이지 여부를 알기 위해 pageSize + 1
@@ -65,13 +60,8 @@ public class RoomService {
     return RoomListResponse.of(rooms, nextCursorId, hasNext);
   }
 
-  private Accommodation getAuthorizedAccommodation(Long hostId, Long accommodationId) {
-    Accommodation accommodation = accommodationRepository.findById(accommodationId)
+  private Accommodation findAccommodationByHostId(Long hostId) {
+    return accommodationRepository.findByHostId(hostId)
         .orElseThrow(() -> new MeongnyangerangException(ErrorCode.ACCOMMODATION_NOT_FOUND));
-
-    if (!hostId.equals(accommodation.getHost().getId())) {
-      throw new MeongnyangerangException(ErrorCode.INVALID_AUTHORIZED);
-    }
-    return accommodation;
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #61

## 📝 변경 사항
### AS-IS
- 객실 생성, 객실 목록 조회 API에서 숙소 ID를 요청으로 받아서 사용 -> 호스트 회원의 숙소가 맞는지 매 요청마다 검증 필요

### TO-BE
- 숙소 ID를 받지 않고 호스트 ID로 직접 식별하여 사용

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.