### PR TITLE
[Feature] 객실 삭제 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/RoomController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/RoomController.java
@@ -12,6 +12,7 @@ import org.hibernate.validator.constraints.Range;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -75,5 +76,17 @@ public class RoomController {
       @RequestPart(required = false) MultipartFile newImage
   ) {
     return ResponseEntity.ok(roomService.updateRoom(userDetail.getId(), request, newImage));
+  }
+
+  /**
+   * 객실 삭제
+   */
+  @DeleteMapping("/{roomId}")
+  public ResponseEntity<Void> deleteRoom(
+      @AuthenticationPrincipal UserDetailsImpl userDetail,
+      @PathVariable Long roomId
+  ){
+    roomService.deleteRoom(userDetail.getId(), roomId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
@@ -118,6 +118,18 @@ public class RoomService {
     }
   }
 
+  /**
+   * 객실 삭제
+   */
+  @Transactional
+  public void deleteRoom(Long hostId, Long roomId) {
+    Room room = getAuthorizedRoom(hostId, roomId);
+    hashtagRepository.deleteAllByRoomId(roomId);
+    roomPetFacilityRepository.deleteAllByRoomId(roomId);
+    roomFacilityRepository.deleteAllByRoomId(roomId);
+    roomRepository.delete(room);
+  }
+
   private List<RoomFacility> updateFacilities(List<RoomFacilityType> newFacilityTypes, Room room) {
     roomFacilityRepository.deleteAllByRoomId(room.getId());
     return saveRoomFacilities(newFacilityTypes, room);


### PR DESCRIPTION
## 📌 관련 이슈
- close #78

## 📝 변경 사항
### AS-IS
- 호스트가 본인의 객실을 삭제하는 기능 부재

### TO-BE
- 호스트가 본인의 객실을 삭제하는 기능 구현

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 성공
![success](https://github.com/user-attachments/assets/c9d13d97-0884-4b5c-ab7f-7fbfde18a1d0)

- 숙소 없을 경우
![accommodation_not_found](https://github.com/user-attachments/assets/df4eb5ab-4619-493c-927f-8d52c887a5dd)

- 객실 없을 경우
![not_found](https://github.com/user-attachments/assets/dd97c844-a3b5-4fd9-b67a-a70fc78165d6)

- 객실이 해당 호스트의 객실이 아닌 경우 (권한 없음)
![no_authorization](https://github.com/user-attachments/assets/861154b1-c46d-4936-84ba-5d2566eb9f3c)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.