### PR TITLE
[Feature] 첫 객실 등록, 추가 객실 등록 & 숙소/객실 수정, 객실 삭제 시 엘라스틱 서치에 문서 저장 및 업데이트

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -88,7 +88,7 @@ public enum ErrorCode {
   SEARCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "숙소 검색 중 오류가 발생했습니다."),
   USER_RECOMMENDATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 맞춤 추천 조회 중 오류가 발생했습니다."),
   ELASTICSEARCH_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인덱스에 문서를 저장하는 도중 오류가 발생했습니다."),
-  DOCUMENT_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "문서를 업데이트 하는 도중 오류가 발생했습니다.")
+  DOCUMENT_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "해당 문서를 업데이트 하는 도중 오류가 발생했습니다.")
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -87,7 +87,8 @@ public enum ErrorCode {
   WEBSOCKET_SERVER_ERROR(HttpStatus.FORBIDDEN, "WebSocket 에러"),
   SEARCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "숙소 검색 중 오류가 발생했습니다."),
   USER_RECOMMENDATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 맞춤 추천 조회 중 오류가 발생했습니다."),
-  ELASTICSEARCH_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인덱스에 문서를 저장하는 도중 오류가 발생했습니다.")
+  ELASTICSEARCH_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인덱스에 문서를 저장하는 도중 오류가 발생했습니다."),
+  DOCUMENT_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "문서를 업데이트 하는 도중 오류가 발생했습니다.")
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -87,6 +87,7 @@ public enum ErrorCode {
   WEBSOCKET_SERVER_ERROR(HttpStatus.FORBIDDEN, "WebSocket 에러"),
   SEARCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "숙소 검색 중 오류가 발생했습니다."),
   USER_RECOMMENDATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 맞춤 추천 조회 중 오류가 발생했습니다."),
+  ELASTICSEARCH_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인덱스에 문서를 저장하는 도중 오류가 발생했습니다.")
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/room/RoomRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/room/RoomRepository.java
@@ -25,4 +25,6 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
   List<Room> findAllByAccommodationId(Long id);
 
   List<Room> findAllByAccommodationIdOrderByPriceAsc(Long accommodationId);
+
+  boolean existsByAccommodationId(Long accommodationId);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
@@ -141,7 +141,7 @@ public class AccommodationRoomSearchService {
     }
   }
 
-  // 추가 객실 등록 또는 숙소/객실 수정 시, 최소 가격과 반려동물 편의시설을 기존 문서에 업데이트
+  // 추가 객실 등록 또는 숙소/객실 수정, 객실 삭제 시, 최소 가격과 반려동물 편의시설을 기존 문서에 업데이트
   public void updateAccommodationDocument(Accommodation accommodation) {
     List<Room> rooms = roomRepository.findAllByAccommodationId(accommodation.getId());
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
@@ -163,7 +163,7 @@ public class AccommodationRoomSearchService {
           AccommodationDocument.class
       );
     } catch (IOException e) {
-      throw new MeongnyangerangException(ErrorCode.ELASTICSEARCH_SAVE_FAILED);
+      throw new MeongnyangerangException(ErrorCode.DOCUMENT_UPDATE_FAILED);
     }
   }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
@@ -6,6 +6,7 @@ import co.elastic.clients.elasticsearch.core.IndexResponse;
 import com.meongnyangerang.meongnyangerang.component.AccommodationRoomMapper;
 import com.meongnyangerang.meongnyangerang.domain.AccommodationRoomDocument;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationDocument;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.AllowPet;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.facility.AccommodationFacility;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.facility.AccommodationPetFacility;
@@ -13,14 +14,22 @@ import com.meongnyangerang.meongnyangerang.domain.room.Room;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.Hashtag;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomFacility;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomPetFacility;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
+import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationFacilityRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationPetFacilityRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AllowPetRepository;
 import com.meongnyangerang.meongnyangerang.repository.room.HashtagRepository;
 import com.meongnyangerang.meongnyangerang.repository.room.RoomFacilityRepository;
 import com.meongnyangerang.meongnyangerang.repository.room.RoomPetFacilityRepository;
