### PR TITLE
[Feature] 호스트 프로필 조회 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
@@ -1,5 +1,6 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
+import com.meongnyangerang.meongnyangerang.dto.HostProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.HostSignupRequest;
 import com.meongnyangerang.meongnyangerang.dto.LoginRequest;
 import com.meongnyangerang.meongnyangerang.dto.LoginResponse;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -48,5 +49,12 @@ public class HostController {
   public ResponseEntity<Void> deleteHost(@AuthenticationPrincipal UserDetailsImpl userDetails) {
     hostService.deleteHost(userDetails.getId());
     return ResponseEntity.ok().build();
+  }
+
+  // 호스트 프로필 조회 API
+  @GetMapping("/me")
+  public ResponseEntity<HostProfileResponse> getHostProfile(
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    return ResponseEntity.ok(hostService.getHostProfile(userDetails.getId()));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/HostProfileResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/HostProfileResponse.java
@@ -1,0 +1,26 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import com.meongnyangerang.meongnyangerang.domain.host.Host;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class HostProfileResponse {
+
+  private String name;
+  private String nickname;
+  private String phone;
+  private String profileImageUrl;
+
+  public static HostProfileResponse of(Host host) {
+    return HostProfileResponse.builder()
+        .name(host.getName())
+        .nickname(host.getNickname())
+        .phone(host.getPhoneNumber())
+        .profileImageUrl(host.getProfileImageUrl())
+        .build();
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -115,4 +115,13 @@ public class HostService {
     host.setStatus(HostStatus.DELETED);
     host.setDeletedAt(LocalDateTime.now());
   }
+
+  // 호스트 프로필 조회
+  @Transactional(readOnly = true)
+  public HostProfileResponse getHostProfile(Long hostId) {
+    Host host = hostRepository.findById(hostId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
+
+    return HostProfileResponse.of(host);
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -13,6 +13,7 @@ import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.RESERVED_R
 
 import com.meongnyangerang.meongnyangerang.domain.host.Host;
 import com.meongnyangerang.meongnyangerang.domain.host.HostStatus;
+import com.meongnyangerang.meongnyangerang.dto.HostProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.HostSignupRequest;
 import com.meongnyangerang.meongnyangerang.dto.LoginRequest;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -1,5 +1,7 @@
 package com.meongnyangerang.meongnyangerang.service;
 
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,6 +20,7 @@ import com.meongnyangerang.meongnyangerang.domain.host.HostStatus;
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
 import com.meongnyangerang.meongnyangerang.dto.HostProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.HostSignupRequest;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.HostRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
@@ -164,4 +167,16 @@ class HostServiceTest {
     assertThat(response.getProfileImageUrl()).isEqualTo("https://example.com/image.jpg");
   }
 
+  @Test
+  @DisplayName("호스트 프로필 조회 - 실패 (존재하지 않는 계정)")
+  void getHostProfile_Fail_NotFound() {
+    // given
+    Long hostId = 999L;
+    Mockito.when(hostRepository.findById(hostId)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> hostService.getHostProfile(hostId))
+        .isInstanceOf(MeongnyangerangException.class)
+        .hasFieldOrPropertyWithValue("errorCode", NOT_EXIST_ACCOUNT);
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -1,5 +1,6 @@
 package com.meongnyangerang.meongnyangerang.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.when;
 import com.meongnyangerang.meongnyangerang.domain.host.Host;
 import com.meongnyangerang.meongnyangerang.domain.host.HostStatus;
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
+import com.meongnyangerang.meongnyangerang.dto.HostProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.HostSignupRequest;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.HostRepository;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -134,4 +137,31 @@ class HostServiceTest {
     // when & then
     assertThrows(MeongnyangerangException.class, () -> hostService.deleteHost(hostId));
   }
+
+  @Test
+  @DisplayName("호스트 프로필 조회 - 성공")
+  void getHostProfile_Success() {
+    // given
+    Long hostId = 1L;
+
+    Host host = Host.builder()
+        .id(hostId)
+        .name("홍길동")
+        .nickname("길동이")
+        .phoneNumber("010-1234-5678")
+        .profileImageUrl("https://example.com/image.jpg")
+        .build();
+
+    Mockito.when(hostRepository.findById(hostId)).thenReturn(Optional.of(host));
+
+    // when
+    HostProfileResponse response = hostService.getHostProfile(hostId);
+
+    // then
+    assertThat(response.getName()).isEqualTo("홍길동");
+    assertThat(response.getNickname()).isEqualTo("길동이");
+    assertThat(response.getPhone()).isEqualTo("010-1234-5678");
+    assertThat(response.getProfileImageUrl()).isEqualTo("https://example.com/image.jpg");
+  }
+
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #147 

## 📝 변경 사항
### AS-IS
- 호스트 프로필 조회 기능 미구현 상태

### TO-BE
- GET /api/v1/hosts/me API를 통해 호스트 정보 응답
- HostProfileResponse DTO 추가 및 정적 팩토리 메서드 도입
- HostService에 getHostProfile 서비스 메서드 구현
- 테스트 코드 작성 (성공/실패 케이스)

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 호스트 프로필 조회 성공
![image](https://github.com/user-attachments/assets/668dbc83-4c82-4f50-be21-f578016e24c1)

- 호스트 프로필 조회 실패(인증되지 않은 사용자)
![image](https://github.com/user-attachments/assets/363f7b46-28b7-4a10-bf02-26f2d34852ca)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
