### PR TITLE
[Feature] 사용자/호스트 공통 프로필 사진 변경 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
@@ -13,7 +13,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -50,6 +52,20 @@ public class CommonAccountController {
       hostService.updateNickname(userDetails.getId(), request.newNickname());
     }
 
+    return ResponseEntity.ok().build();
+  }
+
+  // 프로필 사진 변경 API(사용자, 호스트 공통 기능)
+  @PatchMapping
+  public ResponseEntity<Void> updateProfileImage(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @RequestPart(value = "newProfileImage")MultipartFile newProfileImage
+  ) {
+    if (userDetails.getRole().equals(Role.ROLE_USER)) {
+      userService.updateProfileImage(userDetails.getId(), newProfileImage);
+    } else if (userDetails.getRole().equals(Role.ROLE_HOST)) {
+      hostService.updateProfileImage(userDetails.getId(), newProfileImage);
+    }
     return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/CommonAccountController.java
@@ -56,7 +56,7 @@ public class CommonAccountController {
   }
 
   // 프로필 사진 변경 API(사용자, 호스트 공통 기능)
-  @PatchMapping
+  @PatchMapping("/profile-image")
   public ResponseEntity<Void> updateProfileImage(
       @AuthenticationPrincipal UserDetailsImpl userDetails,
       @RequestPart(value = "newProfileImage")MultipartFile newProfileImage

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/host/Host.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/host/Host.java
@@ -88,4 +88,8 @@ public class Host {
   public void updateNickname(String newNickname) {
     this.nickname = newNickname;
   }
+
+  public void updateProfileImage(String newProfileImage) {
+    this.profileImageUrl = newProfileImage;
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/user/User.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/user/User.java
@@ -67,4 +67,8 @@ public class User {
   public void updateNickname(String newNickname) {
     this.nickname = newNickname;
   }
+
+  public void updateProfileImage(String newProfileImage) {
+    this.profileImage = newProfileImage;
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -198,7 +198,7 @@ public class HostService {
     Host host = hostRepository.findById(hotsId)
         .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
 
-    if (host.getProfileImageUrl() != null) {
+    if (host.getProfileImageUrl() != null && !host.getProfileImageUrl().isBlank()) {
       imageService.deleteImageAsync(host.getProfileImageUrl());
     }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -191,4 +191,17 @@ public class HostService {
 
     host.updateNickname(newNickname);
   }
+
+  // 호스트 프로필 사진 변경
+  @Transactional
+  public void updateProfileImage(Long hotsId, MultipartFile newProfileImage) {
+    Host host = hostRepository.findById(hotsId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
+
+    if (host.getProfileImageUrl() != null) {
+      imageService.deleteImageAsync(host.getProfileImageUrl());
+    }
+
+    host.updateProfileImage(imageService.storeImage(newProfileImage));
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -138,4 +138,14 @@ public class UserService {
 
     user.updateNickname(newNickname);
   }
+
+  public void updateProfileImage(Long userId, MultipartFile newProfileImage) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
+
+    if (user.getProfileImage() != null) {
+      imageService.deleteImageAsync(user.getProfileImage());
+    }
+    user.updateProfileImage(imageService.storeImage(newProfileImage));
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -145,7 +145,7 @@ public class UserService {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
 
-    if (user.getProfileImage() != null) {
+    if (user.getProfileImage() != null && !user.getProfileImage().isBlank()) {
       imageService.deleteImageAsync(user.getProfileImage());
     }
     user.updateProfileImage(imageService.storeImage(newProfileImage));

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -139,6 +139,8 @@ public class UserService {
     user.updateNickname(newNickname);
   }
 
+  // 사용자 프로필 사진 변경
+  @Transactional
   public void updateProfileImage(Long userId, MultipartFile newProfileImage) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -482,4 +482,18 @@ class HostServiceTest {
     verify(imageService, never()).deleteImageAsync(any());
     assertThat(host.getProfileImageUrl()).isEqualTo("https://s3.aws/new-host.jpg");
   }
+
+  @Test
+  @DisplayName("호스트 프로필 이미지 변경 - 실패 (존재하지 않는 호스트)")
+  void updateProfileImage_fail_hostNotFound() {
+    Long hostId = 999L;
+    MultipartFile newImage = mock(MultipartFile.class);
+
+    given(hostRepository.findById(hostId)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> hostService.updateProfileImage(hostId, newImage))
+        .isInstanceOf(MeongnyangerangException.class)
+        .extracting("errorCode")
+        .isEqualTo(NOT_EXIST_ACCOUNT);
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -463,4 +463,23 @@ class HostServiceTest {
     verify(imageService).deleteImageAsync("https://s3.aws/old-host.jpg");
     assertThat(host.getProfileImageUrl()).isEqualTo("https://s3.aws/new-host.jpg");
   }
+
+  @Test
+  @DisplayName("호스트 프로필 이미지 변경 - 성공 (기존 이미지 X)")
+  void updateProfileImage_success_withoutExistingImage() {
+    Long hostId = 2L;
+    MultipartFile newImage = mock(MultipartFile.class);
+    Host host = Host.builder()
+        .id(hostId)
+        .profileImageUrl(null)
+        .build();
+
+    given(hostRepository.findById(hostId)).willReturn(Optional.of(host));
+    given(imageService.storeImage(newImage)).willReturn("https://s3.aws/new-host.jpg");
+
+    hostService.updateProfileImage(hostId, newImage);
+
+    verify(imageService, never()).deleteImageAsync(any());
+    assertThat(host.getProfileImageUrl()).isEqualTo("https://s3.aws/new-host.jpg");
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/HostServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -442,5 +443,24 @@ class HostServiceTest {
         .isInstanceOf(MeongnyangerangException.class)
         .extracting("errorCode")
         .isEqualTo(DUPLICATE_NICKNAME);
+  }
+
+  @Test
+  @DisplayName("호스트 프로필 이미지 변경 - 성공 (기존 이미지 O)")
+  void updateProfileImage_success_withExistingImage() {
+    Long hostId = 1L;
+    MultipartFile newImage = mock(MultipartFile.class);
+    Host host = Host.builder()
+        .id(hostId)
+        .profileImageUrl("https://s3.aws/old-host.jpg")
+        .build();
+
+    given(hostRepository.findById(hostId)).willReturn(Optional.of(host));
+    given(imageService.storeImage(newImage)).willReturn("https://s3.aws/new-host.jpg");
+
+    hostService.updateProfileImage(hostId, newImage);
+
+    verify(imageService).deleteImageAsync("https://s3.aws/old-host.jpg");
+    assertThat(host.getProfileImageUrl()).isEqualTo("https://s3.aws/new-host.jpg");
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
@@ -359,4 +359,18 @@ class UserServiceTest {
     verify(imageService, never()).deleteImageAsync(any());
     assertThat(user.getProfileImage()).isEqualTo("https://s3.aws/new-image.jpg");
   }
+
+  @Test
+  @DisplayName("사용자 프로필 이미지 변경 - 실패 (존재하지 않는 사용자)")
+  void updateProfileImage_fail_userNotFound() {
+    Long userId = 999L;
+    MultipartFile newImage = mock(MultipartFile.class);
+
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> userService.updateProfileImage(userId, newImage))
+        .isInstanceOf(MeongnyangerangException.class)
+        .extracting("errorCode")
+        .isEqualTo(NOT_EXIST_ACCOUNT);
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -337,6 +338,25 @@ class UserServiceTest {
 
     // then
     verify(imageService).deleteImageAsync("https://s3.aws/old-image.jpg");
+    assertThat(user.getProfileImage()).isEqualTo("https://s3.aws/new-image.jpg");
+  }
+
+  @Test
+  @DisplayName("사용자 프로필 이미지 변경 - 성공 (기존 이미지 X)")
+  void updateProfileImage_success_withoutExistingImage() {
+    Long userId = 2L;
+    MultipartFile newImage = mock(MultipartFile.class);
+    User user = User.builder()
+        .id(userId)
+        .profileImage(null)
+        .build();
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(imageService.storeImage(newImage)).willReturn("https://s3.aws/new-image.jpg");
+
+    userService.updateProfileImage(userId, newImage);
+
+    verify(imageService, never()).deleteImageAsync(any());
     assertThat(user.getProfileImage()).isEqualTo("https://s3.aws/new-image.jpg");
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/UserServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -37,6 +38,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -314,5 +316,27 @@ class UserServiceTest {
         .isInstanceOf(MeongnyangerangException.class)
         .extracting("errorCode")
         .isEqualTo(DUPLICATE_NICKNAME);
+  }
+
+  @Test
+  @DisplayName("사용자 프로필 이미지 변경 - 성공 (기존 이미지 O)")
+  void updateProfileImage_success_withExistingImage() {
+    // given
+    Long userId = 1L;
+    MultipartFile newImage = mock(MultipartFile.class);
+    User user = User.builder()
+        .id(userId)
+        .profileImage("https://s3.aws/old-image.jpg")
+        .build();
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(imageService.storeImage(newImage)).willReturn("https://s3.aws/new-image.jpg");
+
+    // when
+    userService.updateProfileImage(userId, newImage);
+
+    // then
+    verify(imageService).deleteImageAsync("https://s3.aws/old-image.jpg");
+    assertThat(user.getProfileImage()).isEqualTo("https://s3.aws/new-image.jpg");
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #180 

## 📝 변경 사항
### AS-IS
- 프로필 이미지 변경 API가 존재하지 않았음

### TO-BE
- 사용자/호스트 공통 `/api/v1/account/profile-image` API 추가
- 기존 이미지 존재 시 S3에서 삭제 후 새 이미지 저장
- `ImageService`를 통해 S3 연동 처리

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 프로필 사진 변경 성공(s3 확인 O)
![image](https://github.com/user-attachments/assets/d96cb15a-2dad-43d6-919a-cceaf97680cd)

- 프로필 사진 변경 실패(인증되지 않은 사용자)
![image](https://github.com/user-attachments/assets/790c7c16-c050-4d4f-9dcc-800e0d2f679c)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
