### PR TITLE
[Featuer] 알림 삭제 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/NotificationController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/NotificationController.java
@@ -16,7 +16,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -70,5 +72,25 @@ public class NotificationController {
     } else {
       throw new MeongnyangerangException(ErrorCode.INVALID_AUTHORIZED);
     }
+  }
+
+  /**
+   * 알림 삭제
+   */
+  @DeleteMapping("/{notificationId}")
+  public ResponseEntity<Void> deleteNotification(
+      @PathVariable Long notificationId,
+      @AuthenticationPrincipal UserDetailsImpl userDetails
+  ) {
+    Role viewerRole = userDetails.getRole();
+
+    if (viewerRole == Role.ROLE_USER) {
+      notificationService.deleteNotificationAsUser(notificationId, userDetails.getId());
+    } else if (viewerRole == Role.ROLE_HOST) {
+      notificationService.deleteNotificationAsHost(notificationId, userDetails.getId());
+    } else {
+      throw new MeongnyangerangException(ErrorCode.INVALID_AUTHORIZED);
+    }
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/NotificationRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/NotificationRepository.java
@@ -10,4 +10,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
   Page<Notification> findAllByUser_IdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
   Page<Notification> findAllByHost_IdOrderByCreatedAtDesc(Long hostId, Pageable pageable);
+
+  void deleteByIdAndUser_Id(Long notificationId, Long userId);
+
+  void deleteByIdAndHost_Id(Long notificationId, Long hostId);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/notification/NotificationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/notification/NotificationService.java
@@ -70,6 +70,23 @@ public class NotificationService {
     return PageResponse.from(response);
   }
 
+  /**
+   * 일반회원 알림 삭제
+   */
+  @Transactional
+  public void deleteNotificationAsUser(Long notificationId, Long userId) {
+    notificationRepository.deleteByIdAndUser_Id(notificationId, userId);
+  }
+
+  /**
+   * 호스트 알림 삭제
+   */
+  @Transactional
+  public void deleteNotificationAsHost(Long notificationId, Long hostId) {
+    notificationRepository.deleteByIdAndHost_Id(notificationId, hostId);
+  }
+
+
   private NotificationResponse createNotificationResponse(Notification notification) {
     return new NotificationResponse(
         notification.getId(),

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/notification/NotificationServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/notification/NotificationServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -286,6 +287,37 @@ class NotificationServiceTest {
     verify(notificationRepository).findAllByHost_IdOrderByCreatedAtDesc(host.getId(), pageable);
   }
 
+  @Test
+  @DisplayName("알림 삭제 - 사용자")
+  void deleteNotification_AsUser_Success() {
+    // given
+    Long userId = user.getId();
+    Long notificationId = 1L;
+    Notification notification = createNotificationReceiveByUser(
+        notificationId, user, "사용자 알림");
+
+    // when
+    notificationService.deleteNotificationAsUser(notification.getId(), userId);
+
+    // then
+    verify(notificationRepository).deleteByIdAndUser_Id(notificationId, userId);
+  }
+
+  @Test
+  @DisplayName("알림 삭제 - 호스트")
+  void deleteNotification_AsHost_Success() {
+    // given
+    Long hostId = host.getId();
+    Long notificationId = 1L;
+    Notification notification = createNotificationReceiveByHost(
+        notificationId, host, "호스트 알림");
+
+    // when
+    notificationService.deleteNotificationAsHost(notification.getId(), hostId);
+
+    // then
+    verify(notificationRepository).deleteByIdAndHost_Id(notificationId, hostId);
+  }
 
   private Notification createNotificationReceiveByHost(Long id, Host host, String content) {
     return Notification.builder()


### PR DESCRIPTION
## 📌 관련 이슈
- close #133 

## 📝 변경 사항
### AS-IS
- 알림 삭제 기능 부재

### TO-BE
- 요청받은 notificationId과 회원 ID, Role에 맞는 알림 제거
- 삭제한 데이터의 유뭉허 별개로 API성공하면 200 반환

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
![success](https://github.com/user-attachments/assets/11d32b14-f256-4179-a0e2-2c5595b784ae)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.