### PR TITLE
[Feature] 예약 상태 변경 구현 및 예약 서비스 관련 로직 수정

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/component/ReservationStatusScheduler.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/component/ReservationStatusScheduler.java
@@ -1,0 +1,32 @@
+package com.meongnyangerang.meongnyangerang.component;
+
+import com.meongnyangerang.meongnyangerang.domain.reservation.Reservation;
+import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
+import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationStatusScheduler {
+
+  private final ReservationRepository reservationRepository;
+
+  // 매일 새벽 2시에 실행
+  @Scheduled(cron = "0 0 2 * * ?")
+  public void updateReservationStatus() {
+    LocalDate today = LocalDate.now();
+
+    List<Reservation> reservations = reservationRepository.findByCheckOutDate(today);
+
+    for (Reservation reservation : reservations) {
+      reservation.setStatus(ReservationStatus.COMPLETED);
+    }
+
+    reservationRepository.saveAll(reservations);
+  }
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReservationController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReservationController.java
@@ -4,6 +4,7 @@ import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
 import com.meongnyangerang.meongnyangerang.dto.CustomReservationResponse;
 import com.meongnyangerang.meongnyangerang.dto.HostReservationResponse;
 import com.meongnyangerang.meongnyangerang.dto.ReservationRequest;
+import com.meongnyangerang.meongnyangerang.dto.ReservationResponse;
 import com.meongnyangerang.meongnyangerang.dto.UserReservationResponse;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.ReservationService;
@@ -29,13 +30,14 @@ public class ReservationController {
   private final ReservationService reservationService;
 
   @PostMapping("/users/reservations")
-  public ResponseEntity<Void> createReservation(
+  public ResponseEntity<ReservationResponse> createReservation(
       @AuthenticationPrincipal UserDetailsImpl userDetails,
       @Valid @RequestBody ReservationRequest reservationRequest) {
 
-    reservationService.createReservation(userDetails.getId(), reservationRequest);
+    ReservationResponse response = reservationService.createReservation(userDetails.getId(),
+        reservationRequest);
 
-    return ResponseEntity.ok().build();
+    return ResponseEntity.ok(response);
   }
 
   @GetMapping("/users/reservations")

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/reservation/Reservation.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/reservation/Reservation.java
@@ -46,6 +46,9 @@ public class Reservation {
   private Room room;
 
   @Column(nullable = false)
+  private String accommodationName;
+
+  @Column(nullable = false)
   private LocalDate checkInDate;
 
   @Column(nullable = false)

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/MyReviewResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/MyReviewResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @Builder
 public class MyReviewResponse {
 
+  private Long reviewId;
   private String accommodationName;
   private Double totalRating;
   private String content;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReservationRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReservationRequest.java
@@ -18,6 +18,9 @@ public class ReservationRequest {
   @NotNull
   private Long roomId;
 
+  @NotBlank
+  private String accommodationName;
+
   @NotNull
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
   private LocalDate checkInDate;
@@ -48,6 +51,7 @@ public class ReservationRequest {
     return Reservation.builder()
         .user(user)
         .room(room)
+        .accommodationName(accommodationName)
         .checkInDate(checkInDate)
         .checkOutDate(checkOutDate)
         .peopleCount(peopleCount)

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReservationResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReservationResponse.java
@@ -1,0 +1,11 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReservationResponse {
+
+  private String orderNumber;
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/UserReservationResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/UserReservationResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Builder
 public class UserReservationResponse {
 
+  private Long reservationId;
   private String reservationDate;
   private String accommodationName;
   private String roomName;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/UserReservationResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/UserReservationResponse.java
@@ -14,6 +14,7 @@ public class UserReservationResponse {
   private String checkOutDate;
   private String checkInTime;
   private String checkOutTime;
+  private boolean reviewWritten;
   private int peopleCount;
   private int petCount;
   private long totalPrice;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReservationRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReservationRepository.java
@@ -2,6 +2,7 @@ package com.meongnyangerang.meongnyangerang.repository;
 
 import com.meongnyangerang.meongnyangerang.domain.reservation.Reservation;
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -46,4 +47,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         AND r.status = :status
     """)
   boolean existsByHostIdAndStatus(Long hostId, ReservationStatus status);
+
+  List<Reservation> findByCheckOutDate(LocalDate checkOutDate);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReservationSlotRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReservationSlotRepository.java
@@ -1,6 +1,7 @@
 package com.meongnyangerang.meongnyangerang.repository;
 
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationSlot;
+import com.meongnyangerang.meongnyangerang.domain.room.Room;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -13,7 +14,8 @@ import org.springframework.stereotype.Repository;
 public interface ReservationSlotRepository extends JpaRepository<ReservationSlot, Long> {
 
   // 특정 객실이 날짜 범위(startDate ~ endDate)내에서 예약이 존재하는지 확인
-  boolean existsByRoomIdAndReservedDateBetweenAndIsReserved(Long roomId, LocalDate startDate, LocalDate endDate, boolean isReserved);
+  boolean existsByRoomIdAndReservedDateBetweenAndIsReserved(Long roomId, LocalDate startDate,
+      LocalDate endDate, boolean isReserved);
 
   // 특정 날짜에 대한 예약 존재하는지 찾거나 생성하는 로직에 활용
   Optional<ReservationSlot> findByRoomIdAndReservedDate(Long roomId, LocalDate reservedDate);
@@ -26,4 +28,7 @@ public interface ReservationSlotRepository extends JpaRepository<ReservationSlot
       """)
   List<Long> findReservedRoomIdsBetweenDates(@Param("checkInDate") LocalDate checkInDate,
       @Param("checkOutDate") LocalDate checkOutDate);
+
+  List<ReservationSlot> findByRoomAndReservedDateBetween(Room room, LocalDate startDate,
+      LocalDate endDate);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewRepository.java
@@ -50,4 +50,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   );
 
   int countByAccommodationId(Long accommodationId);
+
+  boolean existsByReservationId(Long reservationId);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
@@ -116,7 +116,7 @@ public class AccommodationRecommendationService {
               doc)) // 점수와 문서를 함께 보관
           .sorted((a, b) -> Integer.compare(b.getKey(), a.getKey())) // 점수 기준 내림차순 정렬
           .map(entry -> mapToResponse(entry.getValue())) // 최종 응답 객체로 매핑
-          .collect(Collectors.toList());
+          .toList();
 
     } catch (IOException e) {
       throw new MeongnyangerangException(ErrorCode.USER_RECOMMENDATION_FAILED);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
@@ -9,19 +9,21 @@ import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.dto.CustomReservationResponse;
 import com.meongnyangerang.meongnyangerang.dto.HostReservationResponse;
 import com.meongnyangerang.meongnyangerang.dto.ReservationRequest;
+import com.meongnyangerang.meongnyangerang.dto.ReservationResponse;
 import com.meongnyangerang.meongnyangerang.dto.UserReservationResponse;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReservationSlotRepository;
-import com.meongnyangerang.meongnyangerang.repository.room.RoomRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
+import com.meongnyangerang.meongnyangerang.repository.room.RoomRepository;
 import jakarta.persistence.OptimisticLockException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -48,7 +50,7 @@ public class ReservationService {
    * @param reservationRequest 예약 요청 정보
    */
   @Transactional
-  public void createReservation(Long userId, ReservationRequest reservationRequest) {
+  public ReservationResponse createReservation(Long userId, ReservationRequest reservationRequest) {
     // 사용자 검증
     User user = validateUser(userId);
 
@@ -65,6 +67,8 @@ public class ReservationService {
 
     // 예약 정보 생성 후 DB에 저장
     saveReservation(user, room, reservationRequest);
+
+    return new ReservationResponse(UUID.randomUUID().toString());
   }
 
   /**

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
@@ -15,8 +15,8 @@ import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReservationSlotRepository;
+import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
-import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
 import com.meongnyangerang.meongnyangerang.repository.room.RoomRepository;
 import jakarta.persistence.OptimisticLockException;
 import java.time.LocalDate;
@@ -39,9 +39,9 @@ public class ReservationService {
 
   private final ReservationRepository reservationRepository;
   private final ReservationSlotRepository reservationSlotRepository;
-  private final AccommodationRepository accommodationRepository;
   private final UserRepository userRepository;
   private final RoomRepository roomRepository;
+  private final ReviewRepository reviewRepository;
 
   /**
    * 사용자와 객실 정보를 바탕으로 예약을 생성하는 메소드. 예약 가능한지 확인하고, 예약을 처리한 후 예약 정보를 DB에 저장합니다.
@@ -195,6 +195,7 @@ public class ReservationService {
   }
 
   private UserReservationResponse mapToUserReservationResponse(Reservation reservation) {
+    boolean reviewWritten = reviewRepository.existsByReservationId(reservation.getId());
     Room room = reservation.getRoom();
     Accommodation accommodation = room.getAccommodation();
 
@@ -202,6 +203,7 @@ public class ReservationService {
     DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
 
     return UserReservationResponse.builder()
+        .reservationId(reservation.getId())
         .reservationDate(reservation.getCreatedAt().format(dateFormatter))
         .accommodationName(accommodation.getName())
         .roomName(room.getName())
@@ -212,6 +214,7 @@ public class ReservationService {
         .peopleCount(reservation.getPeopleCount())
         .petCount(reservation.getPetCount())
         .totalPrice(reservation.getTotalPrice())
+        .reviewWritten(reviewWritten)
         .build();
   }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
@@ -234,8 +234,20 @@ public class ReservationService {
       throw new MeongnyangerangException(ErrorCode.RESERVATION_ALREADY_CANCELED);
     }
 
+    updateReservationSlot(reservation);
+
     // 예약 상태 변경
     reservation.setStatus(ReservationStatus.CANCELED);
+  }
+
+  private void updateReservationSlot(Reservation reservation) {
+    List<ReservationSlot> slots = reservationSlotRepository.findByRoomAndReservedDateBetween(
+        reservation.getRoom(), reservation.getCheckInDate(),
+        reservation.getCheckOutDate().minusDays(1));
+
+    for (ReservationSlot slot : slots) {
+      slot.setIsReserved(false);
+    }
   }
 
   public CustomReservationResponse<HostReservationResponse> getHostReservation(Long hostId,

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
@@ -225,6 +225,7 @@ public class ReviewService {
     DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     return MyReviewResponse.builder()
+        .reviewId(review.getId())
         .accommodationName(review.getAccommodation().getName())
         .reviewImages(reviewImageResponses)
         .totalRating(totalRating)

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
@@ -26,9 +26,9 @@ import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReservationSlotRepository;
-import com.meongnyangerang.meongnyangerang.repository.room.RoomRepository;
+import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
-import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
+import com.meongnyangerang.meongnyangerang.repository.room.RoomRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -58,7 +58,7 @@ class ReservationServiceTest {
   private ReservationSlotRepository reservationSlotRepository;
 
   @Mock
-  private AccommodationRepository accommodationRepository;
+  private ReviewRepository reviewRepository;
 
   @Mock
   private UserRepository userRepository;
@@ -308,7 +308,6 @@ class ReservationServiceTest {
   void getUserReservation_success() {
     Long userId = 1L;
     Long cursorId = 0L;
-    Long accommodationId = 1L;
     int size = 20;
     ReservationStatus status = ReservationStatus.RESERVED;
 
@@ -387,12 +386,10 @@ class ReservationServiceTest {
         .thenReturn(list.stream()
             .filter(reservation -> reservation.getStatus() == status &&
                 reservation.getUser().getId().equals(userId))
-            .collect(Collectors.toList()));
+            .toList());
 
-    when(roomRepository.findById(101L)).thenReturn(Optional.of(room1));
-    when(roomRepository.findById(102L)).thenReturn(Optional.of(room2));
-
-    when(accommodationRepository.findById(accommodationId)).thenReturn(Optional.of(accommodation));
+    when(reviewRepository.existsByReservationId(r1.getId())).thenReturn(false);
+    when(reviewRepository.existsByReservationId(r2.getId())).thenReturn(true);
 
     CustomReservationResponse<UserReservationResponse> response = reservationService.getUserReservations(
         userId, cursorId, size,
@@ -400,6 +397,8 @@ class ReservationServiceTest {
 
     assertEquals(2, response.getContent().size());
     assertFalse(response.isHasNext());
+    assertEquals(false, response.getContent().get(0).isReviewWritten());
+    assertEquals(true, response.getContent().get(1).isReviewWritten());
   }
 
   @Test

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
@@ -421,13 +421,27 @@ class ReservationServiceTest {
         .createdAt(LocalDateTime.now())
         .build();
 
+    ReservationSlot slot1 = new ReservationSlot(room, reservation.getCheckInDate(), true);
+    ReservationSlot slot2 = new ReservationSlot(room, reservation.getCheckInDate().plusDays(1),
+        true);
+
+    List<ReservationSlot> slots = new ArrayList<>();
+    slots.add(slot1);
+    slots.add(slot2);
+
     when(reservationRepository.findById(reservation.getId())).thenReturn(Optional.of(reservation));
+    when(reservationSlotRepository.findByRoomAndReservedDateBetween(reservation.getRoom(),
+        reservation.getCheckInDate(), reservation.getCheckOutDate().minusDays(1)))
+        .thenReturn(slots);
 
     // when
     reservationService.cancelReservation(user.getId(), reservation.getId());
 
     // then
     verify(reservationRepository, times(1)).findById(reservation.getId());
+    verify(reservationSlotRepository, times(1)).findByRoomAndReservedDateBetween(
+        reservation.getRoom(), reservation.getCheckInDate(),
+        reservation.getCheckOutDate().minusDays(1));
     assertEquals(ReservationStatus.CANCELED, reservation.getStatus());
   }
 

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
@@ -2,7 +2,9 @@ package com.meongnyangerang.meongnyangerang.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -18,6 +20,7 @@ import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.dto.CustomReservationResponse;
 import com.meongnyangerang.meongnyangerang.dto.HostReservationResponse;
 import com.meongnyangerang.meongnyangerang.dto.ReservationRequest;
+import com.meongnyangerang.meongnyangerang.dto.ReservationResponse;
 import com.meongnyangerang.meongnyangerang.dto.UserReservationResponse;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
@@ -98,11 +101,13 @@ class ReservationServiceTest {
         roomId, checkOutDate.minusDays(1))).thenReturn(Optional.empty());
 
     // when
-    reservationService.createReservation(userId, request);
+    ReservationResponse response = reservationService.createReservation(userId, request);
 
     // then
     verify(reservationSlotRepository, times(1)).saveAll(any());
     verify(reservationRepository, times(1)).save(any());
+    assertNotNull(response.getOrderNumber());
+    assertTrue(response.getOrderNumber().matches("^[a-f0-9-]{36}$"));
   }
 
   @Test


### PR DESCRIPTION
## 📌 관련 이슈
- close #120 

## 📝 변경 사항
### AS-IS
-  예약 상태를 변경해주는 기능이 없었음.
- 예약 등록 시, 주문 번호를 반환 안했음.
- 예약 목록 조회 시, reservationId, reviewWritten 을 반환을 안해줬음.
- 예약 취소 시, 취소된 날짜의 예약 슬롯 상태를 변경을 안했었음.

### TO-BE
- 스케줄러를 통해 매일 새벽 2시에 체크아웃 날짜인 예약 목록을 불러와서 예약 상태를 RESERVED -> COMPLETED 로 변경함.
- 예약 등록 시, UUID 로 생성한 주문 번호를 반환하게 함.
- 예약 목록 조회 시, response 에 reservationId, reviewWritten 을 같이 반환하도록 함.
- 예약 취소 시, 취소된 날짜의 예약 슬롯 상태를 false 로 변경하도록 함.

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.