### PR TITLE
[Feature] 사용자 반려동물 조회 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserPetController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserPetController.java
@@ -1,9 +1,11 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
 import com.meongnyangerang.meongnyangerang.dto.UserPetRequest;
+import com.meongnyangerang.meongnyangerang.dto.UserPetResponse;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.UserPetService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserPetController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserPetController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -46,5 +47,11 @@ public class UserPetController {
       @PathVariable Long petId) {
     userPetService.deletePet(userDetails.getId(), petId);
     return ResponseEntity.noContent().build();
+  }
+
+  // 사용자 반려동물 조회 API
+  @GetMapping
+  public ResponseEntity<List<UserPetResponse>> getPets(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    return ResponseEntity.ok(userPetService.getUserPets(userDetails.getId()));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/UserPetResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/UserPetResponse.java
@@ -10,7 +10,7 @@ public class UserPetResponse {
 
   private Long petId;
   private String name;
-  private String birthDate; // YYYY-MM-DD 형식
+  private String birthDate; // yyyy-MM-dd 형식
   private String type;
   private String personality;
   private String activityLevel;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/UserPetResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/UserPetResponse.java
@@ -1,0 +1,28 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import com.meongnyangerang.meongnyangerang.domain.user.UserPet;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserPetResponse {
+
+  private Long petId;
+  private String name;
+  private String birthDate; // YYYY-MM-DD 형식
+  private String type;
+  private String personality;
+  private String activityLevel;
+
+  public static UserPetResponse from(UserPet pet) {
+    return new UserPetResponse(
+        pet.getId(),
+        pet.getName(),
+        pet.getBirthDate().toString(),
+        pet.getType().name(),
+        pet.getPersonality().name(),
+        pet.getActivityLevel().name()
+    );
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/UserPetRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/UserPetRepository.java
@@ -1,6 +1,7 @@
 package com.meongnyangerang.meongnyangerang.repository;
 
 import com.meongnyangerang.meongnyangerang.domain.user.UserPet;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +9,5 @@ import org.springframework.stereotype.Repository;
 public interface UserPetRepository extends JpaRepository<UserPet, Long> {
   long countByUserId(Long userId);
 
+  List<UserPet> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserPetService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserPetService.java
@@ -6,10 +6,13 @@ import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_
 import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.UserPet;
 import com.meongnyangerang.meongnyangerang.dto.UserPetRequest;
+import com.meongnyangerang.meongnyangerang.dto.UserPetResponse;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.UserPetRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserPetService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserPetService.java
@@ -71,4 +71,12 @@ public class UserPetService {
 
     userPetRepository.delete(userPet);
   }
+
+  // 반려동물 조회
+  @Transactional(readOnly = true)
+  public List<UserPetResponse> getUserPets(Long userId) {
+    return userPetRepository.findAllByUserId(userId).stream()
+        .map(UserPetResponse::from)
+        .collect(Collectors.toList());
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/UserPetServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/UserPetServiceTest.java
@@ -11,10 +11,12 @@ import com.meongnyangerang.meongnyangerang.domain.user.Personality;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.UserPet;
 import com.meongnyangerang.meongnyangerang.dto.UserPetRequest;
+import com.meongnyangerang.meongnyangerang.dto.UserPetResponse;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.UserPetRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -201,5 +203,43 @@ public class UserPetServiceTest {
     // when & then
     assertThrows(MeongnyangerangException.class, () ->
         userPetService.deletePet(userId, petId));
+  }
+  @Test
+  @DisplayName("사용자 반려동물 전체 조회 성공")
+  void getUserPetsSuccess() {
+    // given
+    Long userId = 1L;
+    User user = User.builder().id(userId).email("user@example.com").build();
+
+    List<UserPet> pets = List.of(
+        UserPet.builder()
+            .id(101L)
+            .user(user)
+            .name("콩이")
+            .birthDate(LocalDate.of(2020, 1, 1))
+            .type(PetType.SMALL_DOG)
+            .personality(Personality.EXTROVERT)
+            .activityLevel(ActivityLevel.HIGH)
+            .build(),
+        UserPet.builder()
+            .id(102L)
+            .user(user)
+            .name("두부")
+            .birthDate(LocalDate.of(2019, 5, 10))
+            .type(PetType.CAT)
+            .personality(Personality.INTROVERT)
+            .activityLevel(ActivityLevel.MEDIUM)
+            .build()
+    );
+
+    when(userPetRepository.findAllByUserId(userId)).thenReturn(pets);
+
+    // when
+    List<UserPetResponse> result = userPetService.getUserPets(userId);
+
+    // then
+    assertEquals(2, result.size());
+    assertEquals("콩이", result.get(0).getName());
+    assertEquals("두부", result.get(1).getName());
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #73 

## 📝 변경 사항
### AS-IS
- 사용자 반려동물 등록만 가능하고 조회 기능은 존재하지 않았음.

### TO-BE
- 사용자 ID를 기반으로 반려동물 전체 리스트 조회 기능 추가  
- UserPetResponse DTO 생성 및 적용  
- UserPetService 및 Controller에 조회 로직 구현  
- 테스트 코드 작성

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 목록 조회 성공
![image](https://github.com/user-attachments/assets/ca2d699b-c26b-41a4-b2e0-b8fe4ca78bcb)
- 목록 조회 실패(인증 실패)
![image](https://github.com/user-attachments/assets/5a18b076-54bb-4131-ae4f-8efb91c71839)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- UserPetResponse DTO 구조가 적절한지 확인 부탁드립니다.  
