### PR TITLE
[Feature] 객실 상세 조회 API 구현(비로그인 포함 전체 사용자 대상)

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
                 "/ws/**",
                 "/api/v1/accommodations/{accommodationId}/reviews",
                 "/api/v1/search/accommodations",
-                "/api/v1/accommodations/{accommodationId}"
+                "/api/v1/accommodations/{accommodationId}",
+                "/api/v1/rooms/{roomId}"
             ).permitAll()
             .requestMatchers("/api/v1/users/**").hasAuthority("ROLE_USER")
             .requestMatchers("/api/v1/chats/users/create").hasAuthority("ROLE_USER")

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/PublicRoomController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/PublicRoomController.java
@@ -1,0 +1,25 @@
+package com.meongnyangerang.meongnyangerang.controller;
+
+import com.meongnyangerang.meongnyangerang.dto.room.RoomResponse;
+import com.meongnyangerang.meongnyangerang.service.RoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/rooms")
+public class PublicRoomController {
+
+  private final RoomService roomService;
+
+  // 객실 상세 조회 API
+  @GetMapping("/{roomId}")
+  public ResponseEntity<RoomResponse> getRoomDetail(@PathVariable Long roomId) {
+    RoomResponse response = roomService.getRoomDetail(roomId);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationDetailResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationDetailResponse.java
@@ -28,6 +28,7 @@ public class AccommodationDetailResponse {
   @Builder
   @Getter
   public static class ReviewSummary {
+    private Long reviewId;
     private Double reviewRating;
     private String content;
     private LocalDateTime createdAt;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
@@ -220,6 +220,7 @@ public class AccommodationService {
     double rounded = Math.round((review.getUserRating() + review.getPetFriendlyRating()) / 2.0 * 10) / 10.0; // 소수점 첫째자리까지 반올림
 
     return ReviewSummary.builder()
+        .reviewId(review.getId())
         .reviewRating(rounded)
         .content(review.getContent())
         .createdAt(review.getCreatedAt())

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
@@ -97,11 +97,7 @@ public class RoomService {
     Room room = roomRepository.findById(roomId)
         .orElseThrow(() -> new MeongnyangerangException(ROOM_NOT_FOUND));
 
-    List<RoomFacility> facilities = roomFacilityRepository.findAllByRoomId(roomId);
-    List<RoomPetFacility> petFacilities = roomPetFacilityRepository.findAllByRoomId(roomId);
-    List<Hashtag> hashtags = hashtagRepository.findAllByRoomId(roomId);
-
-    return RoomResponse.of(room, facilities, petFacilities, hashtags);
+    return createRoomResponse(room);
   }
 
   /**

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
@@ -1,5 +1,7 @@
 package com.meongnyangerang.meongnyangerang.service;
 
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ROOM_NOT_FOUND;
+
 import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
 import com.meongnyangerang.meongnyangerang.domain.room.Room;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.Hashtag;
@@ -80,11 +82,26 @@ public class RoomService {
   }
 
   /**
-   * 객실 상세 조회
+   * 객실 상세 조회(호스트 전용)
    */
   public RoomResponse getRoom(Long hostId, Long roomId) {
     Room room = getAuthorizedRoom(hostId, roomId);
     return createRoomResponse(room);
+  }
+
+  /**
+   * 객실 상세 조회(모든 사용자가 사용)
+   */
+  @Transactional(readOnly = true)
+  public RoomResponse getRoomDetail(Long roomId) {
+    Room room = roomRepository.findById(roomId)
+        .orElseThrow(() -> new MeongnyangerangException(ROOM_NOT_FOUND));
+
+    List<RoomFacility> facilities = roomFacilityRepository.findAllByRoomId(roomId);
+    List<RoomPetFacility> petFacilities = roomPetFacilityRepository.findAllByRoomId(roomId);
+    List<Hashtag> hashtags = hashtagRepository.findAllByRoomId(roomId);
+
+    return RoomResponse.of(room, facilities, petFacilities, hashtags);
   }
 
   /**
@@ -216,7 +233,7 @@ public class RoomService {
 
   private Room findRoomById(Long roomId) {
     return roomRepository.findById(roomId)
-        .orElseThrow(() -> new MeongnyangerangException(ErrorCode.ROOM_NOT_FOUND));
+        .orElseThrow(() -> new MeongnyangerangException(ROOM_NOT_FOUND));
   }
 
   private void validateRoomAuthorization(Accommodation accommodation, Room room) {

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationServiceTest.java
@@ -526,13 +526,13 @@ class AccommodationServiceTest {
     AccommodationDetailResponse response = accommodationService.getAccommodationDetail(1L);
 
     assertThat(response.getAccommodationId()).isEqualTo(1L);
-    assertThat(response.getAccommodationImages()).hasSize(2);
-    assertThat(response.getAccommodationFacility()).contains("와이파이");
-    assertThat(response.getAccommodationPetFacility()).contains("샤워장");
-    assertThat(response.getAllowPet()).contains("소형견");
-    assertThat(response.getRooms()).hasSize(1);
-    assertThat(response.getReview()).hasSize(1);
-    assertThat(response.getReview().get(0).getReviewRating()).isEqualTo(4.5); // (5+4)/2
+    assertThat(response.getAccommodationImageUrls()).hasSize(2);
+    assertThat(response.getAccommodationFacilities()).contains("와이파이");
+    assertThat(response.getAccommodationPetFacilities()).contains("샤워장");
+    assertThat(response.getAllowedPets()).contains("소형견");
+    assertThat(response.getRoomDetails()).hasSize(1);
+    assertThat(response.getReviews()).hasSize(1);
+    assertThat(response.getReviews().get(0).getReviewRating()).isEqualTo(4.5); // (5+4)/2
   }
 
   @Test

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/RoomServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/RoomServiceTest.java
@@ -2,6 +2,7 @@ package com.meongnyangerang.meongnyangerang.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -482,6 +483,57 @@ class RoomServiceTest {
     assertThatThrownBy(() -> roomService.getRoom(hostId, roomId))
         .isInstanceOf(MeongnyangerangException.class)
         .hasFieldOrPropertyWithValue("ErrorCode", ErrorCode.INVALID_AUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("객실 상세 조회(모든 사용자) - 성공")
+  void getRoomDetail_Success() {
+    // given
+    Long roomId = 1L;
+    Room room = Room.builder()
+        .id(roomId)
+        .name("펫룸")
+        .description("반려견 동반 가능")
+        .standardPeopleCount(2)
+        .maxPeopleCount(4)
+        .standardPetCount(1)
+        .maxPetCount(2)
+        .price(100_000L)
+        .extraFee(10_000L)
+        .extraPeopleFee(5_000L)
+        .extraPetFee(5_000L)
+        .checkInTime(LocalTime.of(15, 0))
+        .checkOutTime(LocalTime.of(11, 0))
+        .imageUrl("https://image.com/room.jpg")
+        .build();
+
+    List<RoomFacility> facilities = List.of(
+        RoomFacility.builder().type(RoomFacilityType.TV).build(),
+        RoomFacility.builder().type(RoomFacilityType.AIR_CONDITIONER).build()
+    );
+
+    List<RoomPetFacility> petFacilities = List.of(
+        RoomPetFacility.builder().type(RoomPetFacilityType.BED).build()
+    );
+
+    List<Hashtag> hashtags = List.of(
+        Hashtag.builder().type(HashtagType.SPA).build()
+    );
+
+    given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
+    given(facilityRepository.findAllByRoomId(roomId)).willReturn(facilities);
+    given(petFacilityRepository.findAllByRoomId(roomId)).willReturn(petFacilities);
+    given(hashtagRepository.findAllByRoomId(roomId)).willReturn(hashtags);
+
+    // when
+    RoomResponse result = roomService.getRoomDetail(roomId);
+
+    // then
+    assertThat(result.name()).isEqualTo("펫룸");
+    assertThat(result.standardPeopleCount()).isEqualTo(2);
+    assertThat(result.facilityTypes()).containsExactly("TV", "에어컨");
+    assertThat(result.petFacilityTypes()).contains("침대");
+    assertThat(result.hashtagTypes()).contains("스파");
   }
 
   @Test

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/RoomServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/RoomServiceTest.java
@@ -405,7 +405,7 @@ class RoomServiceTest {
   }
 
   @Test
-  @DisplayName("객실 상세 조회 성공")
+  @DisplayName("객실 상세 조회 성공(호스트 전용)")
   void getRoom_Success() {
     // given
     Long hostId = host.getId();
@@ -446,7 +446,7 @@ class RoomServiceTest {
 
 
   @Test
-  @DisplayName("객실이 존재하지 않을 때 예외 발생")
+  @DisplayName("객실 상세 조회(호스트 전용) - 객실이 존재하지 않을 때 예외 발생")
   void getRoom_RoomNotFound() {
     // given
     Long hostId = host.getId();
@@ -463,7 +463,7 @@ class RoomServiceTest {
   }
 
   @Test
-  @DisplayName("권한이 없을 때 예외 발생")
+  @DisplayName("객실 상세 조회(호스트 전용) - 권한이 없을 때 예외 발생")
   void getRoom_InvalidAuthorized() {
     // given
     Long hostId = host.getId();

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/RoomServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/RoomServiceTest.java
@@ -2,6 +2,7 @@ package com.meongnyangerang.meongnyangerang.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -534,6 +535,22 @@ class RoomServiceTest {
     assertThat(result.facilityTypes()).containsExactly("TV", "에어컨");
     assertThat(result.petFacilityTypes()).contains("침대");
     assertThat(result.hashtagTypes()).contains("스파");
+  }
+
+  @Test
+  @DisplayName("객실 상세 조회(모든 사용자) - 실패(존재하지 않는 roomId)")
+  void getRoomDetail_Fail_NotFound() {
+    // given
+    Long invalidRoomId = 999L;
+    given(roomRepository.findById(invalidRoomId)).willReturn(Optional.empty());
+
+    // when
+    Throwable throwable = catchThrowable(() -> roomService.getRoomDetail(invalidRoomId));
+
+    // then
+    assertThat(throwable).isInstanceOf(MeongnyangerangException.class);
+    MeongnyangerangException ex = (MeongnyangerangException) throwable;
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_FOUND);
   }
 
   @Test


### PR DESCRIPTION
## 📌 관련 이슈
- close #135 

## 📝 변경 사항
### AS-IS
- 모든 사용자용 객실 상세 조회 API 미구현

### TO-BE
- `PublicRoomController` 생성
- `GET /api/v1/rooms/{roomId}` 요청 처리
- RoomService 내 `getRoomDetail()` 메서드 구현
- RoomResponse DTO 재사용

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 객실 상세 조회 성공
![image](https://github.com/user-attachments/assets/b61acad8-1d91-48bf-9a1c-2f11b78981a9)

- 객실 상세 조회 실패(존재하지 않는 roomId)
![image](https://github.com/user-attachments/assets/ae73ffe2-e911-4f7f-8425-20eca49b2a3d)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
