### PR TITLE
[Feature] 예약 성공 시, 사용자와 호스트에게 알림 발송 로직 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/NotificationController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/NotificationController.java
@@ -43,9 +43,9 @@ public class NotificationController {
     Role role = userDetail.getRole();
 
     if (role == Role.ROLE_USER) {
-      notificationService.sendNotification(request, userDetail.getId(), SenderType.USER);
+      notificationService.sendMessageNotification(request, userDetail.getId(), SenderType.USER);
     } else if (role == Role.ROLE_HOST) {
-      notificationService.sendNotification(request, userDetail.getId(), SenderType.HOST);
+      notificationService.sendMessageNotification(request, userDetail.getId(), SenderType.HOST);
     } else {
       throw new MeongnyangerangException(ErrorCode.INVALID_AUTHORIZED);
     }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/notification/NotificationType.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/notification/NotificationType.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum NotificationType {
 
   MESSAGE("메세지"),
-  RESERVATION_CONFIRMED("예약 확인"),
+  RESERVATION_CONFIRMED("예약 확인"), // 사용자에게
+  RESERVATION_REGISTERED("예약 등록"), // 호스트에게
   RESERVATION_REMINDER("예약 리마인더"),
   REVIEW("리뷰");
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/notification/ReservationPayload.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/notification/ReservationPayload.java
@@ -1,0 +1,32 @@
+package com.meongnyangerang.meongnyangerang.dto.notification;
+
+import com.meongnyangerang.meongnyangerang.domain.chat.SenderType;
+import com.meongnyangerang.meongnyangerang.domain.notification.NotificationType;
+import java.time.LocalDateTime;
+
+public record ReservationPayload(
+    Long reservationId,
+    String content,
+    Long receiverId,
+    SenderType receiverType,
+    NotificationType notificationType,
+    LocalDateTime createdAt
+) {
+
+  public static ReservationPayload from(
+      Long reservationId,
+      String content,
+      Long receiverId,
+      SenderType receiverType,
+      NotificationType notificationType
+  ) {
+    return new ReservationPayload(
+        reservationId,
+        content,
+        receiverId,
+        receiverType,
+        notificationType,
+        LocalDateTime.now()
+    );
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/notification/NotificationAsyncService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/notification/NotificationAsyncService.java
@@ -3,6 +3,7 @@ package com.meongnyangerang.meongnyangerang.service.notification;
 import com.meongnyangerang.meongnyangerang.domain.chat.SenderType;
 import com.meongnyangerang.meongnyangerang.domain.notification.NotificationType;
 import com.meongnyangerang.meongnyangerang.dto.notification.NotificationPayload;
+import com.meongnyangerang.meongnyangerang.dto.notification.ReservationPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -19,7 +20,7 @@ public class NotificationAsyncService {
   private static final String NOTIFICATION_DESTINATION = "/subscribe/notifications";
 
   @Async
-  public void sendWebSocketNotification(
+  public void sendMessageNotification(
       Long chatRoomId,
       Long senderId,
       SenderType senderType,
@@ -42,9 +43,36 @@ public class NotificationAsyncService {
           NOTIFICATION_DESTINATION,
           payload
       );
-      log.debug("WebSocket 알림 전송 완료 - 수신자: {}", receiverKey);
+      log.debug("WebSocket 비동기 메시지 알림 전송 완료 - 수신자: {}", receiverKey);
     } catch (Exception e) {
-      log.error("WebSocket 알림 전송 중 오류 발생", e);
+      log.error("WebSocket 비동기 메시지 알림 전송 중 오류 발생", e);
+    }
+  }
+
+  @Async
+  public void sendReservationNotification(
+      Long reservationId,
+      String content,
+      Long receiverId,
+      SenderType receiverType,
+      NotificationType notificationType
+  ) {
+    try {
+      ReservationPayload payload = ReservationPayload.from(
+          reservationId, content,
+          receiverId, receiverType,
+          notificationType
+      );
+      String receiverKey = receiverType.name() + "_" + receiverId;
+
+      messagingTemplate.convertAndSendToUser(
+          receiverKey,
+          NOTIFICATION_DESTINATION,
+          payload
+      );
+      log.debug("WebSocket 비동기 예약 알림 전송 완료 - 수신자: {}", receiverKey);
+    } catch (Exception e) {
+      log.error("WebSocket 비동기 예약 알림 전송 중 오류 발생", e);
     }
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/notification/NotificationServiceTest.java
@@ -95,7 +95,7 @@ class NotificationServiceTest {
         ArgumentCaptor.forClass(Notification.class);
 
     // when
-    notificationService.sendNotification(request, user.getId(), SenderType.USER);
+    notificationService.sendMessageNotification(request, user.getId(), SenderType.USER);
 
     // Then
     verify(notificationRepository).save(notificationArgumentCaptor.capture());
@@ -105,7 +105,7 @@ class NotificationServiceTest {
     assertEquals(NotificationType.MESSAGE, notification.getType());
     assertFalse(notification.getIsRead());
 
-    verify(notificationAsyncSender).sendWebSocketNotification(
+    verify(notificationAsyncSender).sendMessageNotification(
         chatRoom.getId(),
         user.getId(),
         SenderType.USER,
@@ -131,7 +131,7 @@ class NotificationServiceTest {
         ArgumentCaptor.forClass(Notification.class);
 
     // when
-    notificationService.sendNotification(request, host.getId(), SenderType.HOST);
+    notificationService.sendMessageNotification(request, host.getId(), SenderType.HOST);
 
     // Then
     verify(notificationRepository).save(notificationArgumentCaptor.capture());
@@ -141,7 +141,7 @@ class NotificationServiceTest {
     assertEquals(NotificationType.MESSAGE, notification.getType());
     assertFalse(notification.getIsRead());
 
-    verify(notificationAsyncSender).sendWebSocketNotification(
+    verify(notificationAsyncSender).sendMessageNotification(
         chatRoom.getId(),
         host.getId(),
         SenderType.HOST,
@@ -165,7 +165,7 @@ class NotificationServiceTest {
     // when
     // then
     assertThatThrownBy(
-        () -> notificationService.sendNotification(request, user.getId(), SenderType.USER))
+        () -> notificationService.sendMessageNotification(request, user.getId(), SenderType.USER))
         .isInstanceOf(MeongnyangerangException.class)
         .hasFieldOrPropertyWithValue("ErrorCode", ErrorCode.NOT_EXIST_CHAT_ROOM);
   }
@@ -183,7 +183,7 @@ class NotificationServiceTest {
     // when
     // then
     assertThatThrownBy(
-        () -> notificationService.sendNotification(request, 999L, SenderType.HOST))
+        () -> notificationService.sendMessageNotification(request, 999L, SenderType.HOST))
         .isInstanceOf(MeongnyangerangException.class)
         .hasFieldOrPropertyWithValue("ErrorCode", ErrorCode.CHAT_ROOM_NOT_AUTHORIZED);
   }


### PR DESCRIPTION
## 📌 관련 이슈
- close #139 

## 📝 변경 사항
### AS-IS
- 예약 등록 성공하여도 알림 발송 안 됨

### TO-BE
- 예약 성공 시, 사용자와 호스트에게 알림 발송 로직 추가
- 숙소 등록 테스트 코드에 알림 발송 확인 로직 추가

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 예약 등록 성공
![success](https://github.com/user-attachments/assets/e1e6408e-a93b-424f-afbb-a98b66f1246d)

- 사용자 알림 수신
![success_user](https://github.com/user-attachments/assets/807af43a-2e35-4140-89f6-261355a10815)

- 호스트 알림 수신
![success_host](https://github.com/user-attachments/assets/b70c880a-12d2-4ee0-909b-53ae6c294e8b)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.