### PR TITLE
[Refactor] Controller 상태코드 수정 및 s3 다중 삭제로 변경

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationController.java
@@ -8,7 +8,6 @@ import com.meongnyangerang.meongnyangerang.service.AccommodationService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,7 +37,7 @@ public class AccommodationController {
   ) {
     accommodationService.createAccommodation(
         userDetail.getId(), request, thumbnail, additionalImages);
-    return ResponseEntity.status(HttpStatus.CREATED).build();
+    return ResponseEntity.ok().build();
   }
 
   /**

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
@@ -8,7 +8,6 @@ import com.meongnyangerang.meongnyangerang.service.AdminService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,7 +54,7 @@ public class AdminController {
 
     adminService.approveHost(hostId);
 
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    return ResponseEntity.ok().build();
   }
 
   // 호스트 가입 거절
@@ -64,6 +63,6 @@ public class AdminController {
 
     adminService.rejectHost(hostId);
 
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AuthController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AuthController.java
@@ -6,7 +6,6 @@ import com.meongnyangerang.meongnyangerang.dto.VerifyCodeRequest;
 import com.meongnyangerang.meongnyangerang.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,27 +24,27 @@ public class AuthController {
   @PostMapping("/email/send-code")
   public ResponseEntity<Void> sendVerificationCode(@Valid @RequestBody EmailRequest request) {
     authService.sendVerificationCode(request.getEmail());
-    return ResponseEntity.status(HttpStatus.OK).build();
+    return ResponseEntity.ok().build();
   }
 
   // 인증 코드 검증 API
   @PostMapping("/email/verify-code")
   public ResponseEntity<Void> verifyCode(@Valid @RequestBody VerifyCodeRequest request) {
     authService.verifyCode(request.getEmail(), request.getCode());
-    return ResponseEntity.status(HttpStatus.OK).build();
+    return ResponseEntity.ok().build();
   }
 
   // 이메일 중복 확인 API
   @GetMapping("/email/check")
   public ResponseEntity<Void> checkEmail(@Valid @RequestBody EmailRequest request) {
     authService.checkEmail(request.getEmail());
-    return ResponseEntity.status(HttpStatus.OK).build();
+    return ResponseEntity.ok().build();
   }
 
   // 닉네임 중복 확인 API
   @GetMapping("/nickname/check")
   public ResponseEntity<Void> checkNickname(@Valid @RequestBody NicknameRequest request) {
     authService.checkNickname(request.getNickname());
-    return ResponseEntity.status(HttpStatus.OK).build();
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
@@ -7,7 +7,6 @@ import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.HostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -35,7 +34,7 @@ public class HostController {
       @RequestPart("submitDocument") MultipartFile submitDocumentImage
   ) {
     hostService.registerHost(request, profileImage, businessLicenseImage, submitDocumentImage);
-    return ResponseEntity.status(HttpStatus.CREATED).build();
+    return ResponseEntity.ok().build();
   }
 
   // 호스트 로그인 API
@@ -48,6 +47,6 @@ public class HostController {
   @DeleteMapping("/me")
   public ResponseEntity<Void> deleteHost(@AuthenticationPrincipal UserDetailsImpl userDetails) {
     hostService.deleteHost(userDetails.getId());
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/NoticeController.java
@@ -5,7 +5,6 @@ import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.NoticeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -33,7 +32,7 @@ public class NoticeController {
       @RequestPart(value = "image", required = false) MultipartFile imageFile) {
 
     noticeService.createNotice(adminDetails.getId(), request, imageFile);
-    return ResponseEntity.status(HttpStatus.CREATED).build();
+    return ResponseEntity.ok().build();
   }
 
   // 공지사항 수정 API
@@ -45,7 +44,7 @@ public class NoticeController {
       @RequestPart(value = "image", required = false) MultipartFile imageFile) {
 
     noticeService.updateNotice(adminDetails.getId(), noticeId, request, imageFile);
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.ok().build();
   }
 
   // 공지사항 삭제 API
@@ -55,6 +54,6 @@ public class NoticeController {
       @PathVariable Long noticeId) {
 
     noticeService.deleteNotice(adminDetails.getId(), noticeId);
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReservationController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReservationController.java
@@ -10,7 +10,6 @@ import com.meongnyangerang.meongnyangerang.service.ReservationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,7 +35,7 @@ public class ReservationController {
 
     reservationService.createReservation(userDetails.getId(), reservationRequest);
 
-    return ResponseEntity.status(HttpStatus.CREATED).build();
+    return ResponseEntity.ok().build();
   }
 
   @GetMapping("/users/reservations")
@@ -58,7 +57,7 @@ public class ReservationController {
 
     reservationService.cancelReservation(userDetails.getId(), reservationId);
 
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    return ResponseEntity.ok().build();
   }
 
   @GetMapping("/hosts/reservations")

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
@@ -13,7 +13,6 @@ import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -44,7 +43,7 @@ public class ReviewController {
     reviewService.createReview(userDetails.getId(), reviewRequest,
         (images != null) ? images : Collections.emptyList());
 
-    return ResponseEntity.status(HttpStatus.CREATED).build();
+    return ResponseEntity.ok().build();
   }
 
   // 내 리뷰 조회
@@ -78,7 +77,7 @@ public class ReviewController {
 
     reviewService.deleteReview(reviewId, userDetails.getId());
 
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    return ResponseEntity.ok().build();
   }
 
   // 내 리뷰 수정
@@ -92,7 +91,7 @@ public class ReviewController {
     reviewService.updateReview(userDetails.getId(), reviewId,
         (newImages != null) ? newImages : Collections.emptyList(), request);
 
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    return ResponseEntity.ok().build();
   }
 
   /**

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/RoomController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/RoomController.java
@@ -40,7 +40,7 @@ public class RoomController {
       @RequestPart MultipartFile thumbnail
   ) {
     roomService.createRoom(userDetail.getId(), request, thumbnail);
-    return ResponseEntity.status(HttpStatus.CREATED).build();
+    return ResponseEntity.ok().build();
   }
 
   /**

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserController.java
@@ -7,7 +7,6 @@ import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -33,7 +32,7 @@ public class UserController {
       @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
 
     userService.registerUser(request, profileImage);
-    return ResponseEntity.status(HttpStatus.CREATED).build();
+    return ResponseEntity.ok().build();
   }
 
   // 사용자 로그인 API
@@ -46,6 +45,6 @@ public class UserController {
   @DeleteMapping("/me")
   public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
     userService.deleteUser(userDetails.getId());
-    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserPetController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserPetController.java
@@ -7,7 +7,6 @@ import com.meongnyangerang.meongnyangerang.service.UserPetService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -32,7 +31,7 @@ public class UserPetController {
       @Valid @RequestBody UserPetRequest request) {
 
     userPetService.registerPet(userDetails.getId(), request);
-    return ResponseEntity.status(HttpStatus.CREATED).build();
+    return ResponseEntity.ok().build();
   }
 
   // 사용자 반려동물 수정 API
@@ -48,12 +47,13 @@ public class UserPetController {
   public ResponseEntity<Void> deletePet(@AuthenticationPrincipal UserDetailsImpl userDetails,
       @PathVariable Long petId) {
     userPetService.deletePet(userDetails.getId(), petId);
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.ok().build();
   }
 
   // 사용자 반려동물 조회 API
   @GetMapping
-  public ResponseEntity<List<UserPetResponse>> getPets(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+  public ResponseEntity<List<UserPetResponse>> getPets(
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
     return ResponseEntity.ok(userPetService.getUserPets(userDetails.getId()));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/WishlistController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/WishlistController.java
@@ -6,7 +6,6 @@ import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.WishlistService;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -29,7 +28,7 @@ public class WishlistController {
   public ResponseEntity<Void> addWishlist(@AuthenticationPrincipal UserDetailsImpl userDetails,
       @PathVariable Long accommodationId) {
     wishlistService.addWishlist(userDetails.getId(), accommodationId);
-    return ResponseEntity.status(HttpStatus.CREATED).build();
+    return ResponseEntity.ok().build();
   }
 
   // 찜 삭제 API
@@ -37,7 +36,7 @@ public class WishlistController {
   public ResponseEntity<Void> removeWishlist(@AuthenticationPrincipal UserDetailsImpl userDetails,
       @PathVariable Long accommodationId) {
     wishlistService.removeWishlist(userDetails.getId(), accommodationId);
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.ok().build();
   }
 
   // 찜 조회 API

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
@@ -267,8 +267,9 @@ public class ReviewService {
   // 특정 리뷰에 포함된 모든 이미지 삭제
   private void deleteAllReviewImages(Long reviewId) {
     List<ReviewImage> images = reviewImageRepository.findAllByReviewId(reviewId);
+    List<String> imageUrls = images.stream().map(ReviewImage::getImageUrl).toList();
 
-    images.forEach(image -> imageService.deleteImageAsync(image.getImageUrl()));
+    imageService.deleteImagesAsync(imageUrls);
 
     reviewImageRepository.deleteAll(images);
   }
@@ -286,12 +287,12 @@ public class ReviewService {
 
   // 요청된 이미지 ID 목록을 찾아 삭제 (존재하지 않는 이미지 ID는 무시)
   private void deleteReviewImagesByIds(List<Long> deletedImageIds) {
-    deletedImageIds.forEach(id ->
-        reviewImageRepository.findById(id).ifPresent(image -> {
-          imageService.deleteImageAsync(image.getImageUrl());
-          reviewImageRepository.delete(image);
-        })
-    );
+    List<ReviewImage> images = reviewImageRepository.findAllById(deletedImageIds);
+
+    List<String> imageUrls = images.stream().map(ReviewImage::getImageUrl).toList();
+    imageService.deleteImagesAsync(imageUrls);
+
+    reviewImageRepository.deleteAll(images);
   }
 
   // 리뷰 내용과 평점을 업데이트

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReviewServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReviewServiceTest.java
@@ -688,7 +688,6 @@ class ReviewServiceTest {
 
     when(reviewRepository.findById(review.getId())).thenReturn(Optional.of(review));
     when(reviewImageRepository.findAllByReviewId(review.getId())).thenReturn(images);
-    when(reviewImageRepository.findById(2L)).thenReturn(Optional.of(images.get(1)));
     when(imageService.storeImage(mockImageFile)).thenReturn(newImageUrl);
 
     UpdateReviewRequest request = UpdateReviewRequest.builder()
@@ -710,8 +709,9 @@ class ReviewServiceTest {
     assertEquals("after", review.getContent());
     assertEquals(3.0, review.getPetFriendlyRating());
     assertEquals(4.0, review.getUserRating());
-    verify(reviewImageRepository, times(1)).delete(images.get(1));
-    verify(imageService, times(1)).storeImage(mockImageFile);
+
+    ArgumentCaptor<List<ReviewImage>> captor = ArgumentCaptor.forClass(List.class);
+    verify(reviewImageRepository, times(1)).deleteAll(captor.capture());
   }
 
   @Test


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 기존에는 상태코드로 204, 201 을 사용하였음. 
- 기존 리뷰 수정, 삭제 시 s3에서 단일로 삭제하도록 되어있었음.

### TO-BE
- 상태코드 200으로 통합
- 수정, 삭제 시 List로 url을 담아서 다중 삭제 처리 하도록 설정

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
놓친 부분 있으면 말씀해주세요!