### PR TITLE
[Feature] 공지사항 삭제 기능 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -41,10 +42,19 @@ public class NoticeController {
       @AuthenticationPrincipal UserDetailsImpl adminDetails,
       @PathVariable Long noticeId,
       @RequestPart("request") @Valid NoticeRequest request,
-      @RequestPart(value = "image", required = false) MultipartFile imageFile
-  ) {
+      @RequestPart(value = "image", required = false) MultipartFile imageFile) {
+
     noticeService.updateNotice(adminDetails.getId(), noticeId, request, imageFile);
     return ResponseEntity.ok().build();
   }
 
+  // 공지사항 삭제 API
+  @DeleteMapping("/{noticeId}")
+  public ResponseEntity<Void> deleteNotice(
+      @AuthenticationPrincipal UserDetailsImpl adminDetails,
+      @PathVariable Long noticeId) {
+
+    noticeService.deleteNotice(adminDetails.getId(), noticeId);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
@@ -45,7 +45,7 @@ public class NoticeController {
       @RequestPart(value = "image", required = false) MultipartFile imageFile) {
 
     noticeService.updateNotice(adminDetails.getId(), noticeId, request, imageFile);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 
   // 공지사항 삭제 API

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/NoticeService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/NoticeService.java
@@ -65,4 +65,21 @@ public class NoticeService {
     notice.setTitle(request.getTitle());
     notice.setContent(request.getContent());
   }
+
+  // 공지사항 삭제
+  @Transactional
+  public void deleteNotice(Long adminId, Long noticeId) {
+    Admin admin = adminRepository.findById(adminId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
+
+    Notice notice = noticeRepository.findById(noticeId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_NOTICE));
+
+    // 이미지 삭제 등록
+    if (notice.getImageUrl() != null) {
+      imageService.registerImagesForDeletion(notice.getImageUrl());
+    }
+
+    noticeRepository.delete(notice);
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
@@ -264,4 +264,21 @@ public class NoticeServiceTest {
     assertEquals(ErrorCode.NOT_EXIST_ACCOUNT, exception.getErrorCode());
     assertEquals("해당 계정은 존재하지 않습니다.", exception.getMessage());
   }
+
+  @Test
+  @DisplayName("공지사항 삭제 실패 - 존재하지 않는 공지사항")
+  void deleteNoticeFailNotExistNotice() {
+    // given
+    Long adminId = 1L;
+    given(adminRepository.findById(adminId)).willReturn(Optional.of(Admin.builder().id(adminId).build()));
+    given(noticeRepository.findById(99L)).willReturn(Optional.empty());
+
+    // when
+    MeongnyangerangException exception = assertThrows(MeongnyangerangException.class,
+        () -> noticeService.deleteNotice(adminId, 99L));
+
+    // then
+    assertEquals(ErrorCode.NOT_EXIST_NOTICE, exception.getErrorCode());
+    assertEquals("존재하지 않는 공지사항입니다.", exception.getMessage());
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
@@ -1,6 +1,7 @@
 package com.meongnyangerang.meongnyangerang.service;
 
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_ACCOUNT;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -224,5 +225,28 @@ public class NoticeServiceTest {
     // when & then
     assertThrows(MeongnyangerangException.class, () ->
         noticeService.updateNotice(adminId, noticeId, request, null));
+  }
+
+  @Test
+  @DisplayName("공지사항 삭제 성공")
+  void deleteNoticeSuccess() {
+    Long adminId = 1L;
+    Long noticeId = 10L;
+    Admin admin = Admin.builder().id(adminId).build();
+    Notice notice = Notice.builder()
+        .id(noticeId)
+        .admin(admin)
+        .imageUrl("https://s3.com/image/notice.jpg")
+        .build();
+
+    given(adminRepository.findById(adminId)).willReturn(Optional.of(admin));
+    given(noticeRepository.findById(noticeId)).willReturn(Optional.of(notice));
+
+    // when
+    assertDoesNotThrow(() -> noticeService.deleteNotice(adminId, noticeId));
+
+    // then
+    verify(imageService).registerImagesForDeletion("https://s3.com/image/notice.jpg");
+    verify(noticeRepository).delete(notice);
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import com.meongnyangerang.meongnyangerang.domain.admin.Admin;
 import com.meongnyangerang.meongnyangerang.domain.admin.Notice;
 import com.meongnyangerang.meongnyangerang.dto.NoticeRequest;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.AdminRepository;
 import com.meongnyangerang.meongnyangerang.repository.NoticeRepository;
@@ -248,5 +249,19 @@ public class NoticeServiceTest {
     // then
     verify(imageService).registerImagesForDeletion("https://s3.com/image/notice.jpg");
     verify(noticeRepository).delete(notice);
+  }
+  @Test
+  @DisplayName("공지사항 삭제 실패 - 존재하지 않는 관리자")
+  void deleteNoticeFailNotExistAdmin() {
+    // given
+    given(adminRepository.findById(1L)).willReturn(Optional.empty());
+
+    // when
+    MeongnyangerangException exception = assertThrows(MeongnyangerangException.class,
+        () -> noticeService.deleteNotice(1L, 10L));
+
+    // then
+    assertEquals(ErrorCode.NOT_EXIST_ACCOUNT, exception.getErrorCode());
+    assertEquals("해당 계정은 존재하지 않습니다.", exception.getMessage());
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #97 

## 📝 변경 사항
### AS-IS
- 공지사항 삭제 기능이 존재하지 않았음

### TO-BE
- 공지사항 삭제 API 및 서비스 구현
- 삭제 시 이미지가 존재하면 삭제 큐에 등록 처리
- 예외 발생 시 적절한 HTTP 응답 코드 반환

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
 - 삭제 성공
 
![image](https://github.com/user-attachments/assets/5f5a51f6-5921-4c3f-aa34-ca1ddc557d48)

- 삭제 실패(존재하지 않는 공지사항, 인증되지 않은 사용자, 접근 권한 X)

![image](https://github.com/user-attachments/assets/0f7e106d-52d3-4db1-9384-641726e2517c)
![image](https://github.com/user-attachments/assets/62affcc3-1493-4f7d-8e6a-e762297d2ebf)
![image](https://github.com/user-attachments/assets/218840f2-edb8-4590-a158-0c70b5094509)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
