### PR TITLE
[Feature] 내 리뷰 수정 API 구현 및 테스트 완료

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
@@ -40,7 +40,8 @@ public class ReviewController {
       @Valid @RequestPart ReviewRequest reviewRequest,
       @RequestPart(required = false) List<MultipartFile> images) {
 
-    reviewService.createReview(userDetails.getId(), reviewRequest, images);
+    reviewService.createReview(userDetails.getId(), reviewRequest,
+        (images != null) ? images : Collections.emptyList());
 
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
@@ -4,6 +4,7 @@ import com.meongnyangerang.meongnyangerang.dto.AccommodationReviewResponse;
 import com.meongnyangerang.meongnyangerang.dto.CustomReviewResponse;
 import com.meongnyangerang.meongnyangerang.dto.MyReviewResponse;
 import com.meongnyangerang.meongnyangerang.dto.ReviewRequest;
+import com.meongnyangerang.meongnyangerang.dto.UpdateReviewRequest;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.ReviewService;
 import jakarta.validation.Valid;
@@ -17,6 +18,8 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -30,6 +33,7 @@ public class ReviewController {
 
   private final ReviewService reviewService;
 
+  // 리뷰 등록
   @PostMapping("/users/reviews")
   public ResponseEntity<Void> createReview(
       @AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -41,6 +45,7 @@ public class ReviewController {
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
+  // 내 리뷰 조회
   @GetMapping("/users/reviews")
   public ResponseEntity<CustomReviewResponse<MyReviewResponse>> getUsersReviews(
       @AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -53,6 +58,7 @@ public class ReviewController {
         size));
   }
 
+  // 숙소 리뷰 목록 조회
   @GetMapping("/accommodations/{accommodationId}/reviews")
   public ResponseEntity<CustomReviewResponse<AccommodationReviewResponse>> getAccommodationReviews(
       @PathVariable Long accommodationId,
@@ -63,11 +69,25 @@ public class ReviewController {
         accommodationId, cursor, size));
   }
 
+  // 내 리뷰 삭제
   @DeleteMapping("/users/reviews/{reviewId}")
   public ResponseEntity<Void> deleteReview(@PathVariable Long reviewId,
       @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
     reviewService.deleteReview(reviewId, userDetails.getId());
+
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  // 내 리뷰 수정
+  @PutMapping("/users/reviews/{reviewId}")
+  public ResponseEntity<Void> updateReview(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @PathVariable Long reviewId,
+      @RequestPart(required = false) List<MultipartFile> newImages,
+      @Valid @RequestPart UpdateReviewRequest request) {
+
+    reviewService.updateReview(userDetails.getId(), reviewId, newImages, request);
 
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
@@ -8,6 +8,7 @@ import com.meongnyangerang.meongnyangerang.dto.UpdateReviewRequest;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.ReviewService;
 import jakarta.validation.Valid;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
@@ -19,7 +20,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -87,7 +87,8 @@ public class ReviewController {
       @RequestPart(required = false) List<MultipartFile> newImages,
       @Valid @RequestPart UpdateReviewRequest request) {
 
-    reviewService.updateReview(userDetails.getId(), reviewId, newImages, request);
+    reviewService.updateReview(userDetails.getId(), reviewId,
+        (newImages != null) ? newImages : Collections.emptyList(), request);
 
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/UpdateReviewRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/UpdateReviewRequest.java
@@ -1,0 +1,25 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UpdateReviewRequest {
+
+  @NotNull
+  private Double userRating;
+
+  @NotNull
+  private Double petRating;
+
+  private String content;
+
+  @Default // 삭제할 이미지 Id가 없으면 빈 리스트 기본 값 설정
+  private List<Long> deletedImageId = new ArrayList<>();
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -45,7 +45,7 @@ public enum ErrorCode {
   ACCOUNT_DELETED(HttpStatus.FORBIDDEN, "현재 계정 상태는 삭제 상태입니다."),
   ACCOUNT_PENDING(HttpStatus.FORBIDDEN, "관리자 승인 대기 중입니다."),
   REVIEW_CREATION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "리뷰 작성 가능 기간이 만료되었습니다."),
-  REVIEW_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "해당 리뷰를 삭제할 권한이 없습니다."),
+  REVIEW_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "해당 리뷰에 대한 권한이 없습니다."),
 
   // 404  NOT FOUND
   NOT_EXISTS_HOST(HttpStatus.NOT_FOUND, "존재하지 않는 호스트입니다."),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
@@ -44,14 +44,11 @@ public class ReviewService {
 
     Review review = reviewRequest.toEntity(reservation.getUser(),
         reservation.getRoom().getAccommodation(), reservation);
-
-    // 이미지 등록 (있는 경우에만)
-    if (images != null) {
-      validateImageSize(images);
-      addImages(review, images);
-    }
-
     reviewRepository.save(review);
+
+    // 이미지 등록
+    validateImageSize(images);
+    addImages(review, images);
   }
 
   // 최대 이미지 개수(3장)를 초과하는지 검증
@@ -82,9 +79,9 @@ public class ReviewService {
       throw new MeongnyangerangException(ErrorCode.INVALID_AUTHORIZED);
     }
 
-    // 예약 생성 후 7일이 지나거나, 예약 상태가 RESERVED 가 아닌 경우 예외 발생
+    // 예약 생성 후 7일이 지나거나, 예약 상태가 COMPLETED 가 아닌 경우 예외 발생
     if (reservation.getCreatedAt().plusDays(7).isBefore(LocalDateTime.now()) ||
-        reservation.getStatus() != ReservationStatus.RESERVED) {
+        reservation.getStatus() != ReservationStatus.COMPLETED) {
       throw new MeongnyangerangException(ErrorCode.REVIEW_CREATION_NOT_ALLOWED);
     }
   }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
@@ -8,6 +8,7 @@ import com.meongnyangerang.meongnyangerang.dto.AccommodationReviewResponse;
 import com.meongnyangerang.meongnyangerang.dto.CustomReviewResponse;
 import com.meongnyangerang.meongnyangerang.dto.MyReviewResponse;
 import com.meongnyangerang.meongnyangerang.dto.ReviewRequest;
+import com.meongnyangerang.meongnyangerang.dto.UpdateReviewRequest;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
@@ -47,19 +48,21 @@ public class ReviewService {
     // 이미지 등록 (있는 경우에만)
     if (images != null) {
       validateImageSize(images);
-      addImages(images, review);
+      addImages(review, images);
     }
 
     reviewRepository.save(review);
   }
 
+  // 최대 이미지 개수(3장)를 초과하는지 검증
   private void validateImageSize(List<MultipartFile> images) {
     if (images.size() > 3) {
       throw new MeongnyangerangException(ErrorCode.MAX_IMAGE_LIMIT_EXCEEDED);
     }
   }
 
-  private void addImages(List<MultipartFile> images, Review review) {
+  // 이미지 등록
+  private void addImages(Review review, List<MultipartFile> images) {
     images.stream()
         .filter(image -> !image.isEmpty())
         .map(imageService::storeImage)
@@ -67,6 +70,7 @@ public class ReviewService {
         .forEach(reviewImageRepository::save);
   }
 
+  // 리뷰를 작성할 수 있는지 검증
   private void validateReviewCreation(Long userId, Reservation reservation) {
     // 이미 작성된 리뷰인지 확인
     if (reviewRepository.existsByUserIdAndReservationId(userId, reservation.getId())) {
@@ -101,6 +105,7 @@ public class ReviewService {
     return new CustomReviewResponse<>(content, cursor, hasNext);
   }
 
+  // entity -> dto 변환
   private MyReviewResponse mapToMyReviewResponse(Review review) {
     ReviewImage reviewImage = reviewImageRepository.findByReviewId(review.getId());
 
@@ -137,6 +142,7 @@ public class ReviewService {
     return new CustomReviewResponse<>(content, cursor, hasNext);
   }
 
+  // entity -> dto 변환
   private AccommodationReviewResponse mapToAccommodationReviewResponse(Review review) {
     ReviewImage reviewImage = reviewImageRepository.findByReviewId(review.getId());
 
@@ -156,18 +162,83 @@ public class ReviewService {
         .build();
   }
 
+  @Transactional
   public void deleteReview(Long reviewId, Long userId) {
-    // 리뷰 조회
+    // 리뷰 조회 및 권한 검증
+    Review review = getReviewIfAuthorized(reviewId, userId);
+
+    // 리뷰에 포함된 모든 이미지 삭제
+    deleteAllReviewImages(reviewId);
+
+    // 리뷰 삭제
+    reviewRepository.delete(review);
+  }
+
+  // 주어진 리뷰 ID로 리뷰를 조회하고, 해당 리뷰의 작성자인지 검증
+  private Review getReviewIfAuthorized(Long reviewId, Long userId) {
     Review review = reviewRepository.findById(reviewId)
         .orElseThrow(() -> new MeongnyangerangException(ErrorCode.REVIEW_NOT_FOUND));
 
-    // 요청한 사용자가 작성자인지 확인
     if (!review.getUser().getId().equals(userId)) {
       throw new MeongnyangerangException(ErrorCode.REVIEW_NOT_AUTHORIZED);
     }
-
-    // 리뷰 & 리뷰 이미지 삭제
-    reviewImageRepository.deleteAll(reviewImageRepository.findAllByReviewId(reviewId));
-    reviewRepository.delete(review);
+    return review;
   }
+
+  // 특정 리뷰에 포함된 모든 이미지 삭제
+  private void deleteAllReviewImages(Long reviewId) {
+    List<ReviewImage> images = reviewImageRepository.findAllByReviewId(reviewId);
+
+    images.forEach(image -> imageService.deleteImage(image.getImageUrl()));
+
+    reviewImageRepository.deleteAll(images);
+  }
+
+  @Transactional
+  public void updateReview(Long userId, Long reviewId, List<MultipartFile> newImages,
+      UpdateReviewRequest request) {
+    // 리뷰 조회 및 권한 검증
+    Review review = getReviewIfAuthorized(reviewId, userId);
+
+    // 새로운 이미지 추가 후 최대 업로드 가능 개수(3장) 초과 여부 검증
+    validateImageLimit(reviewId, request.getDeletedImageId(), newImages);
+
+    // 요청된 이미지 삭제 수행
+    deleteReviewImagesByIds(request.getDeletedImageId());
+
+    // 새 이미지 업로드 및 저장
+    addImages(review, newImages);
+
+    // 리뷰 내용 업데이트
+    updateReviewDetails(review, request);
+  }
+
+  // 이미지 삭제 요청 및 새로운 이미지 업로드 시, 최대 이미지 개수(3장)를 초과하는지 검증
+  private void validateImageLimit(Long reviewId, List<Long> deletedImageIds,
+      List<MultipartFile> newImages) {
+    int existingCount = reviewImageRepository.findAllByReviewId(reviewId).size();
+    int newCount = existingCount - deletedImageIds.size() + newImages.size();
+
+    if (newCount > 3) {
+      throw new MeongnyangerangException(ErrorCode.MAX_IMAGE_LIMIT_EXCEEDED);
+    }
+  }
+
+  // 요청된 이미지 ID 목록을 찾아 삭제 (존재하지 않는 이미지 ID는 무시)
+  private void deleteReviewImagesByIds(List<Long> deletedImageIds) {
+    deletedImageIds.forEach(id ->
+        reviewImageRepository.findById(id).ifPresent(image -> {
+          imageService.deleteImage(image.getImageUrl());
+          reviewImageRepository.delete(image);
+        })
+    );
+  }
+
+  // 리뷰 내용과 평점을 업데이트
+  private void updateReviewDetails(Review review, UpdateReviewRequest request) {
+    review.setContent(request.getContent());
+    review.setUserRating(request.getUserRating());
+    review.setPetFriendlyRating(request.getPetRating());
+  }
+
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReviewServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReviewServiceTest.java
@@ -68,7 +68,7 @@ class ReviewServiceTest {
 
     Reservation reservation = Reservation.builder()
         .id(1L)
-        .status(ReservationStatus.RESERVED)
+        .status(ReservationStatus.COMPLETED)
         .user(user)
         .room(room)
         .checkInDate(LocalDate.of(2025, 3, 30))
@@ -354,7 +354,7 @@ class ReviewServiceTest {
 
     Reservation reservation = Reservation.builder()
         .id(1L)
-        .status(ReservationStatus.RESERVED)
+        .status(ReservationStatus.COMPLETED)
         .user(user)
         .room(room)
         .checkInDate(LocalDate.of(2025, 3, 30))

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReviewServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReviewServiceTest.java
@@ -19,6 +19,7 @@ import com.meongnyangerang.meongnyangerang.dto.AccommodationReviewResponse;
 import com.meongnyangerang.meongnyangerang.dto.CustomReviewResponse;
 import com.meongnyangerang.meongnyangerang.dto.MyReviewResponse;
 import com.meongnyangerang.meongnyangerang.dto.ReviewRequest;
+import com.meongnyangerang.meongnyangerang.dto.UpdateReviewRequest;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
@@ -555,5 +556,239 @@ class ReviewServiceTest {
 
     // then
     assertEquals(ErrorCode.REVIEW_NOT_AUTHORIZED, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("유저는 자신의 리뷰를 수정할 수 있다.")
+  void updateReview_success() {
+    // given
+    User user = User.builder().id(1L).build();
+    Room room = Room.builder().id(1L).build();
+
+    Reservation reservation = Reservation.builder()
+        .id(1L)
+        .status(ReservationStatus.COMPLETED)
+        .user(user)
+        .room(room)
+        .checkInDate(LocalDate.of(2025, 3, 30))
+        .checkOutDate(LocalDate.of(2025, 4, 1))
+        .peopleCount(2)
+        .petCount(1)
+        .totalPrice(30000L)
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    Review review = Review.builder()
+        .id(1L)
+        .user(user)
+        .accommodation(Accommodation.builder().id(1L).build())
+        .reservation(reservation)
+        .userRating(3.0)
+        .petFriendlyRating(4.0)
+        .content("before")
+        .reportCount(0)
+        .build();
+
+    String url = "https://test.com/images/image.jpg";
+    String newImageUrl = "https://test.com/images/new-image.jpg";
+
+    List<ReviewImage> images = List.of(
+        ReviewImage.builder().id(1L).review(review).imageUrl(url).build(),
+        ReviewImage.builder().id(2L).review(review).imageUrl(url).build()
+    );
+
+    MockMultipartFile mockImageFile = new MockMultipartFile(
+        "image", "new-image.jpg", "image/jpeg", new byte[]{1, 2, 3, 4}
+    );
+
+    when(reviewRepository.findById(review.getId())).thenReturn(Optional.of(review));
+    when(reviewImageRepository.findAllByReviewId(review.getId())).thenReturn(images);
+    when(reviewImageRepository.findById(2L)).thenReturn(Optional.of(images.get(1)));
+    when(imageService.storeImage(mockImageFile)).thenReturn(newImageUrl);
+
+    UpdateReviewRequest request = UpdateReviewRequest.builder()
+        .content("after")
+        .petRating(3.0)
+        .userRating(4.0)
+        .deletedImageId(List.of(2L))
+        .build();
+
+    // when
+    reviewService.updateReview(user.getId(), review.getId(), List.of(mockImageFile), request);
+
+    // then
+    ArgumentCaptor<ReviewImage> reviewImageCaptor = ArgumentCaptor.forClass(ReviewImage.class);
+    verify(reviewImageRepository, times(1)).save(reviewImageCaptor.capture());
+
+    assertEquals(review, reviewImageCaptor.getValue().getReview());
+    assertEquals(newImageUrl, reviewImageCaptor.getValue().getImageUrl());
+    assertEquals("after", review.getContent());
+    assertEquals(3.0, review.getPetFriendlyRating());
+    assertEquals(4.0, review.getUserRating());
+    verify(reviewImageRepository, times(1)).delete(images.get(1));
+    verify(imageService, times(1)).storeImage(mockImageFile);
+  }
+
+  @Test
+  @DisplayName("리뷰가 존재하지 않는 경우, REVIEW_NOT_FOUND 예외가 발생해야 한다.")
+  void updateReview_review_not_found() {
+    // given
+    User user = User.builder().id(1L).build();
+    Room room = Room.builder().id(1L).build();
+
+    Reservation reservation = Reservation.builder()
+        .id(1L)
+        .status(ReservationStatus.COMPLETED)
+        .user(user)
+        .room(room)
+        .checkInDate(LocalDate.of(2025, 3, 30))
+        .checkOutDate(LocalDate.of(2025, 4, 1))
+        .peopleCount(2)
+        .petCount(1)
+        .totalPrice(30000L)
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    Review review = Review.builder()
+        .id(1L)
+        .user(user)
+        .accommodation(Accommodation.builder().id(1L).build())
+        .reservation(reservation)
+        .userRating(3.0)
+        .petFriendlyRating(4.0)
+        .content("before")
+        .reportCount(0)
+        .build();
+
+    MockMultipartFile mockImageFile = new MockMultipartFile(
+        "image", "new-image.jpg", "image/jpeg", new byte[]{1, 2, 3, 4}
+    );
+
+    UpdateReviewRequest request = UpdateReviewRequest.builder()
+        .content("after")
+        .petRating(3.0)
+        .userRating(4.0)
+        .deletedImageId(List.of(2L))
+        .build();
+
+    // when & then
+    MeongnyangerangException e = assertThrows(MeongnyangerangException.class,
+        () -> reviewService.updateReview(
+            user.getId(), review.getId(), List.of(mockImageFile), request));
+
+    assertEquals(ErrorCode.REVIEW_NOT_FOUND, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("리뷰의 작성자가 아닌 경우, REVIEW_NOT_AUTHORIZED 예외가 발생해야 한다.")
+  void updateReview_review_not_authorized() {
+    // given
+    User user = User.builder().id(2L).build();
+    Room room = Room.builder().id(1L).build();
+
+    Reservation reservation = Reservation.builder()
+        .id(1L)
+        .status(ReservationStatus.COMPLETED)
+        .user(user)
+        .room(room)
+        .checkInDate(LocalDate.of(2025, 3, 30))
+        .checkOutDate(LocalDate.of(2025, 4, 1))
+        .peopleCount(2)
+        .petCount(1)
+        .totalPrice(30000L)
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    Review review = Review.builder()
+        .id(1L)
+        .user(User.builder().id(1L).build())
+        .accommodation(Accommodation.builder().id(1L).build())
+        .reservation(reservation)
+        .userRating(3.0)
+        .petFriendlyRating(4.0)
+        .content("before")
+        .reportCount(0)
+        .build();
+
+    MockMultipartFile mockImageFile = new MockMultipartFile(
+        "image", "new-image.jpg", "image/jpeg", new byte[]{1, 2, 3, 4}
+    );
+
+    UpdateReviewRequest request = UpdateReviewRequest.builder()
+        .content("after")
+        .petRating(3.0)
+        .userRating(4.0)
+        .deletedImageId(List.of(2L))
+        .build();
+
+    when(reviewRepository.findById(review.getId())).thenReturn(Optional.of(review));
+
+    // when & then
+    MeongnyangerangException e = assertThrows(MeongnyangerangException.class,
+        () -> reviewService.updateReview(
+            user.getId(), review.getId(), List.of(mockImageFile), request));
+
+    assertEquals(ErrorCode.REVIEW_NOT_AUTHORIZED, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("최대 이미지 개수(3장)을 초과한 경우, MAX_IMAGE_LIMIT_EXCEEDED 예외가 발생해야 한다.")
+  void updateReview_max_image_limit_exceeded() {
+    // given
+    User user = User.builder().id(1L).build();
+    Room room = Room.builder().id(1L).build();
+
+    Reservation reservation = Reservation.builder()
+        .id(1L)
+        .status(ReservationStatus.COMPLETED)
+        .user(user)
+        .room(room)
+        .checkInDate(LocalDate.of(2025, 3, 30))
+        .checkOutDate(LocalDate.of(2025, 4, 1))
+        .peopleCount(2)
+        .petCount(1)
+        .totalPrice(30000L)
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    Review review = Review.builder()
+        .id(1L)
+        .user(user)
+        .accommodation(Accommodation.builder().id(1L).build())
+        .reservation(reservation)
+        .userRating(3.0)
+        .petFriendlyRating(4.0)
+        .content("before")
+        .reportCount(0)
+        .build();
+
+    String url = "https://test.com/images/image.jpg";
+
+    List<ReviewImage> images = List.of(
+        ReviewImage.builder().id(1L).review(review).imageUrl(url).build(),
+        ReviewImage.builder().id(2L).review(review).imageUrl(url).build()
+    );
+
+    List<MultipartFile> mockImages = List.of(
+        new MockMultipartFile("image1", "new-image1.jpg", "image/jpeg", new byte[]{1, 2, 3, 4}),
+        new MockMultipartFile("image2", "new-image2.jpg", "image/jpeg", new byte[]{1, 2, 3, 4})
+    );
+
+    UpdateReviewRequest request = UpdateReviewRequest.builder()
+        .content("after")
+        .petRating(3.0)
+        .userRating(4.0)
+        .deletedImageId(List.of())
+        .build();
+
+    when(reviewRepository.findById(review.getId())).thenReturn(Optional.of(review));
+    when(reviewImageRepository.findAllByReviewId(review.getId())).thenReturn(images);
+
+    // when & then
+    MeongnyangerangException e = assertThrows(MeongnyangerangException.class,
+        () -> reviewService.updateReview(
+            user.getId(), review.getId(), mockImages, request));
+
+    assertEquals(ErrorCode.MAX_IMAGE_LIMIT_EXCEEDED, e.getErrorCode());
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #70 

## 📝 변경 사항
### AS-IS
- 사용자가 자신이 작성한 리뷰를 수정할 수 있는 기능이 없었음.

### TO-BE
- 사용자가 자신이 작성한 리뷰를 수정할 수 있도록 기능을 추가함. (PUT /api/v1/users/reviews/{reviewId})
- 리뷰 수정 시, 내용, 평점, 이미지(추가/삭제) 변경 가능
- 이미지(추가/삭제 시) S3 (추가/삭제) 후 DB 저장
- 테스트 코드 작성
  - 성공 케이스
    - 사용자가 자신의 리뷰를 정상적으로 수정할 수 있음.
  - 실패 케이스
   1. 리뷰가 존재하지 않을 때 → 404 NOT FOUND
   2. 리뷰 작성자가 아닐 경우 → 403 FORBIDDEN
   3. 인증되지 않은 사용자가 접근할 경우 → 401 UNAUTHORIZED
   4. 최대 이미지 개수(3장)을 초과한 경우 → 400 BAD REQUEST
  

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 성공 (기존에 있던 사진 삭제 X)
![내 리뷰 수정 204 반환](https://github.com/user-attachments/assets/0ee3938d-2098-47b1-98cf-4d0f953fbcd0)
![내 리뷰 수정 db 저장 확인](https://github.com/user-attachments/assets/ed7aa3e4-fcba-4acc-b754-62a8cbd6fa21)
- 성공 (기존에 있던 사진 삭제 O)
![내 리뷰 조회 204 성공 사진 삭제하고 업로드 한 경우](https://github.com/user-attachments/assets/73c713c9-64d3-43d2-b3af-9820a77223fa)
- 리뷰가 존재하지 않는 경우
![내 리뷰 수정 404 존재하지 않는 경우](https://github.com/user-attachments/assets/f98f2d04-1e61-470b-84c4-9c1b0eb59c50)
- 최대 이미지 개수 (3장) 초과한 경우
![내 리뷰 수정 400 최대 이미지 개수 3장](https://github.com/user-attachments/assets/40691ba9-6206-4683-9034-35d4df6887f9)
- 인증 실패
![내 리뷰 조회 401 인증 실패](https://github.com/user-attachments/assets/99a5a864-4379-42ce-acc0-546024b133bf)
- 리뷰 작성자가 아닌 경우
![내 리뷰 조회 403 리뷰 작성자가 아닐 경우](https://github.com/user-attachments/assets/b3df0a7b-e1c4-42bf-9b03-f49b82ad8291)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
