### PR TITLE
[Feature] 닉네임 변경 API 구현 (사용자/호스트 공통), WebSocket CORS 설정 수정

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/WebSocketConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/WebSocketConfig.java
@@ -35,7 +35,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     // WebSocket 연결을 위한 엔드포인트 설정
     registry.addEndpoint("/ws")
-        .setAllowedOriginPatterns("*") // CORS 설정 (모든 도메인 접근 허용)
+        .setAllowedOrigins("http://localhost:5173") // CORS 설정 (모든 도메인 접근 허용)
         .withSockJS(); // WebSocket을 지원하지 않을 때 자동으로 대체 기술 사용
   }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
@@ -38,7 +38,7 @@ public class CommonAccountController {
     return ResponseEntity.ok().build();
   }
 
-  // 닉네임 변경(사용자, 호스트 공통 기능)
+  // 닉네임 변경 API(사용자, 호스트 공통 기능)
   @PatchMapping("/nickname")
   public ResponseEntity<Void> updateNickname(
       @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
@@ -36,4 +36,19 @@ public class CommonAccountController {
 
     return ResponseEntity.ok().build();
   }
+
+  // 닉네임 변경(사용자, 호스트 공통 기능)
+  @PatchMapping("/nickname")
+  public ResponseEntity<Void> updateNickname(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @Valid @RequestBody NicknameUpdateRequest request
+  ) {
+    if (userDetails.getRole().equals(Role.ROLE_USER)) {
+      userService.updateNickname(userDetails.getId(), request.nickname());
+    } else if (userDetails.getRole().equals(Role.ROLE_HOST)) {
+      hostService.updateNickname(userDetails.getId(), request.nickname());
+    }
+
+    return ResponseEntity.ok().build();
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
@@ -45,9 +45,9 @@ public class CommonAccountController {
       @Valid @RequestBody NicknameUpdateRequest request
   ) {
     if (userDetails.getRole().equals(Role.ROLE_USER)) {
-      userService.updateNickname(userDetails.getId(), request.nickname());
+      userService.updateNickname(userDetails.getId(), request.newNickname());
     } else if (userDetails.getRole().equals(Role.ROLE_HOST)) {
-      hostService.updateNickname(userDetails.getId(), request.nickname());
+      hostService.updateNickname(userDetails.getId(), request.newNickname());
     }
 
     return ResponseEntity.ok().build();

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
@@ -1,6 +1,7 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
 import com.meongnyangerang.meongnyangerang.domain.user.Role;
+import com.meongnyangerang.meongnyangerang.dto.NicknameUpdateRequest;
 import com.meongnyangerang.meongnyangerang.dto.PasswordUpdateRequest;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.HostService;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/host/Host.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/host/Host.java
@@ -84,4 +84,8 @@ public class Host {
   public void updatePassword(String newPassword) {
     this.password = newPassword;
   }
+
+  public void updateNickname(String newNickname) {
+    this.nickname = newNickname;
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/user/User.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/user/User.java
@@ -63,4 +63,8 @@ public class User {
   public void updatePassword(String newPassword) {
     this.password = newPassword;
   }
+
+  public void updateNickname(String newNickname) {
+    this.nickname = newNickname;
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/HostSignupRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/HostSignupRequest.java
@@ -24,7 +24,7 @@ public class HostSignupRequest {
   @Pattern(regexp = "^[가-힣a-zA-Z]+$", message = "이름은 한글 또는 영문만 입력 가능합니다.")
   private String name;
 
-  @Size(min = 2, max = 20)
+  @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하여야 합니다.")
   @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
   private String nickname;
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/NicknameUpdateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/NicknameUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record NicknameUpdateRequest(
+
+    @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하여야 합니다.")
+    @NotBlank(message = "새로운 닉네임을 입력해주세요.")
+    String newNickname
+    ) {
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
   ALREADY_REGISTERED_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 등록된 전화번호입니다."),
   DUPLICATE_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 사용 중인 전화번호입니다."),
   ALREADY_REGISTERED_NAME(HttpStatus.BAD_REQUEST,"이미 등록된 이름입니다."),
+  ALREADY_REGISTERED_NICKNAME(HttpStatus.BAD_REQUEST, "기존 닉네임과 동일합니다."),
 
   // 400 BAD REQUEST (JWT 관련 요청 오류)
   INVALID_JWT_FORMAT(HttpStatus.BAD_REQUEST, "JWT 형식이 올바르지 않습니다."),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -6,6 +6,7 @@ import static com.meongnyangerang.meongnyangerang.domain.user.Role.ROLE_HOST;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOUNT_DELETED;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOUNT_PENDING;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ALREADY_REGISTERED_NAME;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ALREADY_REGISTERED_NICKNAME;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ALREADY_REGISTERED_PHONE_NUMBER;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_EMAIL;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_PHONE_NUMBER;
@@ -47,6 +48,7 @@ public class HostService {
   private final JwtTokenProvider jwtTokenProvider;
   private final ImageService imageService;
   private final ReservationRepository reservationRepository;
+  private final AuthService authService;
 
   // 호스트 회원가입
   public void registerHost(HostSignupRequest request,
@@ -172,5 +174,20 @@ public class HostService {
       throw new MeongnyangerangException(INVALID_PASSWORD);
     }
     host.updatePassword(passwordEncoder.encode(request.newPassword()));
+  }
+
+  // 호스트 닉네임 변경
+  public void updateNickname(Long hostId, String newNickname) {
+    Host host = hostRepository.findById(hostId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
+
+    if (host.getNickname().equals(newNickname)) {
+      throw new MeongnyangerangException(ALREADY_REGISTERED_NICKNAME);
+    }
+
+    // 이메일 중복 확인 및 예외처리
+    authService.checkNickname(newNickname);
+
+    host.updateNickname(newNickname);
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -177,6 +177,7 @@ public class HostService {
   }
 
   // 호스트 닉네임 변경
+  @Transactional
   public void updateNickname(Long hostId, String newNickname) {
     Host host = hostRepository.findById(hostId)
         .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -4,6 +4,7 @@ import static com.meongnyangerang.meongnyangerang.domain.user.Role.ROLE_USER;
 import static com.meongnyangerang.meongnyangerang.domain.user.UserStatus.ACTIVE;
 import static com.meongnyangerang.meongnyangerang.domain.user.UserStatus.DELETED;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOUNT_DELETED;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ALREADY_REGISTERED_NICKNAME;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_EMAIL;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.INVALID_PASSWORD;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_ACCOUNT;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -38,6 +38,7 @@ public class UserService {
   private final JwtTokenProvider jwtTokenProvider;
   private final ImageService imageService;
   private final ReservationRepository reservationRepository;
+  private final AuthService authService;
 
   // 사용자 회원가입
   public void registerUser(UserSignupRequest request, MultipartFile profileImage) {
@@ -119,5 +120,20 @@ public class UserService {
       throw new MeongnyangerangException(INVALID_PASSWORD);
     }
     user.updatePassword(passwordEncoder.encode(request.newPassword()));
+  }
+
+  // 사용자 닉네임 변경
+  public void updateNickname(Long userId, String newNickname) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
+
+    if (user.getNickname().equals(newNickname)) {
+      throw new MeongnyangerangException(ALREADY_REGISTERED_NICKNAME);
+    }
+
+    // 이메일 중복 확인 및 예외처리
+    authService.checkNickname(newNickname);
+
+    user.updateNickname(newNickname);
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -124,6 +124,7 @@ public class UserService {
   }
 
   // 사용자 닉네임 변경
+  @Transactional
   public void updateNickname(Long userId, String newNickname) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -403,4 +403,23 @@ class HostServiceTest {
     // then
     assertThat(host.getNickname()).isEqualTo("newNick");
   }
+
+  @DisplayName("호스트 닉네임 변경 - 실패 (이미 등록된 닉네임)")
+  @Test
+  void updateNickname_Host_AlreadyRegistered() {
+    // given
+    Long hostId = 1L;
+    Host host = Host.builder()
+        .id(hostId)
+        .nickname("sameNick")
+        .build();
+
+    given(hostRepository.findById(hostId)).willReturn(Optional.of(host));
+
+    // when & then
+    assertThatThrownBy(() -> hostService.updateNickname(hostId, "sameNick"))
+        .isInstanceOf(MeongnyangerangException.class)
+        .extracting("errorCode")
+        .isEqualTo(ALREADY_REGISTERED_NICKNAME);
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -421,5 +422,25 @@ class HostServiceTest {
         .isInstanceOf(MeongnyangerangException.class)
         .extracting("errorCode")
         .isEqualTo(ALREADY_REGISTERED_NICKNAME);
+  }
+
+  @DisplayName("호스트 닉네임 변경 - 실패 (중복 닉네임 존재)")
+  @Test
+  void updateNickname_Host_DuplicateNickname() {
+    // given
+    Long hostId = 1L;
+    Host host = Host.builder()
+        .id(hostId)
+        .nickname("oldNick")
+        .build();
+
+    given(hostRepository.findById(hostId)).willReturn(Optional.of(host));
+    willThrow(new MeongnyangerangException(DUPLICATE_NICKNAME)).given(authService).checkNickname("duplicateNick");
+
+    // when & then
+    assertThatThrownBy(() -> hostService.updateNickname(hostId, "duplicateNick"))
+        .isInstanceOf(MeongnyangerangException.class)
+        .extracting("errorCode")
+        .isEqualTo(DUPLICATE_NICKNAME);
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,6 +58,9 @@ class HostServiceTest {
 
   @Mock
   private ReservationRepository reservationRepository;
+
+  @Mock
+  private AuthService authService;
 
   @Test
   @DisplayName("호스트 회원가입 성공 테스트")
@@ -378,5 +382,25 @@ class HostServiceTest {
         .isInstanceOf(MeongnyangerangException.class)
         .extracting("errorCode")
         .isEqualTo(INVALID_PASSWORD);
+  }
+
+  @DisplayName("호스트 닉네임 변경 - 성공")
+  @Test
+  void updateNickname_Host_Success() {
+    // given
+    Long hostId = 1L;
+    Host host = Host.builder()
+        .id(hostId)
+        .nickname("oldNick")
+        .build();
+
+    given(hostRepository.findById(hostId)).willReturn(Optional.of(host));
+    willDoNothing().given(authService).checkNickname("newNick");
+
+    // when
+    hostService.updateNickname(hostId, "newNick");
+
+    // then
+    assertThat(host.getNickname()).isEqualTo("newNick");
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -293,5 +294,25 @@ class UserServiceTest {
         .isInstanceOf(MeongnyangerangException.class)
         .extracting("errorCode")
         .isEqualTo(ALREADY_REGISTERED_NICKNAME);
+  }
+
+  @DisplayName("사용자 닉네임 변경 - 실패 (중복 닉네임 존재)")
+  @Test
+  void updateNickname_User_DuplicateNickname() {
+    // given
+    Long userId = 1L;
+    User user = User.builder()
+        .id(userId)
+        .nickname("oldNick")
+        .build();
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    willThrow(new MeongnyangerangException(DUPLICATE_NICKNAME)).given(authService).checkNickname("duplicateNick");
+
+    // when & then
+    assertThatThrownBy(() -> userService.updateNickname(userId, "duplicateNick"))
+        .isInstanceOf(MeongnyangerangException.class)
+        .extracting("errorCode")
+        .isEqualTo(DUPLICATE_NICKNAME);
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
@@ -275,4 +275,23 @@ class UserServiceTest {
     // then
     assertThat(user.getNickname()).isEqualTo("newNickname");
   }
+
+  @DisplayName("사용자 닉네임 변경 - 실패 (이미 등록된 닉네임)")
+  @Test
+  void updateNickname_User_AlreadyRegistered() {
+    // given
+    Long userId = 1L;
+    User user = User.builder()
+        .id(userId)
+        .nickname("sameNick")
+        .build();
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+    // when & then
+    assertThatThrownBy(() -> userService.updateNickname(userId, "sameNick"))
+        .isInstanceOf(MeongnyangerangException.class)
+        .extracting("errorCode")
+        .isEqualTo(ALREADY_REGISTERED_NICKNAME);
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -53,6 +54,9 @@ class UserServiceTest {
 
   @Mock
   private ReservationRepository reservationRepository;
+
+  @Mock
+  private AuthService authService;
 
   @Test
   @DisplayName("사용자 회원가입 성공 테스트 - 프로필 이미지 없음")
@@ -249,5 +253,26 @@ class UserServiceTest {
         .isInstanceOf(MeongnyangerangException.class)
         .extracting("errorCode")
         .isEqualTo(INVALID_PASSWORD);
+  }
+
+
+  @Test
+  @DisplayName("사용자 닉네임 변경 - 성공")
+  void updateNickname_Success() {
+    // given
+    Long userId = 1L;
+    User user = User.builder()
+        .id(userId)
+        .nickname("oldNickname")
+        .build();
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    willDoNothing().given(authService).checkNickname("newNickname");
+
+    // when
+    userService.updateNickname(userId, "newNickname");
+
+    // then
+    assertThat(user.getNickname()).isEqualTo("newNickname");
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #171 

## 📝 변경 사항
### AS-IS
- 사용자와 호스트가 닉네임을 변경할 수 있는 기능이 존재하지 않았음
- WebSocket CORS 설정을 프론트엔드 Origin으로 명시적 허용이 되어있지 않았음

### TO-BE
- 공통 컨트롤러(`/api/v1/account`)를 통해 닉네임 변경 API 추가
- 사용자/호스트 `Service`에서 `AuthService`의 닉네임 중복 확인 메서드를 호출
- 동일 닉네임 및 중복 닉네임에 대한 예외 처리 적용
- WebSocket CORS 설정을 프론트엔드 Origin으로 명시적 허용

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 닉네임 변경 성공
![image](https://github.com/user-attachments/assets/df00ea4b-8ea1-4d7f-91a8-2b7caf69a6e3)

![image](https://github.com/user-attachments/assets/dfa8397f-d08f-4d43-bfb4-ae87647f5983)

- 닉네임 변경 실패(기존 닉네임과 같을 경우, 이미 존재하는 닉네임일 경우, 인증되지 않은 사용자)
![image](https://github.com/user-attachments/assets/2f426306-b675-460f-abd6-352724010ba9)

![image](https://github.com/user-attachments/assets/80fddc69-649e-4d33-973d-4b173cb58e98)

![image](https://github.com/user-attachments/assets/b2f9a37c-73d5-4f36-b21b-ee726b3f27c5)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
