### PR TITLE
[Feature]  호스트 - 객실 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/RoomController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/RoomController.java
@@ -2,6 +2,7 @@ package com.meongnyangerang.meongnyangerang.controller;
 
 import com.meongnyangerang.meongnyangerang.dto.room.RoomCreateRequest;
 import com.meongnyangerang.meongnyangerang.dto.room.RoomListResponse;
+import com.meongnyangerang.meongnyangerang.dto.room.RoomResponse;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.RoomService;
 import jakarta.validation.Valid;
@@ -42,12 +43,23 @@ public class RoomController {
   /**
    * 객실 목록 조회
    */
-  @GetMapping("/{accommodationId}")
+  @GetMapping
   public ResponseEntity<RoomListResponse> getRoomList(
       @AuthenticationPrincipal UserDetailsImpl userDetail,
       @RequestParam(required = false) Long cursorId,
       @RequestParam(defaultValue = "20") @Range(min = 1, max = 100) int pageSize
   ) {
     return ResponseEntity.ok(roomService.getRoomList(userDetail.getId(), cursorId, pageSize));
+  }
+
+  /**
+   * 객실 상세 조회
+   */
+  @GetMapping("/{roomId}")
+  public ResponseEntity<RoomResponse> getRoom(
+      @AuthenticationPrincipal UserDetailsImpl userDetail,
+      @PathVariable Long roomId
+  ) {
+    return ResponseEntity.ok(roomService.getRoom(userDetail.getId(), roomId));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/room/facility/RoomFacility.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/room/facility/RoomFacility.java
@@ -1,6 +1,5 @@
 package com.meongnyangerang.meongnyangerang.domain.room.facility;
 
-
 import com.meongnyangerang.meongnyangerang.domain.room.Room;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomResponse.java
@@ -1,0 +1,58 @@
+package com.meongnyangerang.meongnyangerang.dto.room;
+
+import com.meongnyangerang.meongnyangerang.domain.room.Room;
+import com.meongnyangerang.meongnyangerang.domain.room.facility.Hashtag;
+import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomFacility;
+import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomPetFacility;
+import java.time.LocalTime;
+import java.util.List;
+
+public record RoomResponse(
+    String name,
+    String description,
+    Integer standardPeopleCount,
+    Integer maxPeopleCount,
+    Integer standardPetCount,
+    Integer maxPetCount,
+    Long price,
+    Long extraPeopleFee,
+    Long extraPetFee,
+    Long extraFee,
+    LocalTime checkInTime,
+    LocalTime checkOutTime,
+    String imageUrl,
+    List<String> facilityTypes,
+    List<String> petFacilityTypes,
+    List<String> hashtagTypes
+) {
+
+  public static RoomResponse of(
+      Room room,
+      List<RoomFacility> facilities,
+      List<RoomPetFacility> petFacilities,
+      List<Hashtag> hashtags
+  ) {
+    List<String> facilityValues = facilities.stream()
+        .map(facility -> facility.getType().getValue())
+        .toList();
+
+    List<String> petFacilityValues = petFacilities.stream()
+        .map(petFacility -> petFacility.getType().getValue())
+        .toList();
+
+    List<String> hashtagsValues = hashtags.stream()
+        .map(hashtag -> hashtag.getType().getValue())
+        .toList();
+
+    return new RoomResponse(
+        room.getName(), room.getDescription(),
+        room.getStandardPeopleCount(), room.getMaxPeopleCount(),
+        room.getStandardPetCount(), room.getMaxPetCount(),
+        room.getPrice(), room.getExtraPeopleFee(),
+        room.getExtraPetFee(), room.getExtraFee(),
+        room.getCheckInTime(), room.getCheckOutTime(),
+        room.getImageUrl(), facilityValues,
+        petFacilityValues, hashtagsValues
+    );
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/room/HashtagRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/room/HashtagRepository.java
@@ -1,0 +1,10 @@
+package com.meongnyangerang.meongnyangerang.repository.room;
+
+import com.meongnyangerang.meongnyangerang.domain.room.facility.Hashtag;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+
+  List<Hashtag> findAllByRoomId(Long roomId);
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/room/RoomFacilityRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/room/RoomFacilityRepository.java
@@ -1,0 +1,12 @@
+package com.meongnyangerang.meongnyangerang.repository.room;
+
+import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomFacility;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomFacilityRepository extends JpaRepository<RoomFacility, Long> {
+
+  List<RoomFacility> findAllByRoomId(Long roomId);
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/room/RoomPetFacilityRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/room/RoomPetFacilityRepository.java
@@ -1,0 +1,12 @@
+package com.meongnyangerang.meongnyangerang.repository.room;
+
+import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomPetFacility;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomPetFacilityRepository extends JpaRepository<RoomPetFacility, Long> {
+
+  List<RoomPetFacility> findAllByRoomId(Long roomId);
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/room/RoomRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/room/RoomRepository.java
@@ -1,4 +1,4 @@
-package com.meongnyangerang.meongnyangerang.repository;
+package com.meongnyangerang.meongnyangerang.repository.room;
 
 import com.meongnyangerang.meongnyangerang.domain.room.Room;
 import java.util.List;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
@@ -14,7 +14,7 @@ import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReservationSlotRepository;
-import com.meongnyangerang.meongnyangerang.repository.RoomRepository;
+import com.meongnyangerang.meongnyangerang.repository.room.RoomRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
 import jakarta.persistence.OptimisticLockException;

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
@@ -23,7 +23,7 @@ import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReservationSlotRepository;
-import com.meongnyangerang.meongnyangerang.repository.RoomRepository;
+import com.meongnyangerang.meongnyangerang.repository.room.RoomRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
 import java.time.LocalDate;


### PR DESCRIPTION
## 📌 관련 이슈
- close #68 

## 📝 변경 사항
### AS-IS
- 호스트가 본인의 객실을 상세 조회하는 기능 부재

### TO-BE
- 호스트가 본인의 객실을 상세 조회하는 기능 구현

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 성공
![success](https://github.com/user-attachments/assets/e1ed0815-72a2-4eb8-afd9-6376dd5b688b)

- 객실이 존재하지 않을 때
![error_1](https://github.com/user-attachments/assets/fc34b511-e16e-404c-ac65-c5de3a7379ea)

- 해당 객실에 대한 권한이 없을 때
![no_authorized](https://github.com/user-attachments/assets/90f0dc67-f69f-4c5e-bfd7-d3b2f300dc4a)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.