### PR TITLE
[Feature] 사용자 찜 목록 커서 기반 조회 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/WishlistController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/WishlistController.java
@@ -3,13 +3,16 @@ package com.meongnyangerang.meongnyangerang.controller;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.WishlistService;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Range;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -34,4 +37,15 @@ public class WishlistController {
     wishlistService.removeWishlist(userDetails.getId(), accommodationId);
     return ResponseEntity.noContent().build();
   }
+
+  // 찜 조회 API
+  @GetMapping
+  public ResponseEntity<CustomWishlistResponse<WishlistResponse>> getUserWishlist(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @RequestParam(defaultValue = "0") Long cursor,
+      @RequestParam(defaultValue = "20") @Range(min = 1, max = 100) int size) {
+
+    return ResponseEntity.ok(wishlistService.getUserWishlists(userDetails.getId(), cursor, size));
+  }
+
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/WishlistController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/WishlistController.java
@@ -1,5 +1,7 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
+import com.meongnyangerang.meongnyangerang.dto.CustomWishlistResponse;
+import com.meongnyangerang.meongnyangerang.dto.WishlistResponse;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.WishlistService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/CustomWishlistResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/CustomWishlistResponse.java
@@ -1,0 +1,13 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomWishlistResponse<T> {
+  private List<T> content;
+  private Long nextCursor;
+  private boolean hasNext;
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/WishlistResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/WishlistResponse.java
@@ -1,0 +1,19 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class WishlistResponse {
+
+  private Long wishlistId;
+  private Long accommodationId;
+  private String accommodationName;
+  private String thumbnailImageUrl;
+  private String address;
+  private Double petScore;
+  private Double userScore;
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/WishlistResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/WishlistResponse.java
@@ -14,6 +14,5 @@ public class WishlistResponse {
   private String accommodationName;
   private String thumbnailImageUrl;
   private String address;
-  private Double petScore;
-  private Double userScore;
+  private Double totalRating;
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/WishlistRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/WishlistRepository.java
@@ -1,8 +1,11 @@
 package com.meongnyangerang.meongnyangerang.repository;
 
 import com.meongnyangerang.meongnyangerang.domain.user.Wishlist;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -10,4 +13,16 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
   boolean existsByUserIdAndAccommodationId(Long userId, Long accommodationId);
 
   Optional<Wishlist> findByUserIdAndAccommodationId(Long userId, Long accommodationId);
+
+  @Query(value = """
+      SELECT * FROM wishlist w
+      WHERE w.user_id = :userId
+        AND (:cursorId = 0 OR w.id <= :cursorId)
+      ORDER BY w.created_at DESC
+      LIMIT :size
+  """, nativeQuery = true)
+  List<Wishlist> findByUserId(
+      @Param("userId") Long userId,
+      @Param("cursorId") Long cursorId,
+      @Param("size") int size);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
@@ -8,10 +8,16 @@ import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_
 import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.Wishlist;
+import com.meongnyangerang.meongnyangerang.dto.CustomWishlistResponse;
+import com.meongnyangerang.meongnyangerang.dto.WishlistResponse;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,5 +56,35 @@ public class WishlistService {
         .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_WISHLIST));
 
     wishlistRepository.delete(wishlist);
+  }
+
+  // 찜 목록 조회
+  public CustomWishlistResponse<WishlistResponse> getUserWishlists(Long userId, Long cursorId,
+      int size) {
+
+    // size + 1개 조회해서 hasNext 판단
+    List<Wishlist> wishlists = wishlistRepository.findByUserId(userId, cursorId, size + 1);
+
+    boolean hasNext = wishlists.size() > size;
+    Long nextCursor = hasNext ? wishlists.get(size).getId() : null;
+
+    // 현재 페이지 찜 목록만 사용
+    List<WishlistResponse> content = wishlists.stream()
+        .limit(size)
+        .map(wishlist -> {
+          Accommodation accommodation = wishlist.getAccommodation();
+
+          return WishlistResponse.builder()
+              .wishlistId(wishlist.getId())
+              .accommodationId(accommodation.getId())
+              .accommodationName(accommodation.getName())
+              .thumbnailImageUrl(accommodation.getThumbnailUrl())
+              .address(accommodation.getAddress())
+//              .totalRating(accommodation.getTotalRating())   // 추후 숙소 엔티티에 totalRating 필드가 생성되면 수정 예정
+              .build();
+        })
+        .toList();
+
+    return new CustomWishlistResponse<>(content, nextCursor, hasNext);
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
@@ -186,4 +186,42 @@ class WishlistServiceTest {
     assertThat(first.getAccommodationName()).isEqualTo("숙소1");
     assertThat(first.getAddress()).isEqualTo("서울시 강남구");
   }
+
+  @Test
+  @DisplayName("찜 목록 조회 - hasNext 없음")
+  void getUserWishlists_HasNextFalse() {
+    // given
+    Long userId = 1L;
+    Long cursorId = 0L;
+    int size = 2;
+
+    Accommodation acc1 = Accommodation.builder()
+        .id(100L)
+        .name("숙소1")
+        .thumbnailUrl("thumb1.jpg")
+        .address("서울시 강남구")
+        .build();
+
+    Accommodation acc2 = Accommodation.builder()
+        .id(101L)
+        .name("숙소2")
+        .thumbnailUrl("thumb2.jpg")
+        .address("서울시 종로구")
+        .build();
+
+    Wishlist w1 = Wishlist.builder().id(1L).accommodation(acc1).build();
+    Wishlist w2 = Wishlist.builder().id(2L).accommodation(acc2).build();
+
+    List<Wishlist> wishlistMock = List.of(w1, w2); // size == list.size → hasNext false
+
+    when(wishlistRepository.findByUserId(userId, cursorId, size + 1)).thenReturn(wishlistMock);
+
+    // when
+    CustomWishlistResponse<WishlistResponse> result = wishlistService.getUserWishlists(userId, cursorId, size);
+
+    // then
+    assertThat(result.getContent()).hasSize(2);
+    assertThat(result.isHasNext()).isFalse();
+    assertThat(result.getNextCursor()).isNull();
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
@@ -1,9 +1,9 @@
 package com.meongnyangerang.meongnyangerang.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -11,11 +11,14 @@ import static org.mockito.Mockito.when;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.Wishlist;
+import com.meongnyangerang.meongnyangerang.dto.CustomWishlistResponse;
+import com.meongnyangerang.meongnyangerang.dto.WishlistResponse;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -132,5 +135,55 @@ class WishlistServiceTest {
 
     assertEquals(ErrorCode.NOT_EXIST_WISHLIST.getDescription(), exception.getErrorCode().getDescription());
     verify(wishlistRepository, never()).delete(Mockito.any(Wishlist.class));
+  }
+
+  @Test
+  @DisplayName("찜 목록 조회 - hasNext 있음")
+  void getUserWishlists_HasNext() {
+    // given
+    Long userId = 1L;
+    Long cursorId = 0L;
+    int size = 2;
+
+    Accommodation acc1 = Accommodation.builder()
+        .id(100L)
+        .name("숙소1")
+        .thumbnailUrl("thumb1.jpg")
+        .address("서울시 강남구")
+        .build();
+
+    Accommodation acc2 = Accommodation.builder()
+        .id(101L)
+        .name("숙소2")
+        .thumbnailUrl("thumb2.jpg")
+        .address("서울시 종로구")
+        .build();
+
+    Accommodation acc3 = Accommodation.builder()
+        .id(102L)
+        .name("숙소3")
+        .thumbnailUrl("thumb3.jpg")
+        .address("서울시 마포구")
+        .build();
+
+    Wishlist w1 = Wishlist.builder().id(1L).accommodation(acc1).build();
+    Wishlist w2 = Wishlist.builder().id(2L).accommodation(acc2).build();
+    Wishlist w3 = Wishlist.builder().id(3L).accommodation(acc3).build();
+
+    List<Wishlist> wishlistMock = List.of(w1, w2, w3); // size+1 → hasNext true
+
+    when(wishlistRepository.findByUserId(userId, cursorId, size + 1)).thenReturn(wishlistMock);
+
+    // when
+    CustomWishlistResponse<WishlistResponse> result = wishlistService.getUserWishlists(userId, cursorId, size);
+
+    // then
+    assertThat(result.getContent()).hasSize(2);
+    assertThat(result.isHasNext()).isTrue();
+    assertThat(result.getNextCursor()).isEqualTo(3L);
+
+    WishlistResponse first = result.getContent().get(0);
+    assertThat(first.getAccommodationName()).isEqualTo("숙소1");
+    assertThat(first.getAddress()).isEqualTo("서울시 강남구");
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #86 

## 📝 변경 사항
### AS-IS
- 사용자 찜 등록/삭제 기능까지만 구현된 상태
- 사용자가 본인의 찜 목록을 확인할 수 있는 기능이 없었음

### TO-BE
- 사용자가 찜한 숙소 목록을 조회할 수 있도록 API 추가
- 커서 기반 페이징 적용 (cursor + size 방식)
- Wishlist → Accommodation → 응답 DTO로 매핑
- totalRating 필드는 추후 Accommodation 엔티티 확장 후 수정 예정

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 목록 조회 성공(hasNext가 false인 경우)
![image](https://github.com/user-attachments/assets/1164c12d-cff0-46d3-92ee-83913692a6cf)
- 목록 조회 성공(hasNext가 true인 경우)
![image](https://github.com/user-attachments/assets/9c27da67-ecb7-4611-86b9-80cace00ce27)
- 목록 조회 실패(인증되지 않은 사용자)
![image](https://github.com/user-attachments/assets/d4291112-2184-4461-9bed-d2a06df237a2)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- `커서 기반 페이징 방식` 구현 흐름과 `limit + 1` 처리 방식 확인 부탁드립니다.
- totalRating은 현재 accommodation.getTotalRating() 주석 처리 상태입니다. 추후 확장 예정입니다.
