### PR TITLE
[Feature] 사용자 숙소 찜 등록 및 삭제 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/WishlistController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/WishlistController.java
@@ -1,12 +1,29 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
+import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
+import com.meongnyangerang.meongnyangerang.service.WishlistService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/users/wishlist")
+@RequestMapping("/api/v1/users/wishlist/accommodations")
 public class WishlistController {
+
+  private final WishlistService wishlistService;
+
+  // 찜 등록 API
+  @PostMapping("/{accommodationId}")
+  public ResponseEntity<Void> addWishlist(@AuthenticationPrincipal UserDetailsImpl userDetails,
+      @PathVariable Long accommodationId) {
+    wishlistService.addWishlist(userDetails.getId(), accommodationId);
+    return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
 
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/WishlistController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/WishlistController.java
@@ -1,0 +1,12 @@
+package com.meongnyangerang.meongnyangerang.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users/wishlist")
+public class WishlistController {
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/WishlistController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/WishlistController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,4 +27,11 @@ public class WishlistController {
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
+  // 찜 삭제 API
+  @DeleteMapping("/{accommodationId}")
+  public ResponseEntity<Void> removeWishlist(@AuthenticationPrincipal UserDetailsImpl userDetails,
+      @PathVariable Long accommodationId) {
+    wishlistService.removeWishlist(userDetails.getId(), accommodationId);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -57,6 +57,7 @@ public enum ErrorCode {
   RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약이 존재하지 않습니다."),
   REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰가 존재하지 않습니다."),
   NOT_EXIST_PET(HttpStatus.NOT_FOUND, "존재하지 않는 반려동물입니다."),
+  NOT_EXIST_WISHLIST(HttpStatus.NOT_FOUND, "존재하지 않는 찜 목록입니다."),
 
 
   // 409 Conflict

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -66,6 +66,7 @@ public enum ErrorCode {
   // 409 CONFLICT
   ACCOMMODATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 개설한 숙소가 존재합니다."),
   HOST_ALREADY_PROCESSED(HttpStatus.CONFLICT, "이미 승인 또는 거절된 호스트입니다."),
+  ALREADY_WISHLISTED(HttpStatus.CONFLICT, "이미 찜한 숙소입니다."),
 
   // 500 INTERNAL SERVER ERROR (서버 내부 오류)
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/WishlistRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/WishlistRepository.java
@@ -1,6 +1,7 @@
 package com.meongnyangerang.meongnyangerang.repository;
 
 import com.meongnyangerang.meongnyangerang.domain.user.Wishlist;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +9,5 @@ import org.springframework.stereotype.Repository;
 public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
   boolean existsByUserIdAndAccommodationId(Long userId, Long accommodationId);
 
+  Optional<Wishlist> findByUserIdAndAccommodationId(Long userId, Long accommodationId);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/WishlistRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/WishlistRepository.java
@@ -6,6 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
-
+  boolean existsByUserIdAndAccommodationId(Long userId, Long accommodationId);
 
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/WishlistRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/WishlistRepository.java
@@ -1,0 +1,11 @@
+package com.meongnyangerang.meongnyangerang.repository;
+
+import com.meongnyangerang.meongnyangerang.domain.user.Wishlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
+
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
@@ -1,10 +1,45 @@
 package com.meongnyangerang.meongnyangerang.service;
 
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOMMODATION_NOT_FOUND;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_ACCOUNT;
+
+import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
+import com.meongnyangerang.meongnyangerang.domain.user.User;
+import com.meongnyangerang.meongnyangerang.domain.user.Wishlist;
+import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import com.meongnyangerang.meongnyangerang.repository.UserRepository;
+import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
+import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class WishlistService {
 
+  private final AccommodationRepository accommodationRepository;
+  private final WishlistRepository wishlistRepository;
+  private final UserRepository userRepository;
+
+  // 찜 등록
+  @Transactional
+  public void addWishlist(Long userId, Long accommodationId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
+
+    Accommodation accommodation = accommodationRepository.findById(accommodationId)
+        .orElseThrow(() -> new MeongnyangerangException(ACCOMMODATION_NOT_FOUND));
+
+    if (wishlistRepository.existsByUserIdAndAccommodationId(userId, accommodationId)) {
+      throw new MeongnyangerangException(ALREADY_WISHLISTED);
+    }
+
+    Wishlist wishlist = Wishlist.builder()
+        .user(user)
+        .accommodation(accommodation)
+        .build();
+
+    wishlistRepository.save(wishlist);
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
@@ -3,6 +3,7 @@ package com.meongnyangerang.meongnyangerang.service;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOMMODATION_NOT_FOUND;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ALREADY_WISHLISTED;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_ACCOUNT;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_WISHLIST;
 
 import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
 import com.meongnyangerang.meongnyangerang.domain.user.User;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
@@ -1,0 +1,10 @@
+package com.meongnyangerang.meongnyangerang.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WishlistService {
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
@@ -41,4 +41,13 @@ public class WishlistService {
         .accommodation(accommodation)
         .build());
   }
+
+  // 찜 삭제
+  @Transactional
+  public void removeWishlist(Long userId, Long accommodationId) {
+    Wishlist wishlist = wishlistRepository.findByUserIdAndAccommodationId(userId, accommodationId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_WISHLIST));
+
+    wishlistRepository.delete(wishlist);
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
@@ -35,11 +35,9 @@ public class WishlistService {
       throw new MeongnyangerangException(ALREADY_WISHLISTED);
     }
 
-    Wishlist wishlist = Wishlist.builder()
+    wishlistRepository.save(Wishlist.builder()
         .user(user)
         .accommodation(accommodation)
-        .build();
-
-    wishlistRepository.save(wishlist);
+        .build());
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
@@ -1,6 +1,7 @@
 package com.meongnyangerang.meongnyangerang.service;
 
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOMMODATION_NOT_FOUND;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ALREADY_WISHLISTED;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_ACCOUNT;
 
 import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
@@ -89,4 +89,29 @@ class WishlistServiceTest {
     assertEquals(ErrorCode.ALREADY_WISHLISTED.getDescription(), exception.getErrorCode().getDescription());
     verify(wishlistRepository, never()).save(Mockito.any(Wishlist.class));
   }
+
+  @Test
+  @DisplayName("찜 삭제 성공")
+  void removeWishlistSuccess() {
+    // given
+    Long userId = 1L;
+    Long accommodationId = 100L;
+
+    User user = User.builder().id(userId).email("user@example.com").build();
+    Accommodation accommodation = Accommodation.builder().id(accommodationId).name("숙소").build();
+
+    Wishlist wishlist = Wishlist.builder()
+        .id(10L)
+        .user(user)
+        .accommodation(accommodation)
+        .build();
+
+    when(wishlistRepository.findByUserIdAndAccommodationId(userId, accommodationId)).thenReturn(Optional.of(wishlist));
+
+    // when
+    wishlistService.removeWishlist(userId, accommodationId);
+
+    // then
+    verify(wishlistRepository).delete(wishlist);
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
@@ -114,4 +114,23 @@ class WishlistServiceTest {
     // then
     verify(wishlistRepository).delete(wishlist);
   }
+
+  @Test
+  @DisplayName("찜 삭제 실패 - 존재하지 않는 찜")
+  void removeWishlistNotFound() {
+    // given
+    Long userId = 1L;
+    Long accommodationId = 100L;
+
+    when(wishlistRepository.findByUserIdAndAccommodationId(userId, accommodationId)).thenReturn(Optional.empty());
+
+    // when & then
+    MeongnyangerangException exception = assertThrows(
+        MeongnyangerangException.class,
+        () -> wishlistService.removeWishlist(userId, accommodationId)
+    );
+
+    assertEquals(ErrorCode.NOT_EXIST_WISHLIST.getDescription(), exception.getErrorCode().getDescription());
+    verify(wishlistRepository, never()).delete(Mockito.any(Wishlist.class));
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
@@ -1,0 +1,62 @@
+package com.meongnyangerang.meongnyangerang.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
+import com.meongnyangerang.meongnyangerang.domain.user.User;
+import com.meongnyangerang.meongnyangerang.domain.user.Wishlist;
+import com.meongnyangerang.meongnyangerang.repository.UserRepository;
+import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
+import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WishlistServiceTest {
+
+  @InjectMocks
+  private WishlistService wishlistService;
+
+  @Mock
+  private WishlistRepository wishlistRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private AccommodationRepository accommodationRepository;
+
+  @Test
+  @DisplayName("찜 등록 성공")
+  void addWishlistSuccess() {
+    // given
+    Long userId = 1L;
+    Long accommodationId = 100L;
+    User user = User.builder().id(userId).email("user@example.com").build();
+    Accommodation accommodation = Accommodation.builder().id(accommodationId).name("테스트숙소").build();
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(accommodationRepository.findById(100L)).thenReturn(Optional.of(accommodation));
+    when(wishlistRepository.existsByUserIdAndAccommodationId(1L, 100L)).thenReturn(false);
+
+    // when
+    assertDoesNotThrow(() -> wishlistService.addWishlist(1L, 100L));
+
+    // then
+    ArgumentCaptor<Wishlist> captor = ArgumentCaptor.forClass(Wishlist.class);
+    verify(wishlistRepository).save(captor.capture());
+
+    Wishlist saved = captor.getValue();
+    assertEquals(userId, saved.getUser().getId());
+    assertEquals(accommodationId, saved.getAccommodation().getId());
+  }
+}

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
@@ -2,12 +2,17 @@ package com.meongnyangerang.meongnyangerang.service;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.Wishlist;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
+import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
@@ -18,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -58,5 +64,29 @@ class WishlistServiceTest {
     Wishlist saved = captor.getValue();
     assertEquals(userId, saved.getUser().getId());
     assertEquals(accommodationId, saved.getAccommodation().getId());
+  }
+
+  @Test
+  @DisplayName("찜 등록 실패 - 이미 등록된 찜")
+  void addWishlistAlreadyExists() {
+    // given
+    Long userId = 1L;
+    Long accommodationId = 100L;
+
+    User user = User.builder().id(userId).email("user@example.com").build();
+    Accommodation accommodation = Accommodation.builder().id(accommodationId).name("숙소").build();
+
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(accommodationRepository.findById(accommodationId)).thenReturn(Optional.of(accommodation));
+    when(wishlistRepository.existsByUserIdAndAccommodationId(userId, accommodationId)).thenReturn(true);
+
+    // when & then
+    MeongnyangerangException exception = assertThrows(
+        MeongnyangerangException.class,
+        () -> wishlistService.addWishlist(userId, accommodationId)
+    );
+
+    assertEquals(ErrorCode.ALREADY_WISHLISTED.getDescription(), exception.getErrorCode().getDescription());
+    verify(wishlistRepository, never()).save(Mockito.any(Wishlist.class));
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #82 

## 📝 변경 사항
### AS-IS
- 사용자의 숙소 찜 기능이 구현되어 있지 않았음  

### TO-BE
- 사용자가 숙소를 찜하거나 찜을 취소할 수 있는 기능 구현  
- 중복 찜 등록 방지 및 삭제 시 예외처리 로직 추가  
- 관련 서비스 테스트 코드 작성 

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 찜 등록 성공
![image](https://github.com/user-attachments/assets/b3f4ab3c-3039-4c0d-b7e5-567942d470df)
- 찜 등록 실패(이미 찜한 숙소)
![image](https://github.com/user-attachments/assets/1c979795-0111-4e8b-93c0-bdad0dc814ea)
- 찜 삭제 성공
![image](https://github.com/user-attachments/assets/fed4c6f7-7f59-4ed0-9055-b02b411c3e62)
- 찜 삭제 실패(찜 등록이 되지 않은 숙소)
![image](https://github.com/user-attachments/assets/fb0fa462-0dde-400f-be7f-6e2877f8efc2)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- `WishlistService`의 중복 체크 및 예외 처리 부분 리뷰 부탁드립니다.  
- 예외 메시지 및 상태코드 적절한지 검토 부탁드려요 
