### PR TITLE
[Feature] 호스트 이름 변경 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
@@ -1,5 +1,6 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
+import com.meongnyangerang.meongnyangerang.dto.HostNameUpdateRequest;
 import com.meongnyangerang.meongnyangerang.dto.HostPhoneUpdateRequest;
 import com.meongnyangerang.meongnyangerang.dto.HostProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.HostSignupRequest;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
@@ -70,4 +70,14 @@ public class HostController {
     hostService.updatePhoneNumber(userDetails.getId(), request.phoneNumber());
     return ResponseEntity.ok().build();
   }
+
+  // 호스트 이름 변경 API
+  @PatchMapping("/me/name")
+  public ResponseEntity<Void> updateName(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @Valid @RequestBody HostNameUpdateRequest request
+  ) {
+    hostService.updateName(userDetails.getId(), request.name());
+    return ResponseEntity.ok().build();
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/host/Host.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/host/Host.java
@@ -76,4 +76,8 @@ public class Host {
   public void updatePhoneNumber(String newPhoneNumber) {
     this.phoneNumber = newPhoneNumber;
   }
+
+  public void updateName(String newName) {
+    this.name = newName;
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/HostNameUpdateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/HostNameUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record HostNameUpdateRequest (
+  @NotBlank(message = "새로운 이름을 입력하세요.")
+  @Size(min = 1, max = 20, message = "이름은 1자 이상 20자 이하여야 합니다.")
+  @Pattern(regexp = "^[가-힣a-zA-Z]+$", message = "이름은 한글 또는 영문만 입력 가능합니다.")
+  String name
+) {}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -31,7 +31,7 @@ public enum ErrorCode {
   MAX_PET_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "반려동물은 최대 10마리까지 등록할 수 있습니다."),
   ALREADY_REGISTERED_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 등록된 전화번호입니다."),
   DUPLICATE_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 사용 중인 전화번호입니다."),
-
+  ALREADY_REGISTERED_NAME(HttpStatus.BAD_REQUEST,"이미 등록된 이름입니다."),
 
   // 400 BAD REQUEST (JWT 관련 요청 오류)
   INVALID_JWT_FORMAT(HttpStatus.BAD_REQUEST, "JWT 형식이 올바르지 않습니다."),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -5,6 +5,7 @@ import static com.meongnyangerang.meongnyangerang.domain.reservation.Reservation
 import static com.meongnyangerang.meongnyangerang.domain.user.Role.ROLE_HOST;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOUNT_DELETED;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOUNT_PENDING;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ALREADY_REGISTERED_NAME;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ALREADY_REGISTERED_PHONE_NUMBER;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_EMAIL;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_PHONE_NUMBER;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -27,6 +27,7 @@ import com.meongnyangerang.meongnyangerang.service.image.ImageService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -146,5 +147,17 @@ public class HostService {
       throw new MeongnyangerangException(DUPLICATE_PHONE_NUMBER);
     }
     host.updatePhoneNumber(newPhoneNumber);
+  }
+
+  // 호스트 이름 변경
+  public void updateName(Long hostId, String newName) {
+    Host host = hostRepository.findById(hostId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
+
+    if (host.getName().equals(newName)) {
+      throw new MeongnyangerangException(ALREADY_REGISTERED_NAME);
+    }
+
+    host.updateName(newName);
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -264,5 +264,23 @@ class HostServiceTest {
         .isEqualTo(ErrorCode.DUPLICATE_PHONE_NUMBER);
   }
 
+  @DisplayName("호스트 이름 변경 - 성공")
+  @Test
+  void updateName_success() {
+    // given
+    Long hostId = 1L;
+    Host host = Host.builder()
+        .id(hostId)
+        .name("기존이름")
+        .build();
+
+    given(hostRepository.findById(hostId)).willReturn(Optional.of(host));
+
+    // when
+    hostService.updateName(hostId, "새이름");
+
+    // then
+    assertThat(host.getName()).isEqualTo("새이름");
+  }
 
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -298,6 +298,7 @@ class HostServiceTest {
 
     // when & then
     assertThatThrownBy(() -> hostService.updateName(hostId, sameName))
+        .isInstanceOf(MeongnyangerangException.class)
         .extracting("errorCode")
         .isEqualTo(ALREADY_REGISTERED_NAME);
   }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -283,4 +283,22 @@ class HostServiceTest {
     assertThat(host.getName()).isEqualTo("새이름");
   }
 
+  @DisplayName("호스트 이름 변경 - 실패 (동일한 이름)")
+  @Test
+  void updateName_fail_sameName() {
+    // given
+    Long hostId = 1L;
+    String sameName = "동일이름";
+    Host host = Host.builder()
+        .id(hostId)
+        .name(sameName)
+        .build();
+
+    given(hostRepository.findById(hostId)).willReturn(Optional.of(host));
+
+    // when & then
+    assertThatThrownBy(() -> hostService.updateName(hostId, sameName))
+        .extracting("errorCode")
+        .isEqualTo(ALREADY_REGISTERED_NAME);
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -302,4 +302,18 @@ class HostServiceTest {
         .extracting("errorCode")
         .isEqualTo(ALREADY_REGISTERED_NAME);
   }
+
+  @DisplayName("호스트 이름 변경 - 실패 (존재하지 않는 호스트)")
+  @Test
+  void updateName_fail_hostNotFound() {
+    // given
+    Long hostId = 1L;
+    given(hostRepository.findById(hostId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> hostService.updateName(hostId, "아무이름"))
+        .isInstanceOf(MeongnyangerangException.class)
+        .extracting("errorCode")
+        .isEqualTo(NOT_EXIST_ACCOUNT);
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #164 

## 📝 변경 사항
### AS-IS
- 호스트의 이름은 회원가입 이후 변경할 수 없었음

### TO-BE
- `/api/v1/hosts/me/name` PATCH API 추가
- HostNameUpdateRequest DTO 생성 및 유효성 검증 로직 포함
- HostService에 이름 변경 로직 추가
  - 기존 이름과 동일하면 예외 발생
  - 존재하지 않는 호스트일 경우 예외 발생
- 이름 변경 성공/실패 테스트 코드 작성

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 호스트 이름 변경 성공(DB 확인 완료)
![image](https://github.com/user-attachments/assets/bde20bbe-fc64-447c-ab05-4f5789ff474d)

- 호스트 이름 변경 실패(인증되지 않은 사용자, 기존 이름과 동일)
![image](https://github.com/user-attachments/assets/dbb5bf95-eebd-4cbc-997f-30a5cd059d43)

![image](https://github.com/user-attachments/assets/28d0dfac-9afb-4d58-ad09-8f0c0060b24f)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
