### PR TITLE
[Refactor] 객실 수정: roomId 반환 값 추가 및 S3 롤백 코드 제거

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/room/RoomResponse.java
@@ -8,6 +8,7 @@ import java.time.LocalTime;
 import java.util.List;
 
 public record RoomResponse(
+    Long roomId,
     String name,
     String description,
     Integer standardPeopleCount,
@@ -45,6 +46,7 @@ public record RoomResponse(
         .toList();
 
     return new RoomResponse(
+        room.getId(),
         room.getName(), room.getDescription(),
         room.getStandardPeopleCount(), room.getMaxPeopleCount(),
         room.getStandardPetCount(), room.getMaxPetCount(),

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/RoomServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/RoomServiceTest.java
@@ -73,6 +73,9 @@ class RoomServiceTest {
   @Mock
   private ImageService imageService;
 
+  @Mock
+  private AccommodationRoomSearchService searchService;
+
   @InjectMocks
   private RoomService roomService;
 
@@ -101,7 +104,7 @@ class RoomServiceTest {
         "image",
         imageUrl,
         "image/jpeg",
-        "test image content".getBytes()
+        "test image content" .getBytes()
     );
 
     imageUrl = "https://example.com/images/test-image.jpg";
@@ -561,7 +564,7 @@ class RoomServiceTest {
         "image",
         imageUrl,
         "image/jpeg",
-        "test image content".getBytes()
+        "test image content" .getBytes()
     );
 
     when(accommodationRepository.findByHostId(host.getId()))
@@ -572,6 +575,7 @@ class RoomServiceTest {
     RoomResponse response = roomService.updateRoom(host.getId(), roomUpdateRequest, newImage);
 
     // then
+    assertThat(response.roomId()).isEqualTo(room.getId());
     assertThat(response.name()).isEqualTo(roomUpdateRequest.name());
     assertThat(response.description()).isEqualTo(roomUpdateRequest.description());
     assertThat(response.standardPeopleCount()).isEqualTo(roomUpdateRequest.standardPeopleCount());


### PR DESCRIPTION
## 📌 관련 이슈
- close #152

## 📝 변경 사항
### AS-IS
- 객실 수정 예외 발생 시 S3 롤백
- 객실 수정 API 반환 값에서 roomId 없음

### TO-BE
- 객실 수정 서비스 로직에서 S3 롤백 로직 제거하여 코드 가독성 향상 및 불필요한 try/catch 구문 제거
- 객실 수정 API 반환 값으로 roomId를 추가

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 반환 값으로 roomId 추가
![new_success](https://github.com/user-attachments/assets/25cd58cf-8c04-4a1c-9b66-489bea9b7f83)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.