### PR TITLE
[Feature] 호스트 - 리뷰 목록 조회 (커서 기반)

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
@@ -2,6 +2,7 @@ package com.meongnyangerang.meongnyangerang.controller;
 
 import com.meongnyangerang.meongnyangerang.dto.AccommodationReviewResponse;
 import com.meongnyangerang.meongnyangerang.dto.CustomReviewResponse;
+import com.meongnyangerang.meongnyangerang.dto.HostReviewResponse;
 import com.meongnyangerang.meongnyangerang.dto.MyReviewResponse;
 import com.meongnyangerang.meongnyangerang.dto.ReviewRequest;
 import com.meongnyangerang.meongnyangerang.dto.UpdateReviewRequest;
@@ -92,5 +93,17 @@ public class ReviewController {
         (newImages != null) ? newImages : Collections.emptyList(), request);
 
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  /**
+   * 호스트의 숙소 리뷰 목록 조회
+   */
+  @GetMapping("/hosts/reviews")
+  public ResponseEntity<HostReviewResponse> getHostReviews(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @RequestParam(required = false) Long cursorId,
+      @RequestParam(defaultValue = "20") @Range(min = 1, max = 100) int size
+  ) {
+    return ResponseEntity.ok(reviewService.getHostReviews(userDetails.getId(), cursorId, size));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/RoomController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/RoomController.java
@@ -50,9 +50,9 @@ public class RoomController {
   public ResponseEntity<RoomListResponse> getRoomList(
       @AuthenticationPrincipal UserDetailsImpl userDetail,
       @RequestParam(required = false) Long cursorId,
-      @RequestParam(defaultValue = "20") @Range(min = 1, max = 100) int pageSize
+      @RequestParam(defaultValue = "20") @Range(min = 1, max = 100) int size
   ) {
-    return ResponseEntity.ok(roomService.getRoomList(userDetail.getId(), cursorId, pageSize));
+    return ResponseEntity.ok(roomService.getRoomList(userDetail.getId(), cursorId, size));
   }
 
   /**

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/reservation/Reservation.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/reservation/Reservation.java
@@ -82,6 +82,10 @@ public class Reservation {
   private LocalDateTime updatedAt;
 
   private LocalDateTime canceledAt;
+
+  public String getRoomName(){
+    return this.getRoom().getName();
+  }
 }
 
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/review/Review.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/review/Review.java
@@ -58,6 +58,8 @@ public class Review {
 
   private Integer reportCount;
 
+  private Boolean isHidden;
+
   @CreatedDate
   @Column(nullable = false, updatable = false)
   private LocalDateTime createdAt;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/HostReviewResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/HostReviewResponse.java
@@ -1,0 +1,14 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import java.util.List;
+
+public record HostReviewResponse(
+    List<ReviewContent> content,
+    Long cursorId,
+    Boolean hasNext
+) {
+
+  public static HostReviewResponse of(List<ReviewContent> content, Long cursorId, Boolean hasNext) {
+    return new HostReviewResponse(content, cursorId, hasNext);
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReviewContent.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReviewContent.java
@@ -1,0 +1,32 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import com.meongnyangerang.meongnyangerang.domain.review.Review;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ReviewContent(
+    Long userId,
+    Long roomId,
+    Long reviewId,
+    String roomName,
+    Double totalRating,
+    String content,
+    List<String> imageUrls,
+    LocalDateTime createdAt
+) {
+
+  public static ReviewContent of(Review review, List<String> imageUrls) {
+    Double totalRating = (review.getUserRating() + review.getPetFriendlyRating()) / 2;
+
+    return new ReviewContent(
+        review.getUser().getId(),
+        review.getReservation().getRoom().getId(),
+        review.getId(),
+        review.getReservation().getRoomName(),
+        totalRating,
+        review.getContent(),
+        imageUrls,
+        review.getCreatedAt()
+    );
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomContent.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomContent.java
@@ -2,7 +2,7 @@ package com.meongnyangerang.meongnyangerang.dto.room;
 
 import com.meongnyangerang.meongnyangerang.domain.room.Room;
 
-public record RoomSummary(
+public record RoomContent(
     Long roomId,
     String name,
     String description,
@@ -14,8 +14,8 @@ public record RoomSummary(
     Integer maxPetCount
 ) {
 
-  public static RoomSummary of(Room room) {
-    return new RoomSummary(
+  public static RoomContent of(Room room) {
+    return new RoomContent(
         room.getId(),
         room.getName(),
         room.getDescription(),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomListResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomListResponse.java
@@ -4,14 +4,14 @@ import com.meongnyangerang.meongnyangerang.domain.room.Room;
 import java.util.List;
 
 public record RoomListResponse(
-    List<RoomSummary> content,
+    List<RoomContent> content,
     Long nextCursor,
     Boolean hasNext
 ) {
 
   public static RoomListResponse of(List<Room> rooms, Long nextCursor, boolean hasNext) {
-    List<RoomSummary> content = rooms.stream()
-        .map(RoomSummary::of)
+    List<RoomContent> content = rooms.stream()
+        .map(RoomContent::of)
         .toList();
 
     return new RoomListResponse(content, nextCursor, hasNext);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewImageProjection.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewImageProjection.java
@@ -1,0 +1,8 @@
+package com.meongnyangerang.meongnyangerang.repository;
+
+public interface ReviewImageProjection {
+
+  Long getReviewId();
+
+  String getImageUrl();
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewImageRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewImageRepository.java
@@ -3,6 +3,8 @@ package com.meongnyangerang.meongnyangerang.repository;
 import com.meongnyangerang.meongnyangerang.domain.review.ReviewImage;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,4 +13,14 @@ public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> 
   ReviewImage findByReviewId(Long reviewId);
 
   List<ReviewImage> findAllByReviewId(Long reviewId);
+
+  /**
+   * 리뷰 ID와 이미지 URL만 조회하는 쿼리
+   */
+  @Query("SELECT " +
+      "ri.review.id as reviewId, " +
+      "ri.imageUrl as imageUrl " +
+      "FROM ReviewImage ri " +
+      "WHERE ri.review.id IN :reviewIds")
+  List<ReviewImageProjection> findByReviewIds(@Param("reviewIds") List<Long> reviewIds);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewRepository.java
@@ -2,6 +2,7 @@ package com.meongnyangerang.meongnyangerang.repository;
 
 import com.meongnyangerang.meongnyangerang.domain.review.Review;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -31,4 +32,18 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
       @Param("accommodationId") Long accommodationId,
       @Param("cursorId") Long cursorId,
       @Param("size") int size);
+
+  @Query("SELECT r FROM Review r " +
+      "JOIN FETCH r.user " +
+      "JOIN FETCH r.reservation " +
+      "JOIN r.reservation res JOIN res.room rm " +
+      "WHERE rm.accommodation.id = :accommodationId " +
+      "AND (:cursorId IS NULL OR r.id < :cursorId) " +
+      "AND r.isHidden = false " +
+      "ORDER BY r.id DESC")
+  List<Review> findByAccommodationIdWithCursor(
+      @Param("accommodationId") Long accommodationId,
+      @Param("cursorId") Long cursorId,
+      Pageable pageable
+  );
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/room/RoomRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/room/RoomRepository.java
@@ -13,8 +13,9 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
 
   @Query("SELECT r FROM Room r " +
       "WHERE r.accommodation.id = :accommodationId " +
-      "AND (:cursorId IS NULL OR r.id < :cursorId) ")
-  List<Room> findRoomsWithCursor(
+      "AND (:cursorId IS NULL OR r.id < :cursorId) " +
+      "ORDER BY r.id DESC")
+  List<Room> findByAccommodationIdWithCursor(
       @Param("accommodationId") Long accommodationId,
       @Param("cursorId") Long cursorId,
       Pageable pageable

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
@@ -60,11 +60,10 @@ public class RoomService {
    */
   public RoomListResponse getRoomList(Long hostId, Long cursorId, int pageSize) {
     Accommodation accommodation = findAccommodationByHostId(hostId);
-    Pageable pageable = PageRequest.of(
-        0, pageSize + 1, Sort.by(Direction.DESC, "id"));
+    Pageable pageable = PageRequest.of(0, pageSize + 1);
     // 다음 페이지 여부를 알기 위해 pageSize + 1
 
-    List<Room> rooms = roomRepository.findRoomsWithCursor(
+    List<Room> rooms = roomRepository.findByAccommodationIdWithCursor(
         accommodation.getId(), cursorId, pageable);
 
     boolean hasNext = rooms.size() > pageSize;

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/RoomServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/RoomServiceTest.java
@@ -340,7 +340,7 @@ class RoomServiceTest {
 
     when(accommodationRepository.findByHostId(host.getId())).thenReturn(
         Optional.of(accommodation));
-    when(roomRepository.findRoomsWithCursor(accommodation.getId(), null, pageable))
+    when(roomRepository.findByAccommodationIdWithCursor(accommodation.getId(), null, pageable))
         .thenReturn(rooms.subList(0, 6)); // 5개 요청 + 1개 추가
 
     // when
@@ -361,7 +361,7 @@ class RoomServiceTest {
 
     when(accommodationRepository.findByHostId(host.getId()))
         .thenReturn(Optional.of(accommodation));
-    when(roomRepository.findRoomsWithCursor(accommodation.getId(), cursorId, pageable))
+    when(roomRepository.findByAccommodationIdWithCursor(accommodation.getId(), cursorId, pageable))
         .thenReturn(rooms.subList(5, 10)); // ID가 6 ~ 10인 객실
 
     // when
@@ -382,7 +382,7 @@ class RoomServiceTest {
 
     when(accommodationRepository.findByHostId(host.getId()))
         .thenReturn(Optional.of(accommodation));
-    when(roomRepository.findRoomsWithCursor(accommodation.getId(), cursorId, pageable))
+    when(roomRepository.findByAccommodationIdWithCursor(accommodation.getId(), cursorId, pageable))
         .thenReturn(new ArrayList<>()); // 빈 결과
 
     // when


### PR DESCRIPTION
## 📌 관련 이슈
- close #84

## 📝 변경 사항
### AS-IS
- 호스트가 본인 숙소의 리뷰 목록 조회 기능 부재

### TO-BE
- 호스트 본인 숙소의 모든 리뷰를 조회 기능 구현
- 숙소 존재하는지 검증
- 커서 기반:
  - 첫 요청 시에는 커서 없이 조회 -> 가장 최근 데이터부터 반환
  - cursorId는 요청받은 pageSIze+ 1번째 데이터의 Id를 사용
    - 예를 들어 pageSize가 20이라면, 서비스 코드에서는 21개를 조회하여 마지막 페이지 여부를 확인, 20번째 데이터의 ID를 cursorId로 반환
  - 이후 조회부터는 cusorId를 받고 cursorId를 기준으로 이후의 데이터만 조회
  - hasNext 필드에 다음 페이지 존재 여부를 담아 반환 (Boolean)
- 가장 최근 데이터가 먼저 반환되도록 정렬
- 가장 최근 데이터부터 반환하기 때문에 cursorId보다 작은 데이터들을 순차적으로 반환

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 첫 요청
![first_request](https://github.com/user-attachments/assets/c09c7997-5973-4204-8624-671381b7087b)

- 이후 요청
![second_request](https://github.com/user-attachments/assets/edbbdb05-adf6-4350-b7af-f6cab8a8fda9)

- 마지막 페이지
![final_request](https://github.com/user-attachments/assets/e7550afd-3138-4e51-aa9a-9ea3ca160ba4)

- 숙소가 존재하지 않을 때
![error_1](https://github.com/user-attachments/assets/c6997d98-86ec-40ac-8cb7-9e4197d27e32)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.