### PR TITLE
[Test] 숙소 목록 조회(필터) 테스트 추가 및 반려동물 등록 마리수 상수화

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserPetService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserPetService.java
@@ -21,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserPetService {
 
+  private static final int MAX_PET_COUNT = 10;
+
   private final UserRepository userRepository;
   private final UserPetRepository userPetRepository;
 
@@ -31,7 +33,7 @@ public class UserPetService {
         .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));
 
     // 최대 10마리 제한
-    if (userPetRepository.countByUserId(userId) >= 10) {
+    if (userPetRepository.countByUserId(userId) >= MAX_PET_COUNT) {
       throw new MeongnyangerangException(MAX_PET_COUNT_EXCEEDED);
     }
 

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchServiceTest.java
@@ -1,0 +1,137 @@
+package com.meongnyangerang.meongnyangerang.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
+import com.meongnyangerang.meongnyangerang.domain.AccommodationRoomDocument;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationType;
+import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchRequest;
+import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchResponse;
+import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
+import com.meongnyangerang.meongnyangerang.repository.ReservationSlotRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class AccommodationSearchServiceTest {
+
+  @Mock
+  private ElasticsearchClient elasticsearchClient;
+
+  @Mock
+  private ReservationSlotRepository reservationSlotRepository;
+
+  @InjectMocks
+  private AccommodationSearchService searchService;
+
+  @Test
+  @DisplayName("숙소 목록 조회(필터) - 성공")
+  void searchAccommodation_Success_MultipleHits() throws Exception {
+    // given
+    AccommodationSearchRequest request = new AccommodationSearchRequest(
+        "서울",
+        LocalDate.of(2025, 4, 18),
+        LocalDate.of(2025, 4, 19),
+        2, 1,
+        AccommodationType.PENSION,
+        50000L, 150000L, 4.0,
+        List.of("WIFI", "BREAKFAST"),
+        List.of("SHOWER_ROOM", "SWIMMING_POOL"),
+        List.of("AIR_CONDITIONER", "TV"),
+        List.of("FOOD_BOWL", "TOY"),
+        List.of("FAMILY_TRIP", "OCEAN_VIEW"),
+        List.of("SMALL_DOG", "CAT")
+    );
+
+    AccommodationRoomDocument doc1 = AccommodationRoomDocument.builder()
+        .accommodationId(1L)
+        .roomId(101L)
+        .accommodationName("서울의 휴양지")
+        .roomName("스위트룸")
+        .address("서울 강남구")
+        .thumbnailUrl("https://img.example.com/room1.jpg")
+        .totalRating(4.7)
+        .price(120000L)
+        .standardPeopleCount(2)
+        .maxPeopleCount(4)
+        .standardPetCount(1)
+        .maxPetCount(2)
+        .accommodationType(AccommodationType.PENSION)
+        .accommodationFacilities(List.of("WIFI", "BREAKFAST"))
+        .accommodationPetFacilities(List.of("SHOWER_ROOM", "SWIMMING_POOL"))
+        .roomFacilities(List.of("AIR_CONDITIONER", "TV"))
+        .roomPetFacilities(List.of("FOOD_BOWL", "TOY"))
+        .hashtags(List.of("FAMILY_TRIP", "OCEAN_VIEW"))
+        .allowPets(List.of("SMALL_DOG", "CAT"))
+        .build();
+
+    AccommodationRoomDocument doc2 = AccommodationRoomDocument.builder()
+        .accommodationId(2L)
+        .roomId(201L)
+        .accommodationName("서울의 감성숙소")
+        .roomName("디럭스룸")
+        .address("서울 마포구")
+        .thumbnailUrl("https://img.example.com/room2.jpg")
+        .totalRating(4.8)
+        .price(95000L)
+        .standardPeopleCount(2)
+        .maxPeopleCount(3)
+        .standardPetCount(1)
+        .maxPetCount(2)
+        .accommodationType(AccommodationType.PENSION)
+        .accommodationFacilities(List.of("WIFI"))
+        .accommodationPetFacilities(List.of("PLAYGROUND"))
+        .roomFacilities(List.of("AIR_CONDITIONER"))
+        .roomPetFacilities(List.of("FOOD_BOWL"))
+        .hashtags(List.of("COZY"))
+        .allowPets(List.of("SMALL_DOG"))
+        .build();
+
+    Hit<AccommodationRoomDocument> hit1 = Hit.of(h -> h
+        .index("accommodation_room").id("1_101").source(doc1));
+    Hit<AccommodationRoomDocument> hit2 = Hit.of(h -> h
+        .index("accommodation_room").id("2_201").source(doc2));
+
+    SearchResponse<AccommodationRoomDocument> mockResponse = SearchResponse.of(s -> s
+        .took(15)
+        .timedOut(false)
+        .shards(sh -> sh.total(1).successful(1).skipped(0).failed(0))
+        .hits(h -> h
+            .hits(List.of(hit1, hit2))
+            .total(t -> t.value(2L).relation(TotalHitsRelation.Eq))
+        )
+    );
+
+    given(reservationSlotRepository.findReservedRoomIdsBetweenDates(
+        request.getCheckInDate(), request.getCheckOutDate().minusDays(1)))
+        .willReturn(List.of());
+
+    given(elasticsearchClient.search(any(Function.class), eq(AccommodationRoomDocument.class)))
+        .willReturn(mockResponse);
+
+    // when
+    PageResponse<AccommodationSearchResponse> response =
+        searchService.searchAccommodation(request, PageRequest.of(0, 20));
+
+    // then
+    assertThat(response.content()).hasSize(2);
+    assertThat(response.content()).extracting("accommodationId")
+        .containsExactlyInAnyOrder(1L, 2L);
+  }
+}
+
+


### PR DESCRIPTION
## 📌 관련 이슈
- close #184 

## 📝 변경 사항
### AS-IS
- 숙소 목록 검색 API 테스트 없음
- 반려동물 등록 수 제한을 `10`이라는 매직 넘버로 직접 사용

### TO-BE
- 숙소 목록 검색 테스트 작성 (다중 결과 + 실패 시 예외 처리)
- 반려동물 등록 수 제한을 `MAX_PET_COUNT`로 상수화

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
