### PR TITLE
[Feature] 호스트 - 숙소 리뷰 삭제 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
@@ -106,4 +106,16 @@ public class ReviewController {
   ) {
     return ResponseEntity.ok(reviewService.getReviewsByHost(userDetails.getId(), cursorId, size));
   }
+
+  /**
+   * 호스트 - 리뷰 삭제
+   */
+  @DeleteMapping("/hosts/reviews/{reviewId}")
+  public ResponseEntity<Void> deleteReviewByHost(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @PathVariable Long reviewId
+  ) {
+    reviewService.deleteReviewByHost(userDetails.getId(), reviewId);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
@@ -96,14 +96,14 @@ public class ReviewController {
   }
 
   /**
-   * 호스트의 숙소 리뷰 목록 조회
+   * 호스트 - 숙소 리뷰 목록 조회
    */
   @GetMapping("/hosts/reviews")
-  public ResponseEntity<HostReviewResponse> getHostReviews(
+  public ResponseEntity<HostReviewResponse> getReviewsByHost(
       @AuthenticationPrincipal UserDetailsImpl userDetails,
       @RequestParam(required = false) Long cursorId,
       @RequestParam(defaultValue = "20") @Range(min = 1, max = 100) int size
   ) {
-    return ResponseEntity.ok(reviewService.getHostReviews(userDetails.getId(), cursorId, size));
+    return ResponseEntity.ok(reviewService.getReviewsByHost(userDetails.getId(), cursorId, size));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewImageRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewImageRepository.java
@@ -1,5 +1,6 @@
 package com.meongnyangerang.meongnyangerang.repository;
 
+import com.meongnyangerang.meongnyangerang.domain.review.Review;
 import com.meongnyangerang.meongnyangerang.domain.review.ReviewImage;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,4 +24,6 @@ public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> 
       "FROM ReviewImage ri " +
       "WHERE ri.review.id IN :reviewIds")
   List<ReviewImageProjection> findByReviewIds(@Param("reviewIds") List<Long> reviewIds);
+
+  void deleteAllByReviewId(Long reviewId);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
@@ -145,9 +145,9 @@ public class ReviewService {
   }
 
   /**
-   * 호스트의 숙소 리뷰 목록 조회
+   * 호스트 - 숙소 리뷰 목록 조회
    */
-  public HostReviewResponse getHostReviews(Long hostId, Long cursorId, int pageSize) {
+  public HostReviewResponse getReviewsByHost(Long hostId, Long cursorId, int pageSize) {
     Accommodation accommodation = findAccommodationByHostId(hostId);
     List<Review> reviews = getReviews(cursorId, pageSize, accommodation);
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
@@ -174,6 +174,20 @@ public class ReviewService {
     return new HostReviewResponse(reviewContents, nextCursorId, hasNext);
   }
 
+  /**
+   * 호스트 - 리뷰 삭제
+   */
+  public void deleteReviewByHost(Long hostId, Long reviewId) {
+    Review review = reviewRepository.findById(reviewId)
+        .orElseThrow(() -> new MeongnyangerangException(ErrorCode.REVIEW_NOT_FOUND));
+
+    if (!hostId.equals(review.getAccommodation().getHost().getId())) {
+      throw new MeongnyangerangException(ErrorCode.INVALID_AUTHORIZED);
+    }
+
+    reviewRepository.delete(review);
+  }
+
   // 최대 이미지 개수(3장)를 초과하는지 검증
   private void validateImageSize(List<MultipartFile> images) {
     if (images.size() > 3) {

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
@@ -185,6 +185,7 @@ public class ReviewService {
       throw new MeongnyangerangException(ErrorCode.INVALID_AUTHORIZED);
     }
 
+    reviewImageRepository.deleteAllByReviewId(review.getId());
     reviewRepository.delete(review);
   }
 

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReviewServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReviewServiceTest.java
@@ -886,7 +886,7 @@ class ReviewServiceTest {
         .thenReturn(reviewImageProjections.subList(0, 3));
 
     // when
-    HostReviewResponse response = reviewService.getHostReviews(host.getId(), cursorId, pageSize);
+    HostReviewResponse response = reviewService.getReviewsByHost(host.getId(), cursorId, pageSize);
 
     // then
     assertThat(response.content()).hasSize(3);
@@ -933,7 +933,7 @@ class ReviewServiceTest {
     when(reviewImageRepository.findByReviewIds(actualReviewIds)).thenReturn(reviewImageProjections);
 
     // when
-    HostReviewResponse response = reviewService.getHostReviews(host.getId(), cursorId, pageSize);
+    HostReviewResponse response = reviewService.getReviewsByHost(host.getId(), cursorId, pageSize);
 
     // then
     assertThat(response.content()).hasSize(5);
@@ -989,7 +989,7 @@ class ReviewServiceTest {
 
     // when
     // then
-    assertThatThrownBy(() -> reviewService.getHostReviews(nonExistentHostId, cursorId, pageSize))
+    assertThatThrownBy(() -> reviewService.getReviewsByHost(nonExistentHostId, cursorId, pageSize))
         .isInstanceOf(MeongnyangerangException.class)
         .hasFieldOrPropertyWithValue("ErrorCode", ErrorCode.ACCOMMODATION_NOT_FOUND);
   }


### PR DESCRIPTION
## 📌 관련 이슈
- close #89

## 📝 변경 사항
### AS-IS
- 호스트 본인 숙소의 리뷰 삭제 기능 부재

### TO-BE
- 호스트 회원이 본인 숙소의 리뷰를 삭제하는 기능 구현

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 성공
![success](https://github.com/user-attachments/assets/7bab2458-0d9f-44ce-851b-fcec5a182cd4)

- 권한 없음
![invalid_authorized](https://github.com/user-attachments/assets/feabcdb0-4dcf-4c46-a1e6-a1be1bd24645)

- 리뷰 없음
![review_not_found](https://github.com/user-attachments/assets/744e02dc-9155-4581-afd4-a2f3cf769ebd)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.