### PR TITLE
[Fix] 숙소 검색 응답 Dto에 기준 인원 및 반려동물 수 필드 추가

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchResponse.java
@@ -17,6 +17,8 @@ public class AccommodationSearchResponse {
   private String thumbnailUrl;
   private Double totalRating;
   private Long price;
+  private Integer standardPeopleCount;
+  private Integer standardPetCount;
   private AccommodationType accommodationType;
 
   public static AccommodationSearchResponse fromDocument(AccommodationRoomDocument doc) {
@@ -27,6 +29,8 @@ public class AccommodationSearchResponse {
         .thumbnailUrl(doc.getThumbnailUrl())
         .totalRating(doc.getTotalRating())
         .price(doc.getPrice())
+        .standardPeopleCount(doc.getStandardPeopleCount())
+        .standardPetCount(doc.getStandardPetCount())
         .accommodationType(doc.getAccommodationType())
         .build();
   }


### PR DESCRIPTION

## 📌 관련 이슈
- close #160 

## 📝 변경 사항
### AS-IS
- 숙소 검색 결과에 standardPeopleCount, standardPetCount 정보 누락

### TO-BE
- AccommodationSearchResponse에 standardPeopleCount, standardPetCount 필드 추가
- fromDocument() 메서드에서 해당 필드들 매핑 처리

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 숙소 목록 조회(필터) - 인원수, 반려동물 수 추가 확인
![image](https://github.com/user-attachments/assets/16916d7c-498f-4fcd-abcf-3c59815afb71)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 정말 간단한 수정이라 리뷰는 빠르게 해주시면 감사하겠습니다!
