### PR TITLE
[Feature] 숙소/객실 등록, 수정, 삭제 시 정보 색인 및 Elasticsearch 기반 숙소 검색 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/component/AccommodationRoomMapper.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/component/AccommodationRoomMapper.java
@@ -1,0 +1,65 @@
+package com.meongnyangerang.meongnyangerang.component;
+
+import com.meongnyangerang.meongnyangerang.domain.AccommodationRoomDocument;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.AllowPet;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.facility.AccommodationFacility;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.facility.AccommodationPetFacility;
+import com.meongnyangerang.meongnyangerang.domain.room.Room;
+import com.meongnyangerang.meongnyangerang.domain.room.facility.Hashtag;
+import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomFacility;
+import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomPetFacility;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AccommodationRoomMapper {
+
+  public AccommodationRoomDocument toDocument(
+      Accommodation accommodation,
+      Room room,
+      List<AccommodationFacility> accFacilities,
+      List<AccommodationPetFacility> accPetFacilities,
+      List<RoomFacility> roomFacilities,
+      List<RoomPetFacility> roomPetFacilities,
+      List<Hashtag> hashtags,
+      List<AllowPet> allowPets
+  ) {
+    return AccommodationRoomDocument.builder()
+        .id(accommodation.getId() + "_" + room.getId())
+        .accommodationId(accommodation.getId())
+        .roomId(room.getId())
+        .accommodationName(accommodation.getName())
+        .roomName(room.getName())
+        .address(accommodation.getAddress())
+        .accommodationType(accommodation.getType())
+        .totalRating(accommodation.getTotalRating())
+        .price(room.getPrice())
+        .standardPeopleCount(room.getStandardPeopleCount())
+        .maxPeopleCount(room.getMaxPeopleCount())
+        .standardPetCount(room.getStandardPetCount())
+        .maxPetCount(room.getMaxPetCount())
+        .accommodationFacilities(extractEnumNames(accFacilities, AccommodationFacility::getType))
+        .accommodationPetFacilities(extractEnumNames(accPetFacilities, AccommodationPetFacility::getType))
+        .roomFacilities(extractEnumNames(roomFacilities, RoomFacility::getType))
+        .roomPetFacilities(extractEnumNames(roomPetFacilities, RoomPetFacility::getType))
+        .hashtags(extractEnumNames(hashtags, Hashtag::getType))
+        .allowPets(extractEnumNames(allowPets, AllowPet::getPetType))
+        .build();
+  }
+  private <T> List<String> extractEnumNames(List<T> list, Function<T, Enum<?>> extractor) {
+
+//    if (list == null || list.isEmpty()) {
+//      return Collections.emptyList();
+//    }
+    return list.stream()
+        .map(extractor)
+        .map(Enum::name)
+        .toList();
+  }
+}
+

--- a/src/main/java/com/meongnyangerang/meongnyangerang/component/AccommodationRoomMapper.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/component/AccommodationRoomMapper.java
@@ -9,7 +9,6 @@ import com.meongnyangerang.meongnyangerang.domain.room.Room;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.Hashtag;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomFacility;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomPetFacility;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +35,7 @@ public class AccommodationRoomMapper {
         .accommodationName(accommodation.getName())
         .roomName(room.getName())
         .address(accommodation.getAddress())
+        .thumbnailUrl(accommodation.getThumbnailUrl())
         .accommodationType(accommodation.getType())
         .totalRating(accommodation.getTotalRating())
         .price(room.getPrice())

--- a/src/main/java/com/meongnyangerang/meongnyangerang/component/AccommodationRoomMapper.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/component/AccommodationRoomMapper.java
@@ -9,6 +9,7 @@ import com.meongnyangerang.meongnyangerang.domain.room.Room;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.Hashtag;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomFacility;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomPetFacility;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
@@ -53,9 +54,9 @@ public class AccommodationRoomMapper {
   }
   private <T> List<String> extractEnumNames(List<T> list, Function<T, Enum<?>> extractor) {
 
-//    if (list == null || list.isEmpty()) {
-//      return Collections.emptyList();
-//    }
+    if (list == null || list.isEmpty()) {
+      return Collections.emptyList();
+    }
     return list.stream()
         .map(extractor)
         .map(Enum::name)

--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/ElasticsearchConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/ElasticsearchConfig.java
@@ -1,0 +1,22 @@
+package com.meongnyangerang.meongnyangerang.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.elasticsearch.client.RestClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ElasticsearchConfig {
+
+  @Bean
+  public ElasticsearchClient elasticsearchClient(RestClient restClient) {
+    ElasticsearchTransport transport = new RestClientTransport(restClient,
+        new JacksonJsonpMapper());
+
+    return new ElasticsearchClient(transport);
+  }
+}
+

--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
                 "/api/v1/hosts/login",
                 "/api/v1/admin/login",
                 "/api/v1/accommodations/{accommodationId}/reviews",
-                "/api/v1/recommendations/default"
+                "/api/v1/recommendations/default",
                 "/api/v1/accommodations/{accommodationId}/reviews",
                 "/api/v1/search/accommodations"
             ).permitAll()

--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
@@ -44,7 +44,8 @@ public class SecurityConfig {
                 "/api/v1/users/login",
                 "/api/v1/hosts/login",
                 "/api/v1/admin/login",
-                "/api/v1/accommodations/{accommodationId}/reviews"
+                "/api/v1/accommodations/{accommodationId}/reviews",
+                "/api/v1/search/accommodations"
             ).permitAll()
             .requestMatchers("/api/v1/users/**").hasAuthority("ROLE_USER")
             .requestMatchers("/api/v1/hosts/**").hasAuthority("ROLE_HOST")

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationSearchController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationSearchController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/search")
+@RequestMapping("/api/v1/search/accommodations")
 public class AccommodationSearchController {
 
   private final AccommodationSearchService searchService;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationSearchController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationSearchController.java
@@ -2,6 +2,7 @@ package com.meongnyangerang.meongnyangerang.controller;
 
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchRequest;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchResponse;
+import com.meongnyangerang.meongnyangerang.service.AccommodationSearchService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationSearchController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationSearchController.java
@@ -1,7 +1,9 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchRequest;
+import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationSearchController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationSearchController.java
@@ -1,0 +1,25 @@
+package com.meongnyangerang.meongnyangerang.controller;
+
+import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/search")
+public class AccommodationSearchController {
+
+  private final AccommodationSearchService searchService;
+
+  @PostMapping
+  public ResponseEntity<List<AccommodationSearchResponse>> searchAccommodation(
+      @Valid @RequestBody AccommodationSearchRequest request) {
+
+    return ResponseEntity.ok(searchService.searchAccommodation(request));
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationSearchController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationSearchController.java
@@ -2,10 +2,13 @@ package com.meongnyangerang.meongnyangerang.controller;
 
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchRequest;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchResponse;
+import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
 import com.meongnyangerang.meongnyangerang.service.AccommodationSearchService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,9 +23,9 @@ public class AccommodationSearchController {
   private final AccommodationSearchService searchService;
 
   @PostMapping
-  public ResponseEntity<List<AccommodationSearchResponse>> searchAccommodation(
-      @Valid @RequestBody AccommodationSearchRequest request) {
-
-    return ResponseEntity.ok(searchService.searchAccommodation(request));
+  public ResponseEntity<PageResponse<AccommodationSearchResponse>> searchAccommodation(
+      @Valid @RequestBody AccommodationSearchRequest request,
+      @PageableDefault(size = 20) Pageable pageable) {
+    return ResponseEntity.ok(searchService.searchAccommodation(request, pageable));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/RoomController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/RoomController.java
@@ -86,6 +86,6 @@ public class RoomController {
       @PathVariable Long roomId
   ){
     roomService.deleteRoom(userDetail.getId(), roomId);
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/AccommodationRoomDocument.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/AccommodationRoomDocument.java
@@ -1,0 +1,46 @@
+package com.meongnyangerang.meongnyangerang.domain;
+
+import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationType;
+import jakarta.persistence.Id;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document(indexName = "accommodation_room") // Elasticsearch 의 인덱스 이름
+public class AccommodationRoomDocument {
+
+  @Id
+  private String id; // ex: "1_3" → 숙소ID_객실ID
+
+  private Long accommodationId;
+  private Long roomId;
+
+  private String accommodationName;
+  private String roomName;
+
+  private String address;
+
+  private AccommodationType accommodationType;
+  private Double totalRating;
+
+  private Long price;
+
+  private Integer standardPeopleCount;
+  private Integer maxPeopleCount;
+  private Integer standardPetCount;
+  private Integer maxPetCount;
+
+  private List<String> accommodationFacilities;
+  private List<String> accommodationPetFacilities;
+  private List<String> roomFacilities;
+  private List<String> roomPetFacilities;
+  private List<String> hashtags;
+  private List<String> allowPets;
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/AccommodationRoomDocument.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/AccommodationRoomDocument.java
@@ -29,7 +29,7 @@ public class AccommodationRoomDocument {
 
   private AccommodationType accommodationType;
   private Double totalRating;
-
+  private String thumbnailUrl;
   private Long price;
 
   private Integer standardPeopleCount;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationCreateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationCreateRequest.java
@@ -51,6 +51,7 @@ public record AccommodationCreateRequest(
         .detailedAddress(this.detailedAddress)
         .latitude(this.latitude)
         .longitude(this.longitude)
+        .totalRating(0.0)
         .type(this.type)
         .thumbnailUrl(thumbnailUrl)
         .build();

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchRequest.java
@@ -1,0 +1,50 @@
+package com.meongnyangerang.meongnyangerang.dto.accommodation;
+
+import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccommodationSearchRequest {
+
+  @NotBlank(message = "위치는 필수입니다.")
+  private String location;
+
+  @NotNull(message = "체크인 날짜는 필수입니다.")
+  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+  private LocalDate checkInDate;
+
+  @NotNull(message = "체크아웃 날짜는 필수입니다.")
+  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+  private LocalDate checkOutDate;
+
+  @NotNull(message = "인원 수는 필수입니다.")
+  @Min(value = 1, message = "최소 1명 이상이어야 합니다.")
+  private Integer peopleCount;
+
+  @NotNull(message = "반려동물 수는 필수입니다.")
+  @Min(value = 0, message = "0 이상이어야 합니다.")
+  private Integer petCount;
+
+  // 선택 필터들
+  private AccommodationType accommodationType;
+  private Long minPrice;
+  private Long maxPrice;
+  private Double minRating;
+
+  private List<String> accommodationFacilities;
+  private List<String> accommodationPetFacilities;
+  private List<String> roomFacilities;
+  private List<String> roomPetFacilities;
+  private List<String> hashtags;
+  private List<String> allowPets;
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchResponse.java
@@ -14,7 +14,6 @@ public class AccommodationSearchResponse {
   private Long accommodationId;
   private String accommodationName;
   private String address;
-  private String detailedAddress;
   private String thumbnailUrl;
   private Double totalRating;
   private Long price;
@@ -25,7 +24,6 @@ public class AccommodationSearchResponse {
         .accommodationId(doc.getAccommodationId())
         .accommodationName(doc.getAccommodationName())
         .address(doc.getAddress())
-        .detailedAddress(doc.getDetailedAddress)
         .thumbnailUrl(doc.getThumbanilUrl)
         .totalRating(doc.getTotalRating())
         .price(doc.getPrice())

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchResponse.java
@@ -1,11 +1,14 @@
 package com.meongnyangerang.meongnyangerang.dto.accommodation;
 
+import com.meongnyangerang.meongnyangerang.domain.AccommodationRoomDocument;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationType;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class AccommodationSearchResponse {
 
   private Long accommodationId;
@@ -17,4 +20,16 @@ public class AccommodationSearchResponse {
   private Long price;
   private AccommodationType accommodationType;
 
+  public static AccommodationSearchResponse fromDocument(AccommodationRoomDocument doc) {
+    return AccommodationSearchResponse.builder()
+        .accommodationId(doc.getAccommodationId())
+        .accommodationName(doc.getAccommodationName())
+        .address(doc.getAddress())
+        .detailedAddress(doc.getDetailedAddress)
+        .thumbnailUrl(doc.getThumbanilUrl)
+        .totalRating(doc.getTotalRating())
+        .price(doc.getPrice())
+        .accommodationType(doc.getAccommodationType())
+        .build();
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchResponse.java
@@ -24,7 +24,7 @@ public class AccommodationSearchResponse {
         .accommodationId(doc.getAccommodationId())
         .accommodationName(doc.getAccommodationName())
         .address(doc.getAddress())
-        .thumbnailUrl(doc.getThumbanilUrl)
+        .thumbnailUrl(doc.getThumbnailUrl())
         .totalRating(doc.getTotalRating())
         .price(doc.getPrice())
         .accommodationType(doc.getAccommodationType())

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchResponse.java
@@ -1,0 +1,20 @@
+package com.meongnyangerang.meongnyangerang.dto.accommodation;
+
+import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AccommodationSearchResponse {
+
+  private Long accommodationId;
+  private String accommodationName;
+  private String address;
+  private String detailedAddress;
+  private String thumbnailUrl;
+  private Double totalRating;
+  private Long price;
+  private AccommodationType accommodationType;
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -82,6 +82,7 @@ public enum ErrorCode {
   ACCOMMODATION_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "숙소 수정 오류"),
   ROOM_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "객실 수정 오류"),
   DEFAULT_RECOMMENDATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "기본 추천 조회 중 오류가 발생했습니다."),
+  SEARCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "숙소 검색 중 오류가 발생했습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/jwt/JwtTokenProvider.java
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class JwtTokenProvider {
 
-  @Value("${jwt.secret}")
+  @Value("${JWT_SECRET}")
   private String secretKey;
 
   private Key key;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReservationSlotRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReservationSlotRepository.java
@@ -2,8 +2,11 @@ package com.meongnyangerang.meongnyangerang.repository;
 
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationSlot;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,4 +17,13 @@ public interface ReservationSlotRepository extends JpaRepository<ReservationSlot
 
   // 특정 날짜에 대한 예약 존재하는지 찾거나 생성하는 로직에 활용
   Optional<ReservationSlot> findByRoomIdAndReservedDate(Long roomId, LocalDate reservedDate);
+
+  @Query("""
+          SELECT DISTINCT rs.room.id
+          FROM ReservationSlot rs
+          WHERE rs.isReserved = true
+            AND rs.reservedDate BETWEEN :checkInDate AND :checkOutDate
+      """)
+  List<Long> findReservedRoomIdsBetweenDates(@Param("checkInDate") LocalDate checkInDate,
+      @Param("checkOutDate") LocalDate checkOutDate);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/room/RoomRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/room/RoomRepository.java
@@ -20,4 +20,6 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
       @Param("cursorId") Long cursorId,
       Pageable pageable
   );
+
+  List<Room> findAllByAccommodationId(Long id);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
@@ -1,6 +1,7 @@
 package com.meongnyangerang.meongnyangerang.service;
 
 import com.meongnyangerang.meongnyangerang.component.AccommodationRoomMapper;
+import com.meongnyangerang.meongnyangerang.domain.AccommodationRoomDocument;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.AllowPet;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.facility.AccommodationFacility;
@@ -64,5 +65,14 @@ public class AccommodationRoomSearchService {
         allowPets
     ));
     log.info("[색인 저장] 숙소: {}, 객실: {} 색인 완료", accommodationId, roomId);
+  }
+
+  /**
+   * 객실 삭제 시 색인 삭제
+   */
+  public void delete(Long accommodationId, Long roomId) {
+    String id = accommodationId + "_" + roomId;
+    elasticsearchOperations.delete(id, AccommodationRoomDocument.class);
+    log.info("[색인 삭제] 숙소: {}, 객실: {} 색인 삭제 완료", accommodationId, roomId);
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
@@ -1,0 +1,68 @@
+package com.meongnyangerang.meongnyangerang.service;
+
+import com.meongnyangerang.meongnyangerang.component.AccommodationRoomMapper;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.AllowPet;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.facility.AccommodationFacility;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.facility.AccommodationPetFacility;
+import com.meongnyangerang.meongnyangerang.domain.room.Room;
+import com.meongnyangerang.meongnyangerang.domain.room.facility.Hashtag;
+import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomFacility;
+import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomPetFacility;
+import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationFacilityRepository;
+import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationPetFacilityRepository;
+import com.meongnyangerang.meongnyangerang.repository.accommodation.AllowPetRepository;
+import com.meongnyangerang.meongnyangerang.repository.room.HashtagRepository;
+import com.meongnyangerang.meongnyangerang.repository.room.RoomFacilityRepository;
+import com.meongnyangerang.meongnyangerang.repository.room.RoomPetFacilityRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.stereotype.Service;
+
+// Elasticsearch 색인 저장 및 삭제를 담당하는 서비스
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AccommodationRoomSearchService {
+
+  private final AccommodationRoomMapper mapper;
+  private final ElasticsearchOperations elasticsearchOperations;
+  private final RoomFacilityRepository roomFacilityRepository;
+  private final RoomPetFacilityRepository roomPetFacilityRepository;
+  private final HashtagRepository hashtagRepository;
+  private final AccommodationFacilityRepository accommodationFacilityRepository;
+  private final AccommodationPetFacilityRepository accommodationPetFacilityRepository;
+  private final AllowPetRepository allowPetRepository;
+
+  /**
+   * 객실 등록 또는 숙소/객실 수정 시 색인 저장
+   */
+  public void save(Accommodation accommodation, Room room) {
+    Long accommodationId = accommodation.getId();
+    Long roomId = room.getId();
+
+    List<AccommodationFacility> accFacilities = accommodationFacilityRepository.findAllByAccommodationId(
+        accommodationId);
+    List<AccommodationPetFacility> accPetFacilities = accommodationPetFacilityRepository.findAllByAccommodationId(
+        accommodationId);
+    List<AllowPet> allowPets = allowPetRepository.findAllByAccommodationId(accommodationId);
+
+    List<RoomFacility> roomFacilities = roomFacilityRepository.findAllByRoomId(roomId);
+    List<RoomPetFacility> roomPetFacilities = roomPetFacilityRepository.findAllByRoomId(roomId);
+    List<Hashtag> hashtags = hashtagRepository.findAllByRoomId(roomId);
+
+    elasticsearchOperations.save(mapper.toDocument(
+        accommodation,
+        room,
+        accFacilities,
+        accPetFacilities,
+        roomFacilities,
+        roomPetFacilities,
+        hashtags,
+        allowPets
+    ));
+    log.info("[색인 저장] 숙소: {}, 객실: {} 색인 완료", accommodationId, roomId);
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
@@ -75,4 +75,13 @@ public class AccommodationRoomSearchService {
     elasticsearchOperations.delete(id, AccommodationRoomDocument.class);
     log.info("[색인 삭제] 숙소: {}, 객실: {} 색인 삭제 완료", accommodationId, roomId);
   }
+
+  /**
+   * 숙소 수정 시 연결된 객실 모두 색인 재저장
+   */
+  public void updateAllRooms(Accommodation accommodation, List<Room> rooms) {
+    for (Room room : rooms) {
+      save(accommodation, room);
+    }
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
@@ -80,6 +80,11 @@ public class AccommodationRoomSearchService {
    * 숙소 수정 시 연결된 객실 모두 색인 재저장
    */
   public void updateAllRooms(Accommodation accommodation, List<Room> rooms) {
+
+    if (rooms == null || rooms.isEmpty()) {
+      log.info("[색인 갱신] 숙소 ID: {} - 연결된 객실이 없어 색인 생략", accommodation.getId());
+      return;
+    }
     for (Room room : rooms) {
       save(accommodation, room);
     }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
@@ -148,7 +148,7 @@ public class AccommodationSearchService {
     if (values != null && !values.isEmpty()) {
       mustQueries.add(Query.of(q -> q
           .terms(t -> t
-              .field(field)
+              .field(field + ".keyword")
               .terms(terms -> terms
                   .value(values.stream().map(FieldValue::of).toList())
               )

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
@@ -1,5 +1,7 @@
 package com.meongnyangerang.meongnyangerang.service;
 
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.*;
+
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.SortOrder;
@@ -11,6 +13,8 @@ import com.meongnyangerang.meongnyangerang.domain.AccommodationRoomDocument;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchRequest;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
+import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.ReservationSlotRepository;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -161,7 +165,7 @@ public class AccommodationSearchService {
       );
 
     } catch (IOException e) {
-      throw new RuntimeException("Elasticsearch 검색 실패", e);
+      throw new MeongnyangerangException(SEARCH_FAILED);
     }
   }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
@@ -103,7 +103,9 @@ public class AccommodationSearchService {
               .query(finalQuery)
               .size(100)
               .sort(so -> so
-                  .score(score -> score.order(SortOrder.Desc))),
+                  .field(f -> f
+                      .field("totalRating")
+                      .order(SortOrder.Desc))),
           AccommodationRoomDocument.class
       );
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
@@ -1,0 +1,140 @@
+package com.meongnyangerang.meongnyangerang.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.json.JsonData;
+import com.meongnyangerang.meongnyangerang.domain.AccommodationRoomDocument;
+import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchRequest;
+import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccommodationSearchService {
+
+  private final ElasticsearchClient elasticsearchClient;
+
+  public List<AccommodationSearchResponse> searchAccommodation(AccommodationSearchRequest request) {
+    List<Query> mustQueries = new ArrayList<>();
+
+    // 위치 필터 (wildcard - 주소 전체에서 특정 키워드 포함 검색)
+    if (request.getLocation() != null) {
+      mustQueries.add(Query.of(q -> q
+          .wildcard(w -> w
+              .field("address")
+              .wildcard("*" + request.getLocation() + "*")
+          )));
+    }
+
+    // 인원 수 필터
+    if (request.getPeopleCount() != null) {
+      mustQueries.add(Query.of(q -> q
+          .range(r -> r.field("standardPeopleCount").lte(JsonData.of(request.getPeopleCount())))));
+      mustQueries.add(Query.of(q -> q
+          .range(r -> r.field("maxPeopleCount").gte(JsonData.of(request.getPeopleCount())))));
+    }
+
+    // 반려동물 수 필터
+    if (request.getPetCount() != null) {
+      mustQueries.add(Query.of(q -> q
+          .range(r -> r.field("standardPetCount").lte(JsonData.of(request.getPetCount())))));
+      mustQueries.add(Query.of(q -> q
+          .range(r -> r.field("maxPetCount").gte(JsonData.of(request.getPetCount())))));
+    }
+
+    // 숙소 유형
+    if (request.getAccommodationType() != null) {
+      mustQueries.add(Query.of(q -> q
+          .term(t -> t
+              .field("accommodationType.keyword") // enum은 keyword 필드 기준
+              .value(request.getAccommodationType().name()))));
+    }
+
+    // 가격 필터
+    if (request.getMinPrice() != null || request.getMaxPrice() != null) {
+      mustQueries.add(Query.of(q -> q
+          .range(r -> {
+            r.field("price");
+            if (request.getMinPrice() != null) {
+              r.gte(JsonData.of(request.getMinPrice()));
+            }
+            if (request.getMaxPrice() != null) {
+              r.lte(JsonData.of(request.getMaxPrice()));
+            }
+            return r;
+          })
+      ));
+    }
+
+    // 평점 필터
+    if (request.getMinRating() != null) {
+      mustQueries.add(Query.of(q -> q
+          .range(r -> r
+              .field("totalRating")
+              .gte(JsonData.of(request.getMinRating())))));
+    }
+
+    // terms 필터들
+    applyTermsFilter(mustQueries, "accommodationFacilities", request.getAccommodationFacilities());
+    applyTermsFilter(mustQueries, "accommodationPetFacilities",
+        request.getAccommodationPetFacilities());
+    applyTermsFilter(mustQueries, "roomFacilities", request.getRoomFacilities());
+    applyTermsFilter(mustQueries, "roomPetFacilities", request.getRoomPetFacilities());
+    applyTermsFilter(mustQueries, "hashtags", request.getHashtags());
+    applyTermsFilter(mustQueries, "allowPets", request.getAllowPets());
+
+    // Bool Query 조합
+    Query finalQuery = Query.of(q -> q
+        .bool(b -> b.must(mustQueries)));
+
+    try {
+      SearchResponse<AccommodationRoomDocument> response = elasticsearchClient.search(s -> s
+              .index("accommodation_room")
+              .query(finalQuery)
+              .size(100)
+              .sort(so -> so
+                  .score(score -> score.order(SortOrder.Desc))),
+          AccommodationRoomDocument.class
+      );
+
+      Map<Long, AccommodationRoomDocument> unique = new LinkedHashMap<>();
+      for (Hit<AccommodationRoomDocument> hit : response.hits().hits()) {
+        AccommodationRoomDocument doc = hit.source();
+        if (doc != null) {
+          unique.putIfAbsent(doc.getAccommodationId(), doc);
+        }
+      }
+
+      return unique.values().stream()
+          .map(AccommodationSearchResponse::fromDocument)
+          .toList();
+
+    } catch (IOException e) {
+      throw new RuntimeException("Elasticsearch 검색 실패", e);
+    }
+  }
+
+  private void applyTermsFilter(List<Query> mustQueries, String field, List<String> values) {
+    if (values != null && !values.isEmpty()) {
+      mustQueries.add(Query.of(q -> q
+          .terms(t -> t
+              .field(field)
+              .terms(terms -> terms
+                  .value(values.stream().map(FieldValue::of).toList())
+              )
+          )
+      ));
+    }
+  }
+}
+

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
@@ -9,6 +9,7 @@ import com.meongnyangerang.meongnyangerang.domain.accommodation.facility.Accommo
 import com.meongnyangerang.meongnyangerang.domain.accommodation.facility.AccommodationPetFacility;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.facility.AccommodationPetFacilityType;
 import com.meongnyangerang.meongnyangerang.domain.host.Host;
+import com.meongnyangerang.meongnyangerang.domain.room.Room;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationCreateRequest;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationResponse;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationUpdateRequest;
@@ -20,6 +21,7 @@ import com.meongnyangerang.meongnyangerang.repository.accommodation.Accommodatio
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationPetFacilityRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AllowPetRepository;
+import com.meongnyangerang.meongnyangerang.repository.room.RoomRepository;
 import com.meongnyangerang.meongnyangerang.service.image.ImageService;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,6 +45,8 @@ public class AccommodationService {
   private final AllowPetRepository allowPetRepository;
   private final AccommodationImageRepository accommodationImageRepository;
   private final ImageService imageService;
+  private final RoomRepository roomRepository;
+  private final AccommodationRoomSearchService searchService;
 
   /**
    * 숙소 등록
@@ -119,6 +123,10 @@ public class AccommodationService {
 
       updateEntities(accommodation, request, newThumbnailUrl, newAdditionalImageUrls);
       imageService.deleteImagesAsync(oldImageUrlsToDelete);
+
+      // 색인 갱신 - 객실이 있을 경우에만
+      List<Room> rooms = roomRepository.findAllByAccommodationId(accommodation.getId());
+      searchService.updateAllRooms(accommodation, rooms);
 
       log.info("숙소 수정 성공, 숙소 ID : {}", accommodation.getId());
       return createAccommodationResponse(accommodation);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
@@ -40,16 +40,19 @@ public class RoomService {
   private final RoomPetFacilityRepository roomPetFacilityRepository;
   private final HashtagRepository hashtagRepository;
   private final ImageService imageService;
+  private final AccommodationRoomSearchService searchService;
 
   /**
    * 객실 등록
    */
+  @Transactional
   public void createRoom(Long hostId, RoomCreateRequest request, MultipartFile thumbnail) {
     Accommodation accommodation = findAccommodationByHostId(hostId);
     String thumbnailUrl = imageService.storeImage(thumbnail);
 
     Room room = request.toEntity(accommodation, thumbnailUrl);
     roomRepository.save(room);
+    searchService.save(accommodation, room); // Elasticsearch 색인 저장
   }
 
   /**

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
@@ -131,6 +131,7 @@ public class RoomService {
     roomPetFacilityRepository.deleteAllByRoomId(roomId);
     roomFacilityRepository.deleteAllByRoomId(roomId);
     roomRepository.delete(room);
+    searchService.delete(room.getAccommodation().getId(), roomId); // Elasticsearch 색인 삭제
   }
 
   private List<RoomFacility> updateFacilities(List<RoomFacilityType> newFacilityTypes, Room room) {

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
@@ -128,6 +128,7 @@ public class RoomService {
     roomPetFacilityRepository.deleteAllByRoomId(roomId);
     roomFacilityRepository.deleteAllByRoomId(roomId);
     roomRepository.delete(room);
+    searchService.delete(room.getAccommodation().getId(), roomId); // Elasticsearch 색인 삭제
   }
 
   private List<RoomFacility> updateFacilities(List<RoomFacilityType> newFacilityTypes, Room room) {

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
@@ -107,6 +107,8 @@ public class RoomService {
           request.petFacilityTypes(), room);
       List<Hashtag> updatedHashtags = updateHashtags(request.hashtagTypes(), room);
 
+      searchService.save(room.getAccommodation(), updatedRoom); // Elasticsearch 색인 업데이트
+
       return RoomResponse.of(updatedRoom, updatedFacilities, updatedPetFacilities, updatedHashtags);
     } catch (Exception e) {
       log.error("객실 업데이트 실행: {}", e.getMessage(), e);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,5 +31,8 @@ spring:
           starttls:
             enable: true
 
+  elasticsearch:
+    uris: ${ELASTICSEARCH_URI}
+
   jwt:
     secret: ${JWT_SECRET}


### PR DESCRIPTION
## 📌 관련 이슈
- close #114 

## 📝 변경 사항
### AS-IS
숙소 및 객실 등록/수정 시 색인 기능 없음

검색 조건 반영되지 않은 단순 숙소 조회 기능

### TO-BE
숙소 수정 및 객실 등록/수정/삭제 시 Elasticsearch 색인 저장/삭제/갱신

다양한 필수/선택 필터 기반 숙소 검색 API 구현

예약 가능 여부 고려 (예약된 객실 제외)

숙소 단위로 중복 제거 후 검색 결과 반환

Pageable 기반 페이징 처리

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트
- Postman을 통한 조건별 숙소 검색 테스트 완료

- Elasticsearch 색인 상태 확인 (Kibana + API 테스트)

- 예약 정보가 있을 때/없을 때 검색 결과 정상 필터링 되는지 확인

- 필수/선택 필터 조합 테스트 완료

- 페이징 요청 (page, size) 기반 결과 수 제한 정상 작동

## 📸 스크린샷
- 숙소 수정 시 색인 업데이트 성공
![image](https://github.com/user-attachments/assets/4e7315c8-8602-492c-817f-a03181d98a2d)
![image](https://github.com/user-attachments/assets/eb92e170-d8df-47a5-8eae-1ca53cd3e4f3)

- 객실 등록 시 색인 저장 성공
![image](https://github.com/user-attachments/assets/ca89149b-d38e-406d-8294-01012f65a57d)
![image](https://github.com/user-attachments/assets/540cd959-26a3-4501-8f8f-643a52513e92)
- 객실 수정 시 색인 업데이트 성공
![image](https://github.com/user-attachments/assets/7b732b1d-aad4-4915-9a8c-952526473227)
![image](https://github.com/user-attachments/assets/e4946349-b404-467a-bbff-80d58edc4b0f)
- 객실 삭제 시 색인 삭제 성공
![image](https://github.com/user-attachments/assets/127d86ed-bee9-407d-a126-adb9ed952b2d)
![image](https://github.com/user-attachments/assets/078e737d-204f-4303-ae96-b28125f85745)
- 색인된 내용을 바탕으로 숙소 검색(목록)
![image](https://github.com/user-attachments/assets/711a2def-d600-4154-87e3-158099948704)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
AccommodationSearchService 로직이 필터별로 분리되어 있습니다

전체 로직 중복 제거보다는 가독성과 조건별 필터 우선 적용을 고려했습니다

혹시 더 개선할 부분이나 UI/UX 측면에서 필요한 검색 정렬이 있다면 피드백 주세요!
