### PR TITLE
[Feature] 사용자 프로필 조회 기능 및 CORS 설정 추가

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meongnyangerang.meongnyangerang.jwt.JwtAuthenticationFilter;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Slf4j
 @Configuration
@@ -30,6 +34,7 @@ public class SecurityConfig {
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
+        .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 설정
         .csrf(csrf -> csrf.disable()) // CSRF 보호 비활성화
         // 세션 비활성화(세션을 사용하지 않고 JWT 인증 방식 사용)
         .sessionManagement(
@@ -86,6 +91,19 @@ public class SecurityConfig {
             })
         );
     return http.build();
+  }
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration config = new CorsConfiguration();
+    config.setAllowedOriginPatterns(List.of("http://localhost:5173"));
+    config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+    config.setAllowedHeaders(List.of("*"));
+    config.setAllowCredentials(true);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return source;
   }
 
   @Bean

--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/WebConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/WebConfig.java
@@ -9,7 +9,7 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/**")
-        .allowedOrigins("*") // 또는 프론트엔드 실제 주소만
+        .allowedOrigins("http://localhost:5173/") // 또는 프론트엔드 실제 주소만
         .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
         .allowCredentials(true);
   }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/WebConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.meongnyangerang.meongnyangerang.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/**")
+        .allowedOrigins("*") // 또는 프론트엔드 실제 주소만
+        .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+        .allowCredentials(true);
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserController.java
@@ -2,6 +2,7 @@ package com.meongnyangerang.meongnyangerang.controller;
 
 import com.meongnyangerang.meongnyangerang.dto.LoginRequest;
 import com.meongnyangerang.meongnyangerang.dto.LoginResponse;
+import com.meongnyangerang.meongnyangerang.dto.UserProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.UserSignupRequest;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.UserService;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserController.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -46,5 +47,12 @@ public class UserController {
   public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
     userService.deleteUser(userDetails.getId());
     return ResponseEntity.ok().build();
+  }
+
+  // 사용자 프로필 조회 API
+  @GetMapping("/me")
+  public ResponseEntity<UserProfileResponse> getMyProfile(
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    return ResponseEntity.ok(userService.getMyProfile(userDetails.getId()));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/UserProfileResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/UserProfileResponse.java
@@ -1,0 +1,21 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import com.meongnyangerang.meongnyangerang.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UserProfileResponse {
+  private String nickname;
+  private String profileImageUrl;
+
+  public static UserProfileResponse of(User user) {
+    return UserProfileResponse.builder()
+        .nickname(user.getNickname())
+        .profileImageUrl(user.getProfileImage())
+        .build();
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -12,6 +12,7 @@ import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.RESERVED_R
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.dto.LoginRequest;
+import com.meongnyangerang.meongnyangerang.dto.UserProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.UserSignupRequest;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.jwt.JwtTokenProvider;
@@ -95,5 +96,14 @@ public class UserService {
 
     user.setStatus(DELETED);
     user.setDeletedAt(LocalDateTime.now());
+  }
+
+  // 사용자 프로필 조회
+  @Transactional(readOnly = true)
+  public UserProfileResponse getMyProfile(Long userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
+
+    return UserProfileResponse.of(user);
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.meongnyangerang.meongnyangerang.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -7,12 +8,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
+import com.meongnyangerang.meongnyangerang.dto.UserProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.UserSignupRequest;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
@@ -146,5 +149,26 @@ class UserServiceTest {
 
     // when & then
     assertThrows(MeongnyangerangException.class, () -> userService.deleteUser(userId));
+  }
+
+  @Test
+  @DisplayName("사용자 프로필 조회 - 성공")
+  void getUserProfile_Success() {
+    // given
+    Long userId = 1L;
+    User user = User.builder()
+        .id(userId)
+        .nickname("멍냥이")
+        .profileImage("https://profile.jpg")
+        .build();
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+    // when
+    UserProfileResponse response = userService.getMyProfile(userId);
+
+    // then
+    assertThat(response.getNickname()).isEqualTo("멍냥이");
+    assertThat(response.getProfileImageUrl()).isEqualTo("https://profile.jpg");
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
@@ -1,6 +1,7 @@
 package com.meongnyangerang.meongnyangerang.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -17,6 +18,7 @@ import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
 import com.meongnyangerang.meongnyangerang.dto.UserProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.UserSignupRequest;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
@@ -170,5 +172,19 @@ class UserServiceTest {
     // then
     assertThat(response.getNickname()).isEqualTo("멍냥이");
     assertThat(response.getProfileImageUrl()).isEqualTo("https://profile.jpg");
+  }
+
+  @Test
+  @DisplayName("사용자 프로필 조회 - 실패 (존재하지 않는 사용자)")
+  void getUserProfile_Fail_UserNotFound() {
+    // given
+    Long invalidUserId = 999L;
+    given(userRepository.findById(invalidUserId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> userService.getMyProfile(invalidUserId))
+        .isInstanceOf(MeongnyangerangException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.NOT_EXIST_ACCOUNT);
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #143 

## 📝 변경 사항
### AS-IS
- 사용자 프로필 조회 기능 미구현
- 프론트엔드 개발 환경 연동을 위한 CORS 설정 미구현

### TO-BE
- `GET /api/v1/users/me` API로 사용자 닉네임, 프로필 이미지 반환
- CORS 설정 추가 (`http://localhost:5173/` 허용, allowCredentials: true)

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 사용자 프로필 조회 성공
![image](https://github.com/user-attachments/assets/cf1b7919-56ab-4352-a8bd-5c0963073092)

- 사용자 프로필 조회 실패(인증되지 않은 사용자)
![image](https://github.com/user-attachments/assets/b17ddeac-528c-4887-b51b-debbf06cd0e4)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
