### PR TITLE
[Feature] 채팅 메시지 반환 값으로 채팅방 ID 추가

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/chat/ChatMessageResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/chat/ChatMessageResponse.java
@@ -6,6 +6,7 @@ import com.meongnyangerang.meongnyangerang.domain.chat.SenderType;
 import java.time.LocalDateTime;
 
 public record ChatMessageResponse(
+    Long chatRoomId,
     String messageContent,
     SenderType senderType,
     MessageType messageType,
@@ -14,6 +15,7 @@ public record ChatMessageResponse(
 
   public static ChatMessageResponse from(ChatMessage chatMessage) {
     return new ChatMessageResponse(
+        chatMessage.getChatRoom().getId(),
         chatMessage.getContent(),
         chatMessage.getSenderType(),
         chatMessage.getMessageType(),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/chat/ChatRoomResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/chat/ChatRoomResponse.java
@@ -1,5 +1,6 @@
 package com.meongnyangerang.meongnyangerang.dto.chat;
 
+import com.meongnyangerang.meongnyangerang.domain.chat.MessageType;
 import java.time.LocalDateTime;
 
 public record ChatRoomResponse(
@@ -8,6 +9,7 @@ public record ChatRoomResponse(
     String partnerName,
     String partnerImageUrl,
     String lastMessage,
+    MessageType lastMessageType,
     LocalDateTime lastMessageTime,
     int unreadCount
 ) {

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ChatService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ChatService.java
@@ -237,6 +237,7 @@ public class ChatService {
         accommodation.getName(),
         accommodation.getThumbnailUrl(),
         getLastMessage(lastMessage),
+        getLastMessageType(lastMessage),
         getLastMessageTime(lastMessage),
         unreadCount
     );
@@ -259,6 +260,7 @@ public class ChatService {
         user.getNickname(),
         user.getProfileImage(),
         getLastMessage(lastMessage),
+        getLastMessageType(lastMessage),
         getLastMessageTime(lastMessage),
         unreadCount
     );
@@ -275,15 +277,19 @@ public class ChatService {
         .orElse(DEFAULT_LAST_READ_TIME);
   }
 
-  private static String getLastMessage(ChatMessage lastMessage) {
+  private String getLastMessage(ChatMessage lastMessage) {
     return lastMessage != null ? lastMessage.getContent() : "";
   }
 
-  private static LocalDateTime getLastMessageTime(ChatMessage lastMessage) {
+  private MessageType getLastMessageType(ChatMessage lastMessage) {
+    return lastMessage != null ? lastMessage.getMessageType() : MessageType.MESSAGE;
+  }
+
+  private LocalDateTime getLastMessageTime(ChatMessage lastMessage) {
     return lastMessage != null ? lastMessage.getCreatedAt() : null;
   }
 
-  private static ChatMessage createChatMessage(
+  private ChatMessage createChatMessage(
       String content,
       ChatRoom chatRoom,
       SenderType senderType,

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ChatServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ChatServiceTest.java
@@ -28,7 +28,6 @@ import com.meongnyangerang.meongnyangerang.repository.chat.ChatReadStatusReposit
 import com.meongnyangerang.meongnyangerang.repository.chat.ChatRoomRepository;
 import com.meongnyangerang.meongnyangerang.service.image.ImageService;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -46,7 +45,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
@@ -460,7 +458,7 @@ class ChatServiceTest {
     List<ChatMessageResponse> messages = response.content();
     for (int i = 0; i < messages.size(); i++) {
       ChatMessageResponse message = messages.get(i);
-      assertThat(message.messageId()).isEqualTo(i + 1);
+      assertThat(message.chatRoomId()).isEqualTo(chatRoomId);
       assertThat(message.messageContent()).isEqualTo("테스트 메시지" + (i + 1));
       assertThat(messages.get(i).senderType())
           .isEqualTo(i % 2 == 0 ? SenderType.USER : SenderType.HOST);


### PR DESCRIPTION
## 📌 관련 이슈
- close #177

## 📝 변경 사항
### AS-IS
- 채팅 메시지 정보에 채팅방 ID 부재
- 채팅방 목록 조회 시 마지막 메시지 정보에 메시지 타입 부재

### TO-BE
- 채팅 메시지 정보에 채팅방 ID 추가
- 채팅방 목록 조회 시 마지막 메시지 정보에 메시지 타입 추가

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 실시간 채팅 전송
![send_chat](https://github.com/user-attachments/assets/780a7489-506e-4454-8f3f-4c19642c836c)

- 채팅방 목록 조회
![send_chat_add_message_type](https://github.com/user-attachments/assets/a6db5e73-6e27-4b90-9673-3730ef2aef06)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.