### PR TITLE
[Feature] 공지사항 수정 기능 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,6 +33,18 @@ public class NoticeController {
 
     noticeService.createNotice(adminDetails.getId(), request, imageFile);
     return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
+  // 공지사항 수정 API
+  @PutMapping("/notices/{noticeId}")
+  public ResponseEntity<Void> updateNotice(
+      @AuthenticationPrincipal UserDetailsImpl adminDetails,
+      @PathVariable Long noticeId,
+      @RequestPart("request") @Valid NoticeRequest request,
+      @RequestPart(value = "image", required = false) MultipartFile imageFile
+  ) {
+    noticeService.updateNotice(adminDetails.getId(), noticeId, request, imageFile);
+    return ResponseEntity.ok().build();
   }
 
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
@@ -36,7 +36,7 @@ public class NoticeController {
   }
 
   // 공지사항 수정 API
-  @PutMapping("/notices/{noticeId}")
+  @PutMapping("/{noticeId}")
   public ResponseEntity<Void> updateNotice(
       @AuthenticationPrincipal UserDetailsImpl adminDetails,
       @PathVariable Long noticeId,

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
   REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰가 존재하지 않습니다."),
   NOT_EXIST_PET(HttpStatus.NOT_FOUND, "존재하지 않는 반려동물입니다."),
   NOT_EXIST_WISHLIST(HttpStatus.NOT_FOUND, "존재하지 않는 찜 목록입니다."),
+  NOT_EXIST_NOTICE(HttpStatus.NOT_FOUND, "존재하지 않는 공지사항입니다."),
 
 
   // 409 Conflict

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/NoticeService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/NoticeService.java
@@ -1,6 +1,7 @@
 package com.meongnyangerang.meongnyangerang.service;
 
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_ACCOUNT;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_NOTICE;
 
 import com.meongnyangerang.meongnyangerang.domain.admin.Admin;
 import com.meongnyangerang.meongnyangerang.domain.admin.Notice;
@@ -40,5 +41,28 @@ public class NoticeService {
         .content(request.getContent())
         .imageUrl(imageUrl)
         .build());
+  }
+
+  // 공지사항 수정
+  @Transactional
+  public void updateNotice(Long adminId, Long noticeId, NoticeRequest request, MultipartFile newImage) {
+    Admin admin = adminRepository.findById(adminId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
+
+    Notice notice = noticeRepository.findById(noticeId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_NOTICE));
+
+    // 이미지가 새로 첨부되었을 경우
+    if (newImage != null && !newImage.isEmpty()) {
+      // 기존 이미지가 있다면 삭제 등록
+      if (notice.getImageUrl() != null) {
+        imageService.registerImagesForDeletion(notice.getImageUrl());
+      }
+
+      notice.setImageUrl(imageService.storeImage(newImage));
+    }
+
+    notice.setTitle(request.getTitle());
+    notice.setContent(request.getContent());
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
@@ -207,4 +207,22 @@ public class NoticeServiceTest {
     assertThrows(MeongnyangerangException.class, () ->
         noticeService.updateNotice(adminId, noticeId, request, null));
   }
+
+  @Test
+  @DisplayName("공지사항 수정 실패 - 존재하지 않는 공지사항")
+  void updateNotice_fail_noticeNotFound() {
+    // given
+    Long adminId = 3L;
+    Long noticeId = 300L;
+
+    Admin admin = Admin.builder().id(adminId).email("admin3@example.com").build();
+    NoticeRequest request = new NoticeRequest("제목", "내용");
+
+    given(adminRepository.findById(adminId)).willReturn(Optional.of(admin));
+    given(noticeRepository.findById(noticeId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThrows(MeongnyangerangException.class, () ->
+        noticeService.updateNotice(adminId, noticeId, request, null));
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
@@ -192,4 +192,19 @@ public class NoticeServiceTest {
     verify(imageService).storeImage(newImage);
     verify(imageService, never()).registerImagesForDeletion(anyString()); // 삭제 등록 안 됨
   }
+
+  @Test
+  @DisplayName("공지사항 수정 실패 - 존재하지 않는 관리자")
+  void updateNotice_fail_adminNotFound() {
+    // given
+    Long adminId = 999L;
+    Long noticeId = 1L;
+    NoticeRequest request = new NoticeRequest("제목", "내용");
+
+    given(adminRepository.findById(adminId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThrows(MeongnyangerangException.class, () ->
+        noticeService.updateNotice(adminId, noticeId, request, null));
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #94 

## 📝 변경 사항
### AS-IS
- 공지사항 등록만 가능하고 수정 기능이 없었습니다.

### TO-BE
- 공지사항의 제목, 내용, 이미지(선택)를 수정할 수 있도록 기능 구현
- 이미지가 있을 경우 S3 삭제 큐에 등록 후 새 이미지 업로드
- 예외 케이스 대응: 존재하지 않는 공지사항, 권한 없음, 유효성 실패 등

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 공지사항 수정 성공

![image](https://github.com/user-attachments/assets/f5fb90ab-a472-4e52-a5d1-9d8b07fcdf30)

- 공지사항 수정 실패(인증되지 않은 사용자, 접근권한 X, 존재하지 않는 공지사항)

![image](https://github.com/user-attachments/assets/fd9f8d09-02b3-4336-a206-0324a56b45b8)
![image](https://github.com/user-attachments/assets/528554a5-baa7-48ea-8057-e7e2c0070d16)
![image](https://github.com/user-attachments/assets/1033c08e-f0d8-4a83-a756-9646f42378dd)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 이미지 처리 로직과 예외 처리 흐름 확인 부탁드립니다.
