### PR TITLE
[Feature]  호스트 전화번호 변경 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -57,5 +58,15 @@ public class HostController {
   public ResponseEntity<HostProfileResponse> getHostProfile(
       @AuthenticationPrincipal UserDetailsImpl userDetails) {
     return ResponseEntity.ok(hostService.getHostProfile(userDetails.getId()));
+  }
+
+  // 호스트 전화번호 변경 API
+  @PatchMapping("/me/phone")
+  public ResponseEntity<Void> updatePhoneNumber(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @Valid @RequestBody HostPhoneUpdateRequest request
+  ) {
+    hostService.updatePhoneNumber(userDetails.getId(), request.phoneNumber());
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
@@ -1,5 +1,6 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
+import com.meongnyangerang.meongnyangerang.dto.HostPhoneUpdateRequest;
 import com.meongnyangerang.meongnyangerang.dto.HostProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.HostSignupRequest;
 import com.meongnyangerang.meongnyangerang.dto.LoginRequest;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/host/Host.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/host/Host.java
@@ -72,4 +72,8 @@ public class Host {
   private LocalDateTime updatedAt;
 
   private LocalDateTime deletedAt;
+
+  public void updatePhoneNumber(String newPhoneNumber) {
+    this.phoneNumber = newPhoneNumber;
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/HostPhoneUpdateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/HostPhoneUpdateRequest.java
@@ -5,12 +5,10 @@ import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
-public class HostPhoneUpdateRequest {
+public record HostPhoneUpdateRequest(
+    @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", message = "유효하지 않은 전화번호 형식입니다")
+    @NotBlank(message = "새로운 전화번호를 입력하세요.")
+    String phoneNumber
+) {}
 
-  @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", message = "유효하지 않은 전화번호 형식입니다")
-  @NotBlank(message = "새로운 전화번호를 입력하세요.")
-  private String phoneNumber;
 
-}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/HostPhoneUpdateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/HostPhoneUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class HostPhoneUpdateRequest {
+
+  @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", message = "유효하지 않은 전화번호 형식입니다")
+  @NotBlank(message = "새로운 전화번호를 입력하세요.")
+  private String phoneNumber;
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/HostPhoneUpdateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/HostPhoneUpdateRequest.java
@@ -2,8 +2,6 @@ package com.meongnyangerang.meongnyangerang.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
 public record HostPhoneUpdateRequest(
     @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", message = "유효하지 않은 전화번호 형식입니다")

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
   MISSING_IMAGE_URL(HttpStatus.BAD_REQUEST, "이미지 URL이 비어있습니다."),
   MAX_PET_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "반려동물은 최대 10마리까지 등록할 수 있습니다."),
   ALREADY_REGISTERED_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 등록된 전화번호입니다."),
+  DUPLICATE_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 사용 중인 전화번호입니다."),
 
 
   // 400 BAD REQUEST (JWT 관련 요청 오류)

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
   MISSING_IMAGE_FILE(HttpStatus.BAD_REQUEST, "파일이 비어있습니다."),
   MISSING_IMAGE_URL(HttpStatus.BAD_REQUEST, "이미지 URL이 비어있습니다."),
   MAX_PET_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "반려동물은 최대 10마리까지 등록할 수 있습니다."),
+  ALREADY_REGISTERED_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 등록된 전화번호입니다."),
 
 
   // 400 BAD REQUEST (JWT 관련 요청 오류)

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/HostRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/HostRepository.java
@@ -30,4 +30,6 @@ public interface HostRepository extends JpaRepository<Host, Long> {
       @Param("status") String status);
 
   Optional<Host> findByIdAndStatus(Long id, HostStatus status);
+
+  boolean existByPhoneNumberAndIdNot(String phoneNumber, Long hostId);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/HostRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/HostRepository.java
@@ -31,5 +31,5 @@ public interface HostRepository extends JpaRepository<Host, Long> {
 
   Optional<Host> findByIdAndStatus(Long id, HostStatus status);
 
-  boolean existByPhoneNumberAndIdNot(String phoneNumber, Long hostId);
+  boolean existsByPhoneNumberAndIdNot(String phoneNumber, Long hostId);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -5,6 +5,7 @@ import static com.meongnyangerang.meongnyangerang.domain.reservation.Reservation
 import static com.meongnyangerang.meongnyangerang.domain.user.Role.ROLE_HOST;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOUNT_DELETED;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOUNT_PENDING;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ALREADY_REGISTERED_PHONE_NUMBER;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_EMAIL;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.FILE_IS_EMPTY;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.INVALID_PASSWORD;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -142,7 +142,7 @@ public class HostService {
     }
 
     // 다른 호스트가 이미 해당 전화번호를 사용중일 시 예외처리
-    if (hostRepository.existByPhoneNumberAndIdNot(newPhoneNumber, hostId)) {
+    if (hostRepository.existsByPhoneNumberAndIdNot(newPhoneNumber, hostId)) {
       throw new MeongnyangerangException(DUPLICATE_PHONE_NUMBER);
     }
     host.updatePhoneNumber(newPhoneNumber);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -145,7 +145,6 @@ public class HostService {
     if (hostRepository.existByPhoneNumberAndIdNot(newPhoneNumber, hostId)) {
       throw new MeongnyangerangException(DUPLICATE_PHONE_NUMBER);
     }
-
-
+    host.updatePhoneNumber(newPhoneNumber);
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -23,6 +23,8 @@ import com.meongnyangerang.meongnyangerang.repository.HostRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
 import com.meongnyangerang.meongnyangerang.service.image.ImageService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -124,5 +126,18 @@ public class HostService {
         .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
 
     return HostProfileResponse.of(host);
+  }
+
+  // 호스트 전화번호 변경
+  @Transactional
+  public void updatePhoneNumber(Long hostId, String newPhoneNumber) {
+    Host host = hostRepository.findById(hostId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
+
+    // 바꾸려는 전화번호가 기존의 전화번호와 같을 시 예외처리
+    if (host.getPhoneNumber().equals(newPhoneNumber)) {
+      throw new MeongnyangerangException(ALREADY_REGISTERED_PHONE_NUMBER);
+    }
+
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -146,5 +146,6 @@ public class HostService {
       throw new MeongnyangerangException(DUPLICATE_PHONE_NUMBER);
     }
 
+
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -7,6 +7,7 @@ import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOUNT_DE
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOUNT_PENDING;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ALREADY_REGISTERED_PHONE_NUMBER;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_EMAIL;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_PHONE_NUMBER;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.FILE_IS_EMPTY;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.INVALID_PASSWORD;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_ACCOUNT;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -140,5 +140,10 @@ public class HostService {
       throw new MeongnyangerangException(ALREADY_REGISTERED_PHONE_NUMBER);
     }
 
+    // 다른 호스트가 이미 해당 전화번호를 사용중일 시 예외처리
+    if (hostRepository.existByPhoneNumberAndIdNot(newPhoneNumber, hostId)) {
+      throw new MeongnyangerangException(DUPLICATE_PHONE_NUMBER);
+    }
+
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -241,5 +241,28 @@ class HostServiceTest {
         .isEqualTo(ErrorCode.ALREADY_REGISTERED_PHONE_NUMBER);
   }
 
+  @Test
+  @DisplayName("호스트 전화번호 변경 - 실패 (중복된 전화번호)")
+  void updatePhoneNumber_Fail_DuplicatePhone() {
+    // given
+    Long hostId = 1L;
+    String oldPhone = "010-1234-5678";
+    String newPhone = "010-8888-9999";
+
+    Host host = Host.builder()
+        .id(hostId)
+        .phoneNumber(oldPhone)
+        .build();
+
+    given(hostRepository.findById(hostId)).willReturn(Optional.of(host));
+    given(hostRepository.existByPhoneNumberAndIdNot(newPhone, hostId)).willReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> hostService.updatePhoneNumber(hostId, newPhone))
+        .isInstanceOf(MeongnyangerangException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.DUPLICATE_PHONE_NUMBER);
+  }
+
 
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -220,5 +220,26 @@ class HostServiceTest {
         .isEqualTo(NOT_EXIST_ACCOUNT);
   }
 
+  @Test
+  @DisplayName("호스트 전화번호 변경 - 실패 (기존 전화번호와 동일)")
+  void updatePhoneNumber_Fail_SamePhone() {
+    // given
+    Long hostId = 1L;
+    String phone = "010-1234-5678";
+
+    Host host = Host.builder()
+        .id(hostId)
+        .phoneNumber(phone)
+        .build();
+
+    given(hostRepository.findById(hostId)).willReturn(Optional.of(host));
+
+    // when & then
+    assertThatThrownBy(() -> hostService.updatePhoneNumber(hostId, phone))
+        .isInstanceOf(MeongnyangerangException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.ALREADY_REGISTERED_PHONE_NUMBER);
+  }
+
 
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -179,4 +180,28 @@ class HostServiceTest {
         .isInstanceOf(MeongnyangerangException.class)
         .hasFieldOrPropertyWithValue("errorCode", NOT_EXIST_ACCOUNT);
   }
+
+  @Test
+  @DisplayName("호스트 전화번호 변경 - 성공")
+  void updatePhoneNumber_Success() {
+    // given
+    Long hostId = 1L;
+    String originalPhone = "010-1234-5678";
+    String newPhone = "010-9999-8888";
+
+    Host host = Host.builder()
+        .id(hostId)
+        .phoneNumber(originalPhone)
+        .build();
+
+    given(hostRepository.findById(hostId)).willReturn(Optional.of(host));
+    given(hostRepository.existByPhoneNumberAndIdNot(newPhone, hostId)).willReturn(false);
+
+    // when
+    hostService.updatePhoneNumber(hostId, newPhone);
+
+    // then
+    assertThat(host.getPhoneNumber()).isEqualTo(newPhone);
+  }
+
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -204,4 +204,21 @@ class HostServiceTest {
     assertThat(host.getPhoneNumber()).isEqualTo(newPhone);
   }
 
+  @Test
+  @DisplayName("호스트 전화번호 변경 - 실패 (존재하지 않는 호스트)")
+  void updatePhoneNumber_Fail_NotExist() {
+    // given
+    Long hostId = 1L;
+    String phone = "010-1234-5678";
+
+    given(hostRepository.findById(hostId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> hostService.updatePhoneNumber(hostId, phone))
+        .isInstanceOf(MeongnyangerangException.class)
+        .extracting("errorCode")
+        .isEqualTo(NOT_EXIST_ACCOUNT);
+  }
+
+
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #155 

## 📝 변경 사항
### AS-IS
- 호스트 프로필 정보만 조회 가능
- 호스트 전화번호 변경 기능 미구현

### TO-BE
- PATCH /api/v1/hosts/me/phone API 추가
- 동일 번호 및 중복 전화번호 예외 처리 추가
- 정규 표현식을 이용한 전화번호 유효성 검사 적용

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 호스트 전화번호 변경 성공
![image](https://github.com/user-attachments/assets/e437dcc3-bacb-454e-96bc-6c848224cd92)

- 호스트 전화번호 변경 실패(기존의 전화번호와 동일, 이미 사용중인 번호, 인증되지 않은 사용자)
![image](https://github.com/user-attachments/assets/9a3dba27-d12e-4167-b9b6-114633c5c71e)

![image](https://github.com/user-attachments/assets/61de8ee6-b1d4-4a10-a5f9-3cc00df4ab43)

![image](https://github.com/user-attachments/assets/ea787e7f-368d-4074-8446-e6a1cafa6625)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 정규식 검증을 추가하긴 했지만 프론트에서도 1차 필터링 예정입니다.  
