### PR TITLE
[Feature] 사용자 및 호스트 공통 비밀번호 변경 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
@@ -62,6 +62,7 @@ public class SecurityConfig {
             .requestMatchers("/api/v1/recommendations/most-viewed").hasAuthority("ROLE_USER")
             .requestMatchers("/api/v1/hosts/**").hasAuthority("ROLE_HOST")
             .requestMatchers("/api/v1/admin/**").hasAuthority("ROLE_ADMIN")
+            .requestMatchers("/api/v1/account/**").hasAnyAuthority("ROLE_USER", "ROLE_HOST")
             .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
         )
         .addFilterBefore(jwtAuthenticationFilter,

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/account")
-public class CommonProfileController {
+public class CommonAccountController {
 
   private final UserService userService;
   private final HostService hostService;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
@@ -1,6 +1,7 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
 import com.meongnyangerang.meongnyangerang.domain.user.Role;
+import com.meongnyangerang.meongnyangerang.dto.PasswordUpdateRequest;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.HostService;
 import com.meongnyangerang.meongnyangerang.service.UserService;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonProfileController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonProfileController.java
@@ -1,0 +1,38 @@
+package com.meongnyangerang.meongnyangerang.controller;
+
+import com.meongnyangerang.meongnyangerang.domain.user.Role;
+import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
+import com.meongnyangerang.meongnyangerang.service.HostService;
+import com.meongnyangerang.meongnyangerang.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/account")
+public class CommonProfileController {
+
+  private final UserService userService;
+  private final HostService hostService;
+
+  // 비밀번호 변경 API(사용자, 호스트 공통 기능)
+  @PatchMapping("/password")
+  public ResponseEntity<Void> updatePassword(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @Valid @RequestBody PasswordUpdateRequest request) {
+
+    if (userDetails.getRole().equals(Role.ROLE_USER)) {
+      userService.updatePassword(userDetails.getId(), request);
+    } else if (userDetails.getRole().equals(Role.ROLE_HOST)) {
+      hostService.updatePassword(userDetails.getId(), request);
+    }
+
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/host/Host.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/host/Host.java
@@ -80,4 +80,8 @@ public class Host {
   public void updateName(String newName) {
     this.name = newName;
   }
+
+  public void updatePassword(String newPassword) {
+    this.password = newPassword;
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/user/User.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/user/User.java
@@ -59,4 +59,8 @@ public class User {
   private LocalDateTime updatedAt;
 
   private LocalDateTime deletedAt;
+
+  public void updatePassword(String newPassword) {
+    this.password = newPassword;
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/PasswordUpdateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/PasswordUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record PasswordUpdateRequest(
+
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$])[A-Za-z\\d!@#$]{8,}$",
+        message = "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자(!,@,#,$)를 각각 하나 이상 포함해야 합니다.")
+    @NotBlank(message = "기존 비밀번호를 입력해주세요.")
+    String currentPassword,
+
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$])[A-Za-z\\d!@#$]{8,}$",
+        message = "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자(!,@,#,$)를 각각 하나 이상 포함해야 합니다.")
+    @NotBlank(message = "새로운 비밀번호를 입력해주세요.")
+    String newPassword
+
+) {
+
+}
+
+

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -21,7 +21,6 @@ public enum ErrorCode {
   INVALID_FILENAME(HttpStatus.BAD_REQUEST, "파일명이 유효하지 않습니다."),
   INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "파일 확장자가 유효하지 않습니다."),
   NOT_SUPPORTED_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
-  NOT_EXIST_ACCOUNT(HttpStatus.BAD_REQUEST, "해당 계정은 존재하지 않습니다."),
   EMPTY_PET_TYPE(HttpStatus.BAD_REQUEST, "허용 반려동물 타입을 지정해 주세요."),
   RESERVATION_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 예약입니다."),
   REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "리뷰가 이미 존재합니다."),
@@ -53,6 +52,7 @@ public enum ErrorCode {
   WEBSOCKET_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "WebSocket 권한 없음"),
 
   // 404  NOT FOUND
+  NOT_EXIST_ACCOUNT(HttpStatus.BAD_REQUEST, "해당 계정은 존재하지 않습니다."),
   NOT_EXISTS_HOST(HttpStatus.NOT_FOUND, "존재하지 않는 호스트입니다."),
   FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일이 존재하지 않습니다."),
   FILE_IS_EMPTY(HttpStatus.NOT_FOUND, "파일이 비어있습니다."),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -10,7 +10,7 @@ public enum ErrorCode {
 
   // 400 BAD REQUEST (잘못된 요청)
   INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-  INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다."),
+  INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
   DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다"),
   DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 등록된 닉네임입니다."),
   EXPIRED_AUTH_CODE(HttpStatus.BAD_REQUEST, "인증코드가 만료되었습니다. 다시 발급받아주세요"),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -19,6 +19,7 @@ import com.meongnyangerang.meongnyangerang.domain.host.HostStatus;
 import com.meongnyangerang.meongnyangerang.dto.HostProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.HostSignupRequest;
 import com.meongnyangerang.meongnyangerang.dto.LoginRequest;
+import com.meongnyangerang.meongnyangerang.dto.PasswordUpdateRequest;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.jwt.JwtTokenProvider;
@@ -160,5 +161,16 @@ public class HostService {
     }
 
     host.updateName(newName);
+  }
+
+  // 호스트 비밀번호 변경
+  public void updatePassword(Long hostId, PasswordUpdateRequest request) {
+    Host host = hostRepository.findById(hostId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
+
+    if (!passwordEncoder.matches(request.currentPassword(), host.getPassword())) {
+      throw new MeongnyangerangException(INVALID_PASSWORD);
+    }
+    host.updatePassword(passwordEncoder.encode(request.newPassword()));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -12,8 +12,10 @@ import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.RESERVED_R
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.dto.LoginRequest;
+import com.meongnyangerang.meongnyangerang.dto.PasswordUpdateRequest;
 import com.meongnyangerang.meongnyangerang.dto.UserProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.UserSignupRequest;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.jwt.JwtTokenProvider;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
@@ -105,5 +107,17 @@ public class UserService {
         .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
 
     return UserProfileResponse.of(user);
+  }
+
+  // 사용자 비밀번호 변경
+  @Transactional
+  public void updatePassword(Long userId, PasswordUpdateRequest request) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
+
+    if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
+      throw new MeongnyangerangException(INVALID_PASSWORD);
+    }
+    user.updatePassword(passwordEncoder.encode(request.newPassword()));
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -341,4 +341,20 @@ class HostServiceTest {
     // then
     assertThat(host.getPassword()).isEqualTo("encodedNewPassword");
   }
+
+  @Test
+  @DisplayName("호스트 비밀번호 변경 - 실패(존재하지 않는 호스트)")
+  void updatePassword_Fail_NotExistHost() {
+    // given
+    Long hostId = 1L;
+    PasswordUpdateRequest request = new PasswordUpdateRequest("oldPassword", "newPassword1!");
+
+    given(hostRepository.findById(hostId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> hostService.updatePassword(hostId, request))
+        .isInstanceOf(MeongnyangerangException.class)
+        .extracting("errorCode")
+        .isEqualTo(NOT_EXIST_ACCOUNT);
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -357,4 +357,26 @@ class HostServiceTest {
         .extracting("errorCode")
         .isEqualTo(NOT_EXIST_ACCOUNT);
   }
+
+  @Test
+  @DisplayName("호스트 비밀번호 변경 - 실패(기존 비밀번호 불일치)")
+  void updatePassword_Fail_InvalidPassword() {
+    // given
+    Long hostId = 1L;
+    Host host = Host.builder()
+        .id(hostId)
+        .password("encodedOldPassword")
+        .build();
+
+    PasswordUpdateRequest request = new PasswordUpdateRequest("wrongOldPassword", "newPassword1!");
+
+    given(hostRepository.findById(hostId)).willReturn(Optional.of(host));
+    given(passwordEncoder.matches("wrongOldPassword", "encodedOldPassword")).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(() -> hostService.updatePassword(hostId, request))
+        .isInstanceOf(MeongnyangerangException.class)
+        .extracting("errorCode")
+        .isEqualTo(INVALID_PASSWORD);
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -21,6 +21,7 @@ import com.meongnyangerang.meongnyangerang.domain.host.HostStatus;
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
 import com.meongnyangerang.meongnyangerang.dto.HostProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.HostSignupRequest;
+import com.meongnyangerang.meongnyangerang.dto.PasswordUpdateRequest;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.HostRepository;
@@ -315,5 +316,29 @@ class HostServiceTest {
         .isInstanceOf(MeongnyangerangException.class)
         .extracting("errorCode")
         .isEqualTo(NOT_EXIST_ACCOUNT);
+  }
+
+  @Test
+  @DisplayName("호스트 비밀번호 변경 - 성공")
+  void updatePassword_Success() {
+    // given
+    Long hostId = 1L;
+    Host host = Host.builder()
+        .id(hostId)
+        .password("encodedOldPassword")
+        .build();
+
+    PasswordUpdateRequest request = new PasswordUpdateRequest("oldPassword", "newPassword1!");
+
+    given(hostRepository.findById(hostId)).willReturn(Optional.of(host));
+    given(passwordEncoder.matches("oldPassword", "encodedOldPassword")).willReturn(true);
+    given(passwordEncoder.encode("newPassword1!"))
+        .willReturn("encodedNewPassword");
+
+    // when
+    hostService.updatePassword(hostId, request);
+
+    // then
+    assertThat(host.getPassword()).isEqualTo("encodedNewPassword");
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.meongnyangerang.meongnyangerang.service;
 
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -186,7 +187,7 @@ class UserServiceTest {
     assertThatThrownBy(() -> userService.getMyProfile(invalidUserId))
         .isInstanceOf(MeongnyangerangException.class)
         .extracting("errorCode")
-        .isEqualTo(ErrorCode.NOT_EXIST_ACCOUNT);
+        .isEqualTo(NOT_EXIST_ACCOUNT);
   }
 
   @Test
@@ -225,6 +226,28 @@ class UserServiceTest {
     assertThatThrownBy(() -> userService.updatePassword(userId, request))
         .isInstanceOf(MeongnyangerangException.class)
         .extracting("errorCode")
-        .isEqualTo(ErrorCode.NOT_EXIST_ACCOUNT);
+        .isEqualTo(NOT_EXIST_ACCOUNT);
+  }
+
+  @Test
+  @DisplayName("사용자 비밀번호 변경 - 실패(기존 비밀번호 불일치)")
+  void updatePassword_Fail_InvalidPassword() {
+    // given
+    Long userId = 1L;
+    User user = User.builder()
+        .id(userId)
+        .password("encodedOldPassword")
+        .build();
+
+    PasswordUpdateRequest request = new PasswordUpdateRequest("wrongOldPassword", "newPassword1!");
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(passwordEncoder.matches("wrongOldPassword", "encodedOldPassword")).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(() -> userService.updatePassword(userId, request))
+        .isInstanceOf(MeongnyangerangException.class)
+        .extracting("errorCode")
+        .isEqualTo(INVALID_PASSWORD);
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
+import com.meongnyangerang.meongnyangerang.dto.PasswordUpdateRequest;
 import com.meongnyangerang.meongnyangerang.dto.UserProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.UserSignupRequest;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
@@ -186,5 +187,28 @@ class UserServiceTest {
         .isInstanceOf(MeongnyangerangException.class)
         .extracting("errorCode")
         .isEqualTo(ErrorCode.NOT_EXIST_ACCOUNT);
+  }
+
+  @Test
+  @DisplayName("사용자 비밀번호 변경 - 성공")
+  void updatePassword_Success() {
+    // given
+    Long userId = 1L;
+    User user = User.builder()
+        .id(userId)
+        .password("encodedOldPassword")
+        .build();
+
+    PasswordUpdateRequest request = new PasswordUpdateRequest("oldPassword", "newPassword1!");
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(passwordEncoder.matches("oldPassword", "encodedOldPassword")).willReturn(true);
+    given(passwordEncoder.encode("newPassword1!")).willReturn("encodedNewPassword");
+
+    // when
+    userService.updatePassword(userId, request);
+
+    // then
+    assertThat(user.getPassword()).isEqualTo("encodedNewPassword");
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
@@ -211,4 +211,20 @@ class UserServiceTest {
     // then
     assertThat(user.getPassword()).isEqualTo("encodedNewPassword");
   }
+
+  @Test
+  @DisplayName("사용자 비밀번호 변경 - 실패(존재하지 않는 사용자)")
+  void updatePassword_Fail_NotExistUser() {
+    // given
+    Long userId = 1L;
+    PasswordUpdateRequest request = new PasswordUpdateRequest("oldPassword", "newPassword1!");
+
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> userService.updatePassword(userId, request))
+        .isInstanceOf(MeongnyangerangException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.NOT_EXIST_ACCOUNT);
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #167 

## 📝 변경 사항
### AS-IS
- 사용자와 호스트 각각의 계정 관련 기능은 분리되어 있었고, 공통 기능에 대한 통합 처리가 없었음

### TO-BE
- 공통 컨트롤러(CommonAccountController)를 통해 사용자와 호스트의 비밀번호 변경을 하나의 API로 통합 처리
- 역할(Role)을 기준으로 `UserService`, `HostService` 분기 호출
- PasswordUpdateRequest DTO로 기존/신규 비밀번호 입력값 검증
- 기존 비밀번호가 일치할 경우에만 새 비밀번호로 변경되도록 로직 구성

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 비밀번호 변경 성공
![image](https://github.com/user-attachments/assets/4dca182a-a191-486b-ae8f-14514e41b81a)


- 비밀번호 변경 실패(기존 비밀번호와 다름, 인증되지 않은 사용자)
![image](https://github.com/user-attachments/assets/e455360b-7a95-4acc-a893-71e26d704575)

![image](https://github.com/user-attachments/assets/9a814cd8-cd8e-416e-851f-7190c6e3e1d9)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 컨트롤러 분기 구조가 깔끔한지, 로직 중 불필요하거나 중복된 부분이 있는지 확인 부탁드립니다
