### PR TITLE
[Feature] 호스트 가입 거절 API 구현 및 테스트 완료

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -53,6 +54,15 @@ public class AdminController {
   public ResponseEntity<Void> approveHost(@PathVariable Long hostId) {
 
     adminService.approveHost(hostId);
+
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  // 호스트 가입 거절
+  @DeleteMapping("/hosts/{hostId}/reject")
+  public ResponseEntity<Void> rejectHost(@PathVariable Long hostId) {
+
+    adminService.rejectHost(hostId);
 
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AdminService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AdminService.java
@@ -133,7 +133,7 @@ public class AdminService {
       throw new MeongnyangerangException(ErrorCode.HOST_ALREADY_PROCESSED);
     }
 
-    // 가입 승인 이메일 발송
+    // 가입 거절 이메일 발송
     mailComponent.sendMail(
         host.getEmail(),
         "[멍냥이랑] 요청하신 호스트 가입이 거절되었습니다",

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AdminService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AdminService.java
@@ -120,4 +120,34 @@ public class AdminService {
             """
     );
   }
+
+  // 호스트 가입 거절
+  @Transactional
+  public void rejectHost(Long hostId) {
+    // 호스트 조회
+    Host host = hostRepository.findById(hostId)
+        .orElseThrow(() -> new MeongnyangerangException(ErrorCode.NOT_EXISTS_HOST));
+
+    // 호스트의 상태가 PENDING이 아닌 경우 예외 처리
+    if (host.getStatus() != HostStatus.PENDING) {
+      throw new MeongnyangerangException(ErrorCode.HOST_ALREADY_PROCESSED);
+    }
+
+    // 가입 승인 이메일 발송
+    mailComponent.sendMail(
+        host.getEmail(),
+        "[멍냥이랑] 요청하신 호스트 가입이 거절되었습니다",
+        """
+            <div>
+              <h2>안녕하세요, 멍냥이랑입니다.</h2>
+              <p>요청하신 <strong>호스트 가입</strong>이 거절되었습니다.</p>
+              <p>제출하신 서류를 다시 검토해주시고, 가입 신청 부탁드립니다.</p>
+              <p>감사합니다.</p>
+            </div>
+            """
+    );
+
+    // DB에서 호스트 정보 삭제
+    hostRepository.delete(host);
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #79 

## 📝 변경 사항
### AS-IS
- 관리자가 호스트 가입 신청을 거절하는 기능이 없었음.
- 거절된 호스트에게 이메일 발송하는 기능이 없었고, 거절된 호스트를 삭제하는 기능이 없었음.

### TO-BE
- 관리자가 호스트 가입 신청을 거절할 수 있는 기능이 추가됨.
- 거절된 호스트에게 "가입 거절" 이메일을 발송하는 로직이 추가됨.
- 거절된 호스트의 정보는 DB 에서 삭제됨.
- 이미 승인/거절된 호스트에 대해서는 409 CONFLICT 오류를 반환하도록 예외 처리가 추가됨.
- 테스트: 호스트 거절 기능에 대한 단위 테스트가 작성되었으며, 메일 발송도 테스트됨.

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 성공
![관리자 - 호스트 가입 거절 204 반환](https://github.com/user-attachments/assets/1fb49d5d-4eda-4f88-b20d-863e23e149bf)
- 성공 (메일 확인)
![관리자 - 호스트 가입 거절 204 메일 전송 확인](https://github.com/user-attachments/assets/309e4e01-16a4-4a62-b568-7ccbded2d1cd)
- 실패 401 인증 실패
![관리자 - 호스트 가입 거절 401 인증 실패](https://github.com/user-attachments/assets/84124729-1645-4f15-a12b-fc18c59215ba)
- 실패 404 존재하지 않는 호스트
![관리자 - 호스트 가입 거절 404 존재하지 않는 호스트](https://github.com/user-attachments/assets/76056415-0922-4733-afee-440e875ddcbe)
- 실패 409 이미 처리된 요청
![관리자 - 호스트 가입 거절 409 이미 처리된 호스트](https://github.com/user-attachments/assets/629b3744-f41a-4e38-9b9e-7fa9c0954ba2)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
가입 거절 메일 내용도 임의로 작성해서 내용 변경 원하시면 말씀해주세요. (중요한 내용 아닌 것 같아서 임의로 정했습니다.)
