### PR TITLE
[Feature] 비로그인 사용자 숙소 추천 API 구현 및 테스트 완료

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
@@ -44,7 +44,8 @@ public class SecurityConfig {
                 "/api/v1/users/login",
                 "/api/v1/hosts/login",
                 "/api/v1/admin/login",
-                "/api/v1/accommodations/{accommodationId}/reviews"
+                "/api/v1/accommodations/{accommodationId}/reviews",
+                "/api/v1/recommendations/default"
             ).permitAll()
             .requestMatchers("/api/v1/users/**").hasAuthority("ROLE_USER")
             .requestMatchers("/api/v1/hosts/**").hasAuthority("ROLE_HOST")

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationRecommendationController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationRecommendationController.java
@@ -1,6 +1,6 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
-import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationDocument;
+import com.meongnyangerang.meongnyangerang.dto.accommodation.DefaultRecommendationResponse;
 import com.meongnyangerang.meongnyangerang.service.AccommodationRecommendationService;
 import java.util.List;
 import java.util.Map;
@@ -19,7 +19,7 @@ public class AccommodationRecommendationController {
 
   // 비로그인 사용자 기본 추천
   @GetMapping("/default")
-  public ResponseEntity<Map<String, List<AccommodationDocument>>> getDefaultRecommendations() {
+  public ResponseEntity<Map<String, List<DefaultRecommendationResponse>>> getDefaultRecommendations() {
 
     return ResponseEntity.ok(recommendationService.getDefaultRecommendations());
   }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationRecommendationController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationRecommendationController.java
@@ -1,0 +1,26 @@
+package com.meongnyangerang.meongnyangerang.controller;
+
+import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationDocument;
+import com.meongnyangerang.meongnyangerang.service.AccommodationRecommendationService;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/recommendations")
+public class AccommodationRecommendationController {
+
+  private final AccommodationRecommendationService recommendationService;
+
+  // 비로그인 사용자 기본 추천
+  @GetMapping("/default")
+  public ResponseEntity<Map<String, List<AccommodationDocument>>> getDefaultRecommendations() {
+
+    return ResponseEntity.ok(recommendationService.getDefaultRecommendations());
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/accommodation/AccommodationDocument.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/accommodation/AccommodationDocument.java
@@ -1,0 +1,26 @@
+package com.meongnyangerang.meongnyangerang.domain.accommodation;
+
+import java.util.Set;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AccommodationDocument {
+
+  private Long id;
+
+  private String name;
+
+  private String thumbnailUrl;
+
+  private Long price;
+
+  private Double totalRating;
+
+  private Set<String> accommodationPetFacilities;
+
+  private Set<String> roomPetFacilities;
+
+  private Set<String> allowedPetTypes;
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/accommodation/facility/AccommodationPetFacilityType.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/accommodation/facility/AccommodationPetFacilityType.java
@@ -8,14 +8,13 @@ import lombok.RequiredArgsConstructor;
 public enum AccommodationPetFacilityType {
 
   EXERCISE_AREA("대형 운동장"),
-  EXCLUSIVE_YARD("전용 마당"),
   PLAYGROUND("놀이터"),
   SHOWER_ROOM("샤워장"),
   SWIMMING_POOL("수영장"),
-  ANTI_SLIP_FLOOR("미끄럼 방지 바닥"),
   FENCE_AREA("펜스 설치 공간"),
   CARE_SERVICE("돌봄 서비스"),
   PET_FOOD("펫 푸드 제공"),
+  DRY_ROOM("드라이룸"),
   NEARBY_HOSPITAL("인근 동물병원");
 
   private final String value;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/room/facility/RoomPetFacilityType.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/room/facility/RoomPetFacilityType.java
@@ -8,15 +8,15 @@ import lombok.RequiredArgsConstructor;
 public enum RoomPetFacilityType {
 
   FOOD_BOWL("식기"),
+  EXCLUSIVE_YARD("전용 마당"),
   POTTY_SUPPLIES("배변용품"),
   TOY("장난감"),
   BED("침대"),
-  DRY_ROOM("드라이룸"),
   ANTI_SLIP_FLOOR("미끄럼 방지 바닥"),
   FENCE_AREA("펜스 설치 공간"),
   CAT_TOWER("캣타워"),
   CAT_WHEEL("캣휠"),
-  COMB("빗"),
+  BRUSH("브러쉬"),
   PET_STEPS("강아지 계단");
 
   private final String value;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/DefaultRecommendationResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/DefaultRecommendationResponse.java
@@ -1,18 +1,25 @@
 package com.meongnyangerang.meongnyangerang.dto.accommodation;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class DefaultRecommendationResponse {
 
   private Long id;
 
-  private String accommodationName;
+  private String name;
 
   private Long price;
 
   private Double totalRating;
+
+  private String thumbnailUrl;
 
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/DefaultRecommendationResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/DefaultRecommendationResponse.java
@@ -1,0 +1,18 @@
+package com.meongnyangerang.meongnyangerang.dto.accommodation;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DefaultRecommendationResponse {
+
+  private Long id;
+
+  private String accommodationName;
+
+  private Long price;
+
+  private Double totalRating;
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -78,6 +78,7 @@ public enum ErrorCode {
   ACCOMMODATION_REGISTRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "숙소 등록 오류"),
   ACCOMMODATION_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "숙소 수정 오류"),
   ROOM_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "객실 수정 오류"),
+  DEFAULT_RECOMMENDATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "기본 추천 조회 중 오류가 발생했습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
@@ -73,7 +73,7 @@ public class AccommodationRecommendationService {
           .map(Hit::source)
           .collect(Collectors.toList());
     } catch (IOException e) {
-      throw new MeongnyangerangException(ErrorCode.INTERNAL_SERVER_ERROR);
+      throw new MeongnyangerangException(ErrorCode.DEFAULT_RECOMMENDATION_FAILED);
     }
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
@@ -60,6 +60,8 @@ public class AccommodationRecommendationService {
                   .order(SortOrder.Desc)
               )
           )
+          .source(src -> src.filter(
+              f -> f.includes("id", "name", "price", "totalRating", "thumbnailUrl")))
           .size(SIZE)
       );
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
@@ -7,8 +7,8 @@ import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
-import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationDocument;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.PetType;
+import com.meongnyangerang.meongnyangerang.dto.accommodation.DefaultRecommendationResponse;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import java.io.IOException;
@@ -29,12 +29,12 @@ public class AccommodationRecommendationService {
   private static final int SIZE = 6;
 
   // 비로그인 사용자 기본 추천
-  public Map<String, List<AccommodationDocument>> getDefaultRecommendations() {
-    Map<String, List<AccommodationDocument>> result = new HashMap<>();
+  public Map<String, List<DefaultRecommendationResponse>> getDefaultRecommendations() {
+    Map<String, List<DefaultRecommendationResponse>> result = new HashMap<>();
 
     // 각 petType 별로 인기 숙소 검색하여 결과에 추가
     for (PetType petType : PetType.values()) {
-      List<AccommodationDocument> docs = searchByPetType(petType.name());
+      List<DefaultRecommendationResponse> docs = searchByPetType(petType.name());
       result.put(petType.name(), docs);
     }
 
@@ -43,7 +43,7 @@ public class AccommodationRecommendationService {
 
 
   // 반려동물 타입에 대한 숙소 검색. totalRating 내림차순으로 정렬하여 최대 SIZE 만큼 가져옴
-  private List<AccommodationDocument> searchByPetType(String petType) {
+  private List<DefaultRecommendationResponse> searchByPetType(String petType) {
     try {
       // 쿼리 설정 (검색 조건) - allowedPetTypes 필드에 petType 과 정확히 일치하는 문서 검색
       Query petTypeQuery = TermQuery.of(t -> t
@@ -63,11 +63,11 @@ public class AccommodationRecommendationService {
           .size(SIZE)
       );
 
-      // Elasticsearch 에 요청 전송 후, 응답의 _source 부분을 AccommodationDocument 객체로 자동 매핑하여 받음
-      SearchResponse<AccommodationDocument> response =
-          elasticsearchClient.search(request, AccommodationDocument.class);
+      // Elasticsearch 에 요청 전송 후, 응답의 _source 부분을 DefaultRecommendationResponse 로 자동 매핑하여 받음
+      SearchResponse<DefaultRecommendationResponse> response =
+          elasticsearchClient.search(request, DefaultRecommendationResponse.class);
 
-      // 검색 응답(Hits)에서 AccommodationDocument 객체만 추출하여 리스트로 정리
+      // 검색 응답(Hits)에서 DefaultRecommendationResponse 만 추출하여 리스트로 정리
       return response.hits().hits()
           .stream()
           .map(Hit::source)

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
@@ -1,0 +1,79 @@
+package com.meongnyangerang.meongnyangerang.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationDocument;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.PetType;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
+import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccommodationRecommendationService {
+
+  private final ElasticsearchClient elasticsearchClient;
+
+  private static final String INDEX_NAME = "accommodations";
+  private static final int SIZE = 6;
+
+  // 비로그인 사용자 기본 추천
+  public Map<String, List<AccommodationDocument>> getDefaultRecommendations() {
+    Map<String, List<AccommodationDocument>> result = new HashMap<>();
+
+    // 각 petType 별로 인기 숙소 검색하여 결과에 추가
+    for (PetType petType : PetType.values()) {
+      List<AccommodationDocument> docs = searchByPetType(petType.name());
+      result.put(petType.name(), docs);
+    }
+
+    return result;
+  }
+
+
+  // 반려동물 타입에 대한 숙소 검색. totalRating 내림차순으로 정렬하여 최대 SIZE 만큼 가져옴
+  private List<AccommodationDocument> searchByPetType(String petType) {
+    try {
+      // 쿼리 설정 (검색 조건) - allowedPetTypes 필드에 petType 과 정확히 일치하는 문서 검색
+      Query petTypeQuery = TermQuery.of(t -> t
+          .field("allowedPetTypes")
+          .value(petType)
+      )._toQuery();
+
+      // 검색 요청 생성 (전체 쿼리) - 인덱스에서 조건에 맞는 문서를 totalRating 내림차순으로 최대 SIZE개 조회
+      SearchRequest request = SearchRequest.of(s -> s.index(INDEX_NAME)
+          .query(petTypeQuery)
+          .sort(sort -> sort
+              .field(f -> f
+                  .field("totalRating")
+                  .order(SortOrder.Desc)
+              )
+          )
+          .size(SIZE)
+      );
+
+      // Elasticsearch 에 요청 전송 후, 응답의 _source 부분을 AccommodationDocument 객체로 자동 매핑하여 받음
+      SearchResponse<AccommodationDocument> response =
+          elasticsearchClient.search(request, AccommodationDocument.class);
+
+      // 검색 응답(Hits)에서 AccommodationDocument 객체만 추출하여 리스트로 정리
+      return response.hits().hits()
+          .stream()
+          .map(Hit::source)
+          .collect(Collectors.toList());
+    } catch (IOException e) {
+      throw new MeongnyangerangException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,5 +31,8 @@ spring:
           starttls:
             enable: true
 
+  elasticsearch:
+    uris: ${ELASTICSEARCH_URI}
+
   jwt:
     secret: ${JWT_SECRET}

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationServiceTest.java
@@ -1,0 +1,128 @@
+package com.meongnyangerang.meongnyangerang.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationDocument;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AccommodationRecommendationServiceTest {
+
+  @Mock
+  private ElasticsearchClient elasticsearchClient;
+
+  @InjectMocks
+  private AccommodationRecommendationService recommendationService;
+
+  @Test
+  @DisplayName("비로그인 사용자 기본 추천 - 성공")
+  void getDefaultRecommendations_success() throws IOException {
+    // given - 테스트용 문서 준비
+    AccommodationDocument doc1 = AccommodationDocument.builder()
+        .id(1L)
+        .name("test1 숙소")
+        .thumbnailUrl("http://example.com/image1.jpg")
+        .price(70000L)
+        .totalRating(4.5)
+        .allowedPetTypes(Set.of("SMALL_DOG", "LARGE_DOG"))
+        .build();
+
+    AccommodationDocument doc2 = AccommodationDocument.builder()
+        .id(2L)
+        .name("test2 숙소")
+        .thumbnailUrl("http://example.com/image2.jpg")
+        .price(80000L)
+        .totalRating(4.7)
+        .allowedPetTypes(Set.of("LARGE_DOG", "MEDIUM_DOG"))
+        .build();
+
+    AccommodationDocument doc3 = AccommodationDocument.builder()
+        .id(3L)
+        .name("test3 숙소")
+        .thumbnailUrl("http://example.com/image3.jpg")
+        .price(75000L)
+        .totalRating(3.5)
+        .allowedPetTypes(Set.of("CAT"))
+        .build();
+
+    List<AccommodationDocument> allDocs = List.of(doc1, doc2, doc3);
+
+    when(elasticsearchClient.search(any(SearchRequest.class), eq(AccommodationDocument.class)))
+        .thenAnswer(invocation -> {
+          // SearchRequest 를 꺼냄
+          SearchRequest request = invocation.getArgument(0);
+          // petType 추출
+          String petType = request.query().term().value().stringValue();
+
+          // allowedPetTypes 에 petType 포함된 문서만 추출 (totalRating 내림차순 정렬)
+          List<AccommodationDocument> filtered = allDocs.stream()
+              .filter(doc -> doc.getAllowedPetTypes().contains(petType))
+              .sorted(Comparator.comparingDouble(AccommodationDocument::getTotalRating).reversed())
+              .toList();
+
+          return mockSearchResponse(filtered);
+        });
+
+    // when
+    Map<String, List<AccommodationDocument>> result = recommendationService.getDefaultRecommendations();
+
+    // then
+    // 결과에 각 petType이 key로 들어 있는지 확인
+    assertTrue(result.containsKey("SMALL_DOG"));
+    assertTrue(result.containsKey("LARGE_DOG"));
+    assertTrue(result.containsKey("MEDIUM_DOG"));
+    assertTrue(result.containsKey("CAT"));
+
+    // 각 key에 대한 추천 숙소 수가 예상대로인지 확인
+    assertEquals(1, result.get("SMALL_DOG").size());
+    assertEquals(2, result.get("LARGE_DOG").size());
+    assertEquals(1, result.get("MEDIUM_DOG").size());
+    assertEquals(1, result.get("CAT").size());
+
+    // LARGE_DOG 추천 목록이 평점 높은 순으로 정렬되어 있는지 확인
+    List<AccommodationDocument> largeDogList = result.get("LARGE_DOG");
+    assertEquals(4.7, largeDogList.get(0).getTotalRating());
+    assertEquals(4.5, largeDogList.get(1).getTotalRating());
+  }
+
+  private SearchResponse<AccommodationDocument> mockSearchResponse(
+      List<AccommodationDocument> docs) {
+    // SearchResponse, HitsMetadata를 mock 객체로 생성
+    SearchResponse<AccommodationDocument> response = mock(SearchResponse.class);
+    HitsMetadata<AccommodationDocument> hits = mock(HitsMetadata.class);
+
+    // 각 AccommodationDocument를 Elasticsearch의 Hit 객체로 매핑
+    List<Hit<AccommodationDocument>> hitList = docs.stream()
+        .map(doc -> Hit.<AccommodationDocument>of(h -> h
+            .id(String.valueOf(doc.getId()))
+            .index("accommodations")
+            .source(doc)))
+        .toList();
+
+    // SearchResponse 내부의 hits 설정
+    when(hits.hits()).thenReturn(hitList);
+    when(response.hits()).thenReturn(hits);
+
+    return response;
+  }
+}

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationServiceTest.java
@@ -112,7 +112,7 @@ class AccommodationRecommendationServiceTest {
       AccommodationDocument doc) {
     return DefaultRecommendationResponse.builder()
         .id(doc.getId())
-        .accommodationName(doc.getName())
+        .name(doc.getName())
         .totalRating(doc.getTotalRating())
         .price(doc.getPrice())
         .build();

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationServiceTest.java
@@ -124,7 +124,7 @@ class AccommodationRecommendationServiceTest {
     SearchResponse<DefaultRecommendationResponse> response = mock(SearchResponse.class);
     HitsMetadata<DefaultRecommendationResponse> hits = mock(HitsMetadata.class);
 
-    // 각 AccommodationDocument를 Elasticsearch의 Hit 객체로 매핑
+    // 각 DefaultRecommendationResponse를 Elasticsearch의 Hit 객체로 매핑
     List<Hit<DefaultRecommendationResponse>> hitList = docs.stream()
         .map(doc -> Hit.<DefaultRecommendationResponse>of(h -> h
             .id(String.valueOf(doc.getId()))

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/RoomServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/RoomServiceTest.java
@@ -136,7 +136,7 @@ class RoomServiceTest {
     List<RoomFacilityType> facilityTypes = List.of(RoomFacilityType.STYLER);
     List<RoomPetFacilityType> petFacilityTypes =
         Arrays.asList(RoomPetFacilityType.CAT_WHEEL, RoomPetFacilityType.CAT_TOWER,
-            RoomPetFacilityType.DRY_ROOM, RoomPetFacilityType.BED, RoomPetFacilityType.TOY);
+            RoomPetFacilityType.BED, RoomPetFacilityType.TOY);
     List<HashtagType> hashtagTypes = Arrays.asList(HashtagType.FAMILY_TRIP, HashtagType.SPA);
 
     facilities = Arrays.asList(
@@ -247,11 +247,6 @@ class RoomServiceTest {
             .id(2L)
             .room(room)
             .type(RoomPetFacilityType.CAT_TOWER)
-            .build(),
-        RoomPetFacility.builder()
-            .id(3L)
-            .room(room)
-            .type(RoomPetFacilityType.DRY_ROOM)
             .build(),
         RoomPetFacility.builder()
             .id(4L)


### PR DESCRIPTION
## 📌 관련 이슈
- close #111 

## 📝 변경 사항
### AS-IS
- 비로그인 사용자 홈화면에서 추천 숙소를 보여주기 위한 API가 없었음
- 추천 로직이 없어서 반려동물 타입별로 인기 숙소를 구분하여 보여줄 수 없었음

### TO-BE
- PetType(소형견, 중형견, 대형견, 고양이)별 숙소를 반환하는 추천 API (getDefaultRecommendations) 구현
- Elasticsearch의 allowedPetTypes 필드를 기준으로 term 쿼리를 수행하여 필터링
- totalRating 내림차순 정렬 후 최대 6개의 숙소만 응답
- _source 필드 필터링을 통해 id, name, price, totalRating, thumbnailUrl만 가져오도록 최적화
- 응답 객체 DefaultRecommendationResponse를 통해 필요한 데이터만 전달

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 성공
![비로그인 사용자 숙소 추천 성공 1](https://github.com/user-attachments/assets/d71c78a3-fb58-4608-83d2-d5aa881ed9a7)
![비로그인 사용자 숙소 추천 성공 2](https://github.com/user-attachments/assets/254abfce-af8b-4fb6-8b32-98ec90ea0638)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
더미 데이터는 키바나로 넣고 테스트 했습니다.
리뷰 부탁드립니다.