### PR TITLE
[Feature] 채팅방 목록 조회 API - 수정

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ChatController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ChatController.java
@@ -1,7 +1,10 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
+import com.meongnyangerang.meongnyangerang.domain.user.Role;
 import com.meongnyangerang.meongnyangerang.dto.chat.ChatRoomResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
+import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.ChatService;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +33,14 @@ public class ChatController {
       @PageableDefault(size = 20, sort = "updatedAt", direction = Sort.Direction.DESC)
       Pageable pageable
   ) {
-    return ResponseEntity.ok(
-        chatService.getChatRooms(userDetails.getId(), userDetails.getRole(), pageable));
+    Role viewerRole = userDetails.getRole();
+
+    if (viewerRole == Role.ROLE_USER) {
+      return ResponseEntity.ok(chatService.getChatRoomsAsUser(userDetails.getId(), pageable));
+    } else if (viewerRole == Role.ROLE_HOST) {
+      return ResponseEntity.ok(chatService.getChatRoomsAsHost(userDetails.getId(), pageable));
+    } else {
+      throw new MeongnyangerangException(ErrorCode.INVALID_AUTHORIZED);
+    }
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ChatController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ChatController.java
@@ -24,7 +24,7 @@ public class ChatController {
   /**
    * 채팅방 목록 조회
    */
-  @GetMapping("/rooms")
+  @GetMapping
   public ResponseEntity<PageResponse<ChatRoomResponse>> getChatRooms(
       @AuthenticationPrincipal UserDetailsImpl userDetails,
       @PageableDefault(size = 20, sort = "updatedAt", direction = Sort.Direction.DESC)

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/chat/ChatRoom.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/chat/ChatRoom.java
@@ -47,4 +47,8 @@ public class ChatRoom {
   @LastModifiedDate
   @Column(nullable = false)
   private LocalDateTime updatedAt;
+
+  public Long getHostId() {
+    return this.getHost().getId();
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/chat/ChatRoomResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/chat/ChatRoomResponse.java
@@ -8,11 +8,11 @@ import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import java.time.LocalDateTime;
 
 public record ChatRoomResponse(
-    Long chatRoomId,
-    Long viewerId,
+    Long chatroomId,
     Long partnerId,
-    String viewerName,
-    String partnerName,
+    String viewerNickname,
+    String partnerNickname,
+    String partnerProfileImageUrl,
     String lastMessage,
     LocalDateTime lastMessageTime,
     int unreadCount // 현재 보는 사람 기준 읽지 않은 메시지 수
@@ -46,10 +46,10 @@ public record ChatRoomResponse(
   ) {
     return new ChatRoomResponse(
         chatRoom.getId(),
-        chatRoom.getUser().getId(),        // 조회자 ID (사용자)
-        chatRoom.getHost().getId(),        // 상대방 ID (호스트)
-        chatRoom.getUser().getNickname(),  // 조회자 이름 (사용자)
-        chatRoom.getHost().getNickname(),  // 상대방 이름 (호스트)
+        chatRoom.getHost().getId(),              // 상대방 ID (호스트)
+        chatRoom.getUser().getNickname(),        // 조회자 이름 (사용자)
+        chatRoom.getHost().getNickname(),        // 상대방 이름 (호스트)
+        chatRoom.getHost().getProfileImageUrl(), // 상대방의 프로필 사진 URL (호스트)
         lastMessage != null ? lastMessage.getContent() : "",
         lastMessage != null ? lastMessage.getCreatedAt() : null,
         unreadCount
@@ -66,10 +66,10 @@ public record ChatRoomResponse(
   ) {
     return new ChatRoomResponse(
         chatRoom.getId(),
-        chatRoom.getHost().getId(),        // 조회자 ID (호스트)
-        chatRoom.getUser().getId(),        // 상대방 ID (사용자)
-        chatRoom.getHost().getNickname(),  // 조회자 이름 (호스트)
-        chatRoom.getUser().getNickname(),  // 상대방 이름 (사용자)
+        chatRoom.getUser().getId(),           // 상대방 ID (사용자)
+        chatRoom.getHost().getNickname(),     // 조회자 이름 (호스트)
+        chatRoom.getUser().getNickname(),     // 상대방 이름 (사용자)
+        chatRoom.getUser().getProfileImage(), // 상대방의 프로필 사진 URL (호스트)
         lastMessage != null ? lastMessage.getContent() : "",
         lastMessage != null ? lastMessage.getCreatedAt() : null,
         unreadCount

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/chat/ChatRoomResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/chat/ChatRoomResponse.java
@@ -1,77 +1,33 @@
 package com.meongnyangerang.meongnyangerang.dto.chat;
 
-import com.meongnyangerang.meongnyangerang.domain.chat.ChatMessage;
-import com.meongnyangerang.meongnyangerang.domain.chat.ChatRoom;
-import com.meongnyangerang.meongnyangerang.domain.user.Role;
-import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
-import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import java.time.LocalDateTime;
 
 public record ChatRoomResponse(
-    Long chatroomId,
+    Long chatRoomId,
     Long partnerId,
-    String viewerNickname,
-    String partnerNickname,
-    String partnerProfileImageUrl,
+    String partnerName,
+    String partnerImageUrl,
     String lastMessage,
     LocalDateTime lastMessageTime,
-    int unreadCount // 현재 보는 사람 기준 읽지 않은 메시지 수
+    int unreadCount
 ) {
 
-  /**
-   * 역할에 따른 ChatRoomResponse 생성
-   */
-  public static ChatRoomResponse of(
-      ChatRoom chatRoom,
-      ChatMessage lastMessage,
-      int unreadCount,
-      Role viewerRole
-  ) {
-    if (viewerRole == Role.ROLE_USER) {
-      return createUserViewResponse(chatRoom, lastMessage, unreadCount);
-    } else if (viewerRole == Role.ROLE_HOST) {
-      return createHostViewResponse(chatRoom, lastMessage, unreadCount);
-    } else {
-      throw new MeongnyangerangException(ErrorCode.INVALID_AUTHORIZED);
-    }
-  }
-
-  /**
-   * 사용자 관점의 응답 생성
-   */
-  private static ChatRoomResponse createUserViewResponse(
-      ChatRoom chatRoom,
-      ChatMessage lastMessage,
+  public static ChatRoomResponse createChatRoomResponse(
+      Long chatRoomId,
+      Long partnerId,
+      String partnerName,
+      String partnerImageUrl,
+      String lastMessage,
+      LocalDateTime lastMessageTime,
       int unreadCount
   ) {
     return new ChatRoomResponse(
-        chatRoom.getId(),
-        chatRoom.getHost().getId(),              // 상대방 ID (호스트)
-        chatRoom.getUser().getNickname(),        // 조회자 이름 (사용자)
-        chatRoom.getHost().getNickname(),        // 상대방 이름 (호스트)
-        chatRoom.getHost().getProfileImageUrl(), // 상대방의 프로필 사진 URL (호스트)
-        lastMessage != null ? lastMessage.getContent() : "",
-        lastMessage != null ? lastMessage.getCreatedAt() : null,
-        unreadCount
-    );
-  }
-
-  /**
-   * 호스트 관점의 응답 생성
-   */
-  private static ChatRoomResponse createHostViewResponse(
-      ChatRoom chatRoom,
-      ChatMessage lastMessage,
-      int unreadCount
-  ) {
-    return new ChatRoomResponse(
-        chatRoom.getId(),
-        chatRoom.getUser().getId(),           // 상대방 ID (사용자)
-        chatRoom.getHost().getNickname(),     // 조회자 이름 (호스트)
-        chatRoom.getUser().getNickname(),     // 상대방 이름 (사용자)
-        chatRoom.getUser().getProfileImage(), // 상대방의 프로필 사진 URL (호스트)
-        lastMessage != null ? lastMessage.getContent() : "",
-        lastMessage != null ? lastMessage.getCreatedAt() : null,
+        chatRoomId,
+        partnerId,       // 상대방 ID
+        partnerName,     // 상대방 이름 (호스트는 숙소 이름)
+        partnerImageUrl, // 상대방 프로필 이미지 (호스트는 숙소 썸네일)
+        lastMessage != null ? lastMessage : "",
+        lastMessageTime,
         unreadCount
     );
   }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/chat/ChatRoomRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/chat/ChatRoomRepository.java
@@ -4,17 +4,14 @@ import com.meongnyangerang.meongnyangerang.domain.chat.ChatRoom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
   // 사용자 ID로 채팅방 목록 조회
-  Page<ChatRoom> findAllByUserIdOrderByUpdatedAtDesc(
-      @Param("userId") Long userId, Pageable pageable);
+  Page<ChatRoom> findAllByUser_IdOrderByUpdatedAtDesc(Long userId, Pageable pageable);
 
   // 호스트 ID로 채팅방 목록 조회
-  Page<ChatRoom> findAllByHostIdOrderByUpdatedAtDesc(
-      @Param("hostId") Long hostId, Pageable pageable);
+  Page<ChatRoom> findAllByHost_IdOrderByUpdatedAtDesc(Long hostId, Pageable pageable);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ChatService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ChatService.java
@@ -40,15 +40,18 @@ public class ChatService {
       Pageable pageable
   ) {
     Page<ChatRoom> chatRooms = findChatRoomsByViewer(viewerId, viewerRole, pageable);
-
-    Page<ChatRoomResponse> response = chatRooms.map(chatRoom -> {
-      ChatMessage lastMessage = chatMessageRepository.findTopByChatRoomIdOrderByCreatedAtDesc(
-          chatRoom.getId()); // 마지막 메시지 정보
-      int unreadCount = calculateUnreadCount(chatRoom, viewerRole); // 읽지 않은 메시지 수
-      return ChatRoomResponse.of(chatRoom, lastMessage, unreadCount, viewerRole);
-    });
+    Page<ChatRoomResponse> response = chatRooms.map(
+        chatRoom -> createChatRoomResponse(viewerRole, chatRoom));
 
     return PageResponse.from(response);
+  }
+
+  private ChatRoomResponse createChatRoomResponse(Role viewerRole, ChatRoom chatRoom) {
+    ChatMessage lastMessage = chatMessageRepository.findTopByChatRoomIdOrderByCreatedAtDesc(
+        chatRoom.getId()); // 마지막 메시지 정보
+    int unreadCount = calculateUnreadCount(chatRoom, viewerRole); // 읽지 않은 메시지 수
+
+    return ChatRoomResponse.of(chatRoom, lastMessage, unreadCount, viewerRole);
   }
 
   /**

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ChatService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ChatService.java
@@ -1,14 +1,16 @@
 package com.meongnyangerang.meongnyangerang.service;
 
+import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
 import com.meongnyangerang.meongnyangerang.domain.chat.ChatMessage;
 import com.meongnyangerang.meongnyangerang.domain.chat.ChatReadStatus;
 import com.meongnyangerang.meongnyangerang.domain.chat.ChatRoom;
 import com.meongnyangerang.meongnyangerang.domain.chat.SenderType;
-import com.meongnyangerang.meongnyangerang.domain.user.Role;
+import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.dto.chat.ChatRoomResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
 import com.meongnyangerang.meongnyangerang.repository.chat.ChatMessageRepository;
 import com.meongnyangerang.meongnyangerang.repository.chat.ChatReadStatusRepository;
 import com.meongnyangerang.meongnyangerang.repository.chat.ChatRoomRepository;
@@ -27,68 +29,74 @@ public class ChatService {
   private final ChatRoomRepository chatRoomRepository;
   private final ChatReadStatusRepository chatReadStatusRepository;
   private final ChatMessageRepository chatMessageRepository;
+  private final AccommodationRepository accommodationRepository;
 
   private static final LocalDateTime DEFAULT_LAST_READ_TIME =
       LocalDateTime.of(2000, 1, 1, 0, 0);
 
   /**
-   * 채팅방 목록 조회
+   * 일반회원이 채팅방 목록 조회
    */
-  public PageResponse<ChatRoomResponse> getChatRooms(
-      Long viewerId,
-      Role viewerRole,
-      Pageable pageable
-  ) {
-    Page<ChatRoom> chatRooms = findChatRoomsByViewer(viewerId, viewerRole, pageable);
-    Page<ChatRoomResponse> response = chatRooms.map(
-        chatRoom -> createChatRoomResponse(viewerRole, chatRoom));
+  public PageResponse<ChatRoomResponse> getChatRoomsAsUser(Long userId, Pageable pageable) {
+    log.info("일반회원 채팅방 목록 조회");
+    
+    Page<ChatRoom> chatRooms = chatRoomRepository.findAllByUser_IdOrderByUpdatedAtDesc(
+        userId, pageable);
+    Page<ChatRoomResponse> response = chatRooms.map(this::createChatRoomResponseAsUser);
 
     return PageResponse.from(response);
   }
 
-  private ChatRoomResponse createChatRoomResponse(Role viewerRole, ChatRoom chatRoom) {
+  /**
+   * 호스트가 채팅방 목록 조회
+   */
+  public PageResponse<ChatRoomResponse> getChatRoomsAsHost(Long hostId, Pageable pageable) {
+    log.info("호스트 채팅방 목록 조회");
+
+    Page<ChatRoom> chatRooms = chatRoomRepository.findAllByHost_IdOrderByUpdatedAtDesc(
+        hostId, pageable);
+
+    Page<ChatRoomResponse> response = chatRooms.map(this::createChatRoomResponseAsHost);
+
+    return PageResponse.from(response);
+  }
+
+  private ChatRoomResponse createChatRoomResponseAsUser(ChatRoom chatRoom) {
+    Accommodation accommodation = accommodationRepository.findByHostId(chatRoom.getHostId())
+        .orElseThrow(() -> new MeongnyangerangException(ErrorCode.ACCOMMODATION_NOT_FOUND));
+
     ChatMessage lastMessage = chatMessageRepository.findTopByChatRoomIdOrderByCreatedAtDesc(
         chatRoom.getId()); // 마지막 메시지 정보
-    int unreadCount = calculateUnreadCount(chatRoom, viewerRole); // 읽지 않은 메시지 수
 
-    return ChatRoomResponse.of(chatRoom, lastMessage, unreadCount, viewerRole);
+    int unreadCount = countUnreadMessagesForUser(chatRoom); // 읽지 않은 메시지 수
+
+    return ChatRoomResponse.createChatRoomResponse(
+        chatRoom.getId(),
+        chatRoom.getHostId(),
+        accommodation.getName(),
+        accommodation.getThumbnailUrl(),
+        lastMessage.getContent(),
+        lastMessage.getCreatedAt(),
+        unreadCount
+    );
   }
 
-  /**
-   * 참여자 역할에 따른 채팅방 목록 조회
-   */
-  private Page<ChatRoom> findChatRoomsByViewer(Long viewerId, Role viewerRole, Pageable pageable) {
-    if (viewerRole == Role.ROLE_USER) {
-      return chatRoomRepository.findAllByUserIdOrderByUpdatedAtDesc(viewerId, pageable);
-    } else if (viewerRole == Role.ROLE_HOST) {
-      return chatRoomRepository.findAllByHostIdOrderByUpdatedAtDesc(viewerId, pageable);
-    } else {
-      throw new MeongnyangerangException(ErrorCode.INVALID_AUTHORIZED);
-    }
-  }
+  private ChatRoomResponse createChatRoomResponseAsHost(ChatRoom chatRoom) {
+    ChatMessage lastMessage = chatMessageRepository.findTopByChatRoomIdOrderByCreatedAtDesc(
+        chatRoom.getId()); // 마지막 메시지 정보
 
-  private LocalDateTime getLastReadTime(
-      Long roomId,
-      Long participantId,
-      SenderType viewerType
-  ) {
-    return chatReadStatusRepository
-        .findByChatRoomIdAndParticipantIdAndParticipantType(roomId, participantId, viewerType)
-        .map(ChatReadStatus::getLastReadTime)
-        .orElse(DEFAULT_LAST_READ_TIME);
-  }
+    User user = chatRoom.getUser();
+    int unreadCount = countUnreadMessagesForHost(chatRoom); // 읽지 않은 메시지 수
 
-  /**
-   * 읽지 않은 메시지 수 계산
-   */
-  private int calculateUnreadCount(ChatRoom chatRoom, Role viewerRole) {
-    if (viewerRole == Role.ROLE_USER) {
-      return countUnreadMessagesForUser(chatRoom);
-    } else if (viewerRole == Role.ROLE_HOST) {
-      return countUnreadMessagesForHost(chatRoom);
-    } else {
-      throw new MeongnyangerangException(ErrorCode.INVALID_AUTHORIZED);
-    }
+    return ChatRoomResponse.createChatRoomResponse(
+        chatRoom.getId(),
+        user.getId(),
+        user.getNickname(),
+        user.getProfileImage(),
+        lastMessage.getContent(),
+        lastMessage.getCreatedAt(),
+        unreadCount
+    );
   }
 
   /**
@@ -99,7 +107,7 @@ public class ChatService {
 
     return chatMessageRepository.countUnreadMessages(
         chatRoom.getId(),
-        SenderType.HOST,  // 호스트가 보낸 메시지 중에서
+        SenderType.HOST, // 호스트가 보낸 메시지 중에서
         getLastReadTime(chatRoom.getId(), userId, SenderType.USER)
     );
   }
@@ -112,8 +120,19 @@ public class ChatService {
 
     return chatMessageRepository.countUnreadMessages(
         chatRoom.getId(),
-        SenderType.USER,  // 사용자가 보낸 메시지 중에서
+        SenderType.USER, // 사용자가 보낸 메시지 중에서
         getLastReadTime(chatRoom.getId(), hostId, SenderType.HOST)
     );
+  }
+
+  private LocalDateTime getLastReadTime(
+      Long chatRoomId,
+      Long viewerId,
+      SenderType viewerType
+  ) {
+    return chatReadStatusRepository
+        .findByChatRoomIdAndParticipantIdAndParticipantType(chatRoomId, viewerId, viewerType)
+        .map(ChatReadStatus::getLastReadTime)
+        .orElse(DEFAULT_LAST_READ_TIME);
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ChatServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ChatServiceTest.java
@@ -165,13 +165,13 @@ class ChatServiceTest {
 
     // 첫 번째 채팅방 검증
     ChatRoomResponse response1 = responses.content().get(0);
-    assertThat(response1.chatRoomId()).isEqualTo(chatRoomId1);
+    assertThat(response1.chatroomId()).isEqualTo(chatRoomId1);
     assertThat(response1.lastMessage()).isEqualTo("안녕하세요.");
     assertThat(response1.unreadCount()).isEqualTo(2);
 
     // 두 번째 채팅방 검증
     ChatRoomResponse response2 = responses.content().get(1);
-    assertThat(response2.chatRoomId()).isEqualTo(chatRoomId2);
+    assertThat(response2.chatroomId()).isEqualTo(chatRoomId2);
     assertThat(response2.lastMessage()).isEqualTo("문의 드립니다.");
     assertThat(response2.unreadCount()).isEqualTo(0);
 
@@ -227,13 +227,13 @@ class ChatServiceTest {
 
     // 첫 번째 채팅방 검증
     ChatRoomResponse response1 = responses.content().get(0);
-    assertThat(response1.chatRoomId()).isEqualTo(chatRoomId1);
+    assertThat(response1.chatroomId()).isEqualTo(chatRoomId1);
     assertThat(response1.lastMessage()).isEqualTo("안녕하세요.");
     assertThat(response1.unreadCount()).isEqualTo(0);
 
     // 두 번째 채팅방 검증
     ChatRoomResponse response2 = responses.content().get(1);
-    assertThat(response2.chatRoomId()).isEqualTo(chatRoomId2);
+    assertThat(response2.chatroomId()).isEqualTo(chatRoomId2);
     assertThat(response2.lastMessage()).isEqualTo("문의 드립니다.");
     assertThat(response2.unreadCount()).isEqualTo(3);
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #104 

## 📝 변경 사항
### AS-IS
- 메서드마다 일반회원과 호스트회원을 구분하여 분기

### TO-BE
- 컨트롤러에서 일반회원과 호스트회원을 구분하여 분기
- 일반회원이 API 호출 시, 상대방의 이름과 프로필 사진은 숙소명과 숙소의 썸네일이 반환되도록 수정

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 성공
![캡처](https://github.com/user-attachments/assets/a944c430-bcd3-4cc7-8761-d8f0c763cc43)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.