### PR TITLE
[Feature]  공지사항 등록 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
@@ -1,0 +1,33 @@
+package com.meongnyangerang.meongnyangerang.controller;
+
+import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/notices")
+public class NoticeController {
+
+  private final NoticeService noticeService;
+
+  @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<Void> createNotice(
+      @AuthenticationPrincipal UserDetailsImpl adminDetails,
+      @RequestPart("request") @Valid NoticeRequest request,
+      @RequestPart(value = "image", required = false) MultipartFile imageFile) {
+
+    noticeService.createNotice(adminDetails.getId(), request, imageFile);
+    return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
@@ -1,6 +1,8 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
+import com.meongnyangerang.meongnyangerang.dto.NoticeRequest;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
+import com.meongnyangerang.meongnyangerang.service.NoticeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
@@ -20,6 +20,7 @@ public class NoticeController {
 
   private final NoticeService noticeService;
 
+  // 공지사항 등록 API
   @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<Void> createNotice(
       @AuthenticationPrincipal UserDetailsImpl adminDetails,

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/NoticeRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/NoticeRequest.java
@@ -1,0 +1,21 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoticeRequest {
+
+  @NotBlank(message = "제목은 필수입니다.")
+  @Size(max = 100, message = "제목은 최대 100자까지 입력할 수 있습니다.")
+  private String title;
+
+  @NotBlank(message = "내용은 필수입니다.")
+  @Size(max = 5000, message = "내용은 최대 5000자까지 입력할 수 있습니다.")
+  private String content;
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/NoticeRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/NoticeRepository.java
@@ -1,0 +1,11 @@
+package com.meongnyangerang.meongnyangerang.repository;
+
+import com.meongnyangerang.meongnyangerang.domain.admin.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/NoticeService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/NoticeService.java
@@ -7,6 +7,7 @@ import com.meongnyangerang.meongnyangerang.domain.admin.Notice;
 import com.meongnyangerang.meongnyangerang.dto.NoticeRequest;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.AdminRepository;
+import com.meongnyangerang.meongnyangerang.repository.NoticeRepository;
 import com.meongnyangerang.meongnyangerang.service.image.ImageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/NoticeService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/NoticeService.java
@@ -1,0 +1,43 @@
+package com.meongnyangerang.meongnyangerang.service;
+
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_ACCOUNT;
+
+import com.meongnyangerang.meongnyangerang.domain.admin.Admin;
+import com.meongnyangerang.meongnyangerang.domain.admin.Notice;
+import com.meongnyangerang.meongnyangerang.dto.NoticeRequest;
+import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import com.meongnyangerang.meongnyangerang.repository.AdminRepository;
+import com.meongnyangerang.meongnyangerang.service.image.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+
+  private final NoticeRepository noticeRepository;
+  private final AdminRepository adminRepository;
+  private final ImageService imageService;
+
+  // 공지사항 등록
+  @Transactional
+  public void createNotice(Long adminId, NoticeRequest request, MultipartFile imageFile) {
+
+    Admin admin = adminRepository.findById(adminId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
+
+    String imageUrl = null;
+    if (imageFile != null && !imageFile.isEmpty()) {
+      imageUrl = imageService.storeImage(imageFile);
+    }
+
+    noticeRepository.save(Notice.builder()
+        .admin(admin)
+        .title(request.getTitle())
+        .content(request.getContent())
+        .imageUrl(imageUrl)
+        .build());
+  }
+}

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
@@ -1,0 +1,64 @@
+package com.meongnyangerang.meongnyangerang.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.meongnyangerang.meongnyangerang.domain.admin.Admin;
+import com.meongnyangerang.meongnyangerang.domain.admin.Notice;
+import com.meongnyangerang.meongnyangerang.dto.NoticeRequest;
+import com.meongnyangerang.meongnyangerang.repository.AdminRepository;
+import com.meongnyangerang.meongnyangerang.repository.NoticeRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+public class NoticeServiceTest {
+
+  @InjectMocks
+  private NoticeService noticeService;
+
+  @Mock
+  private NoticeRepository noticeRepository;
+
+  @Mock
+  private AdminRepository adminRepository;
+
+  @Test
+  @DisplayName("공지사항 등록 성공 - 이미지 X")
+  void createNoticeWithoutImageSuccess() {
+    // given
+    Long adminId = 1L;
+    Admin admin = Admin.builder()
+        .id(adminId)
+        .email("admin@meongnyang.com")
+        .build();
+
+    NoticeRequest request = new NoticeRequest("제목", "내용");
+    MultipartFile imageFile = null;
+
+    when(adminRepository.findById(adminId)).thenReturn(Optional.of(admin));
+
+    ArgumentCaptor<Notice> captor = ArgumentCaptor.forClass(Notice.class);
+
+    // when
+    noticeService.createNotice(adminId, request, imageFile);
+
+    // then
+    verify(noticeRepository).save(captor.capture());
+    Notice savedNotice = captor.getValue();
+
+    assertEquals("제목", savedNotice.getTitle());
+    assertEquals("내용", savedNotice.getContent());
+    assertEquals(admin, savedNotice.getAdmin());
+    assertNull(savedNotice.getImageUrl());
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #91 

## 📝 변경 사항
### AS-IS
- 공지사항 등록 기능 미구현 상태

### TO-BE
- 관리자 인증을 통해 공지사항 등록 API 구현
- 제목, 내용, 이미지 파일을 포함한 등록 처리

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 공지사항 등록 성공
![image](https://github.com/user-attachments/assets/e66ebfe8-0979-43e5-8cd2-3c63ef3f65ea)
- 공지사항 등록 실패(인증되지 않은 사용자)
![image](https://github.com/user-attachments/assets/20c752e2-fcdf-4326-9111-2838f46573a0)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