+import com.meongnyangerang.meongnyangerang.repository.room.RoomRepository;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -39,6 +48,7 @@ public class AccommodationRoomSearchService {
   private final AccommodationFacilityRepository accommodationFacilityRepository;
   private final AccommodationPetFacilityRepository accommodationPetFacilityRepository;
   private final AllowPetRepository allowPetRepository;
+  private final RoomRepository roomRepository;
 
   /**
    * 객실 등록 또는 숙소/객실 수정 시 색인 저장
@@ -109,5 +119,96 @@ public class AccommodationRoomSearchService {
     for (Room room : rooms) {
       save(accommodation, room);
     }
+  }
+
+  // 첫 객실 등록 시, 색인하여 accommodations 인덱스에 문서를 저장
+  public void indexAccommodationDocument(Accommodation accommodation, Room room) {
+    Set<String> allowedPetTypes = getAllowedPetTypes(accommodation);
+
+    Set<String> accommodationPetFacilities = getAccommodationPetFacilities(accommodation);
+
+    Set<String> roomPetFacilities = getRoomPetFacilities(room);
+
+    AccommodationDocument document = toDocument(
+        accommodation, room, accommodationPetFacilities, allowedPetTypes, roomPetFacilities);
+
+    try {
+      elasticsearchClient.index(index -> index.index("accommodations")
+          .id(document.getId().toString())
+          .document(document));
+    } catch (IOException e) {
+      throw new MeongnyangerangException(ErrorCode.ELASTICSEARCH_SAVE_FAILED);
+    }
+  }
+
+  // 추가 객실 등록 또는 숙소/객실 수정 시, 최소 가격과 반려동물 편의시설을 기존 문서에 업데이트
+  public void updateAccommodationDocument(Accommodation accommodation) {
+    List<Room> rooms = roomRepository.findAllByAccommodationId(accommodation.getId());
+
+    Set<String> updatedAccommodationPetFacilities = getAccommodationPetFacilities(accommodation);
+    Set<String> updatedRoomPetFacilities = collectRoomPetFacilities(rooms);
+    long minPrice = calculateMinRoomPrice(rooms);
+
+    Map<String, Object> doc = Map.of(
+        "price", minPrice,
+        "accommodationPetFacilities", updatedAccommodationPetFacilities,
+        "roomPetFacilities", updatedRoomPetFacilities
+    );
+
+    try {
+      elasticsearchClient.update(
+          u -> u.index("accommodations")
+              .id(accommodation.getId().toString())
+              .doc(doc),
+          AccommodationDocument.class
+      );
+    } catch (IOException e) {
+      throw new MeongnyangerangException(ErrorCode.ELASTICSEARCH_SAVE_FAILED);
+    }
+  }
+
+  private Set<String> collectRoomPetFacilities(List<Room> rooms) {
+    return rooms.stream()
+        .flatMap(r -> roomPetFacilityRepository.findAllByRoomId(r.getId()).stream())
+        .map(f -> f.getType().name())
+        .collect(Collectors.toSet());
+  }
+
+  private long calculateMinRoomPrice(List<Room> rooms) {
+    return rooms.stream()
+        .map(Room::getPrice)
+        .min(Long::compareTo).orElse(0L);
+  }
+
+  private AccommodationDocument toDocument(Accommodation accommodation,
+      Room room, Set<String> accommodationPetFacilities, Set<String> allowedPetTypes,
+      Set<String> roomPetFacilities) {
+    return AccommodationDocument.builder()
+        .id(accommodation.getId())
+        .name(accommodation.getName())
+        .thumbnailUrl(accommodation.getThumbnailUrl())
+        .price(room.getPrice())
+        .totalRating(accommodation.getTotalRating())
+        .accommodationPetFacilities(accommodationPetFacilities)
+        .allowedPetTypes(allowedPetTypes)
+        .roomPetFacilities(roomPetFacilities)
+        .build();
+  }
+
+  private Set<String> getRoomPetFacilities(Room room) {
+    return roomPetFacilityRepository.findAllByRoomId(room.getId())
+        .stream().map(RoomPetFacility::getType).map(Enum::name).collect(Collectors.toSet());
+  }
+
+  private Set<String> getAccommodationPetFacilities(Accommodation accommodation) {
+    return accommodationPetFacilityRepository.findAllByAccommodationId(
+            accommodation.getId()).stream().map(AccommodationPetFacility::getType).map(Enum::name)
+        .collect(Collectors.toSet());
+  }
+
+  private Set<String> getAllowedPetTypes(Accommodation accommodation) {
+    return allowPetRepository.findAllByAccommodationId(
+            accommodation.getId()).stream().map(AllowPet::getPetType).map(Enum::name)
+        .collect(Collectors.toSet());
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
@@ -86,7 +86,7 @@ public class AccommodationRoomSearchService {
     } catch (IOException e) {
       log.error("Elasticsearch 색인 실패: 숙소 {}, 객실 {}, 에러: {}", accommodation.getId(), room.getId(),
           e.getMessage());
-      throw new RuntimeException("Elasticsearch 색인 실패", e);
+      throw new MeongnyangerangException(ErrorCode.ELASTICSEARCH_SAVE_FAILED);
     }
   }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
@@ -135,6 +135,7 @@ public class AccommodationService {
       // 색인 갱신 - 객실이 있을 경우에만
       List<Room> rooms = roomRepository.findAllByAccommodationId(accommodation.getId());
       searchService.updateAllRooms(accommodation, rooms);
+      searchService.updateAccommodationDocument(accommodation);
 
       log.info("숙소 수정 성공, 숙소 ID : {}", accommodation.getId());
       return createAccommodationResponse(accommodation);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
@@ -147,11 +147,14 @@ public class RoomService {
   @Transactional
   public void deleteRoom(Long hostId, Long roomId) {
     Room room = getAuthorizedRoom(hostId, roomId);
+    Accommodation accommodation = room.getAccommodation();
+
     hashtagRepository.deleteAllByRoomId(roomId);
     roomPetFacilityRepository.deleteAllByRoomId(roomId);
     roomFacilityRepository.deleteAllByRoomId(roomId);
     roomRepository.delete(room);
     searchService.delete(room.getAccommodation().getId(), roomId); // Elasticsearch 색인 삭제
+    searchService.updateAccommodationDocument(accommodation);
   }
 
   private List<RoomFacility> updateFacilities(List<RoomFacilityType> newFacilityTypes, Room room) {

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/RoomService.java
@@ -58,6 +58,12 @@ public class RoomService {
     saveRoomPetFacilities(request.petFacilityTypes(), room);
     saveHashtags(request.hashtagTypes(), room);
     searchService.save(accommodation, room); // Elasticsearch 색인 저장
+
+    if (roomRepository.findAllByAccommodationId(accommodation.getId()).size() > 1) {
+      searchService.updateAccommodationDocument(accommodation);
+    } else {
+      searchService.indexAccommodationDocument(accommodation, room);
+    }
   }
 
   /**
@@ -124,6 +130,7 @@ public class RoomService {
       List<Hashtag> updatedHashtags = updateHashtags(request.hashtagTypes(), room);
 
       searchService.save(room.getAccommodation(), updatedRoom); // Elasticsearch 색인 업데이트
+      searchService.updateAccommodationDocument(room.getAccommodation());
 
       return RoomResponse.of(updatedRoom, updatedFacilities, updatedPetFacilities, updatedHashtags);
     } catch (Exception e) {


### PR DESCRIPTION
## 📌 관련 이슈
- close #140 

## 📝 변경 사항
### AS-IS
- 추천 시스템 로직은 구현했었지만, 추천해줄 숙소가 들어있는 문서들을 저장하는 기능이 없었음.

### TO-BE
- 첫 객실 등록 시, 색인하여 accommodations 인덱스에 문서를 저장하도록 함.
- 추가 객실 등록 & 숙소/객실 수정 시, 해당 문서를 업데이트 하도록 함.

## 🔍 테스트
- [] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 첫 객실 등록
![객실 등록 시 요청 사진 postman](https://github.com/user-attachments/assets/110c469d-627b-4dbb-a263-378bc2aa9957)
![객실 등록 시 엘라스틱 서치에 색인되어 저장 확인](https://github.com/user-attachments/assets/fad13824-74c6-46be-a17e-8274db661d0c)
- 추가 객실 등록 (가격 변경 확인 가능)
![2번째 객실 등록 요청 사진 postman](https://github.com/user-attachments/assets/f0b8b410-f7a9-44cc-a91f-ce99f44c3f15)
![2번째 객실 등록 시 엘라스틱 서치에 update 성공](https://github.com/user-attachments/assets/990c5d10-e7b4-456e-8333-c0f88c1f844a)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
