### PR TITLE
[Refactor] 찜 목록 조회를 Pageable 기반으로 변경하고 숙소 검색 offset 처리 개선

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/WishlistController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/WishlistController.java
@@ -1,11 +1,14 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
-import com.meongnyangerang.meongnyangerang.dto.CustomWishlistResponse;
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
 import com.meongnyangerang.meongnyangerang.dto.WishlistResponse;
+import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.WishlistService;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.validator.constraints.Range;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -13,7 +16,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -41,12 +43,10 @@ public class WishlistController {
 
   // 찜 조회 API
   @GetMapping
-  public ResponseEntity<CustomWishlistResponse<WishlistResponse>> getUserWishlist(
+  public ResponseEntity<PageResponse<WishlistResponse>> getUserWishlist(
       @AuthenticationPrincipal UserDetailsImpl userDetails,
-      @RequestParam(defaultValue = "0") Long cursor,
-      @RequestParam(defaultValue = "20") @Range(min = 1, max = 100) int size) {
+      @PageableDefault(size = 20, sort = "createdAt", direction = DESC) Pageable pageable) {
 
-    return ResponseEntity.ok(wishlistService.getUserWishlists(userDetails.getId(), cursor, size));
+    return ResponseEntity.ok(wishlistService.getUserWishlists(userDetails.getId(), pageable));
   }
-
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/WishlistRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/WishlistRepository.java
@@ -1,28 +1,18 @@
 package com.meongnyangerang.meongnyangerang.repository;
 
 import com.meongnyangerang.meongnyangerang.domain.user.Wishlist;
-import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
+
   boolean existsByUserIdAndAccommodationId(Long userId, Long accommodationId);
 
   Optional<Wishlist> findByUserIdAndAccommodationId(Long userId, Long accommodationId);
 
-  @Query(value = """
-      SELECT * FROM wishlist w
-      WHERE w.user_id = :userId
-        AND (:cursorId = 0 OR w.id <= :cursorId)
-      ORDER BY w.created_at DESC
-      LIMIT :size
-  """, nativeQuery = true)
-  List<Wishlist> findByUserId(
-      @Param("userId") Long userId,
-      @Param("cursorId") Long cursorId,
-      @Param("size") int size);
+  Page<Wishlist> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
@@ -80,7 +80,7 @@ public class AccommodationSearchService {
               .index("accommodation_room")
               .query(finalQuery)
               .size(pageable.getPageSize())
-              .from((int) pageable.getOffset())
+              .from(Math.toIntExact(pageable.getOffset()))
               .sort(so -> so
                   .field(f -> f
                       .field("totalRating")

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
@@ -8,17 +8,15 @@ import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_
 import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.Wishlist;
-import com.meongnyangerang.meongnyangerang.dto.CustomWishlistResponse;
 import com.meongnyangerang.meongnyangerang.dto.WishlistResponse;
+import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
-import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
-import java.util.List;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,32 +57,22 @@ public class WishlistService {
   }
 
   // 찜 목록 조회
-  public CustomWishlistResponse<WishlistResponse> getUserWishlists(Long userId, Long cursorId,
-      int size) {
+  public PageResponse<WishlistResponse> getUserWishlists(Long userId, Pageable pageable) {
 
-    // size + 1개 조회해서 hasNext 판단
-    List<Wishlist> wishlists = wishlistRepository.findByUserId(userId, cursorId, size + 1);
+    Page<Wishlist> wishlists = wishlistRepository.findByUserId(userId, pageable);
 
-    boolean hasNext = wishlists.size() > size;
-    Long nextCursor = hasNext ? wishlists.get(size).getId() : null;
+    Page<WishlistResponse> responsePage = wishlists.map(wishlist -> {
+      Accommodation accommodation = wishlist.getAccommodation();
+      return WishlistResponse.builder()
+          .wishlistId(wishlist.getId())
+          .accommodationId(accommodation.getId())
+          .accommodationName(accommodation.getName())
+          .thumbnailImageUrl(accommodation.getThumbnailUrl())
+          .address(accommodation.getAddress())
+          .totalRating(accommodation.getTotalRating())
+          .build();
+    });
 
-    // 현재 페이지 찜 목록만 사용
-    List<WishlistResponse> content = wishlists.stream()
-        .limit(size)
-        .map(wishlist -> {
-          Accommodation accommodation = wishlist.getAccommodation();
-
-          return WishlistResponse.builder()
-              .wishlistId(wishlist.getId())
-              .accommodationId(accommodation.getId())
-              .accommodationName(accommodation.getName())
-              .thumbnailImageUrl(accommodation.getThumbnailUrl())
-              .address(accommodation.getAddress())
-//              .totalRating(accommodation.getTotalRating())   // 추후 숙소 엔티티에 totalRating 필드가 생성되면 수정 예정
-              .build();
-        })
-        .toList();
-
-    return new CustomWishlistResponse<>(content, nextCursor, hasNext);
+    return PageResponse.from(responsePage);
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
@@ -13,6 +13,7 @@ import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.Wishlist;
 import com.meongnyangerang.meongnyangerang.dto.CustomWishlistResponse;
 import com.meongnyangerang.meongnyangerang.dto.WishlistResponse;
+import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
@@ -28,6 +29,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class WishlistServiceTest {
@@ -138,18 +143,18 @@ class WishlistServiceTest {
   }
 
   @Test
-  @DisplayName("찜 목록 조회 - hasNext 있음")
-  void getUserWishlists_HasNext() {
+  @DisplayName("찜 목록 조회 - 페이징 성공")
+  void getUserWishlists_PageableSuccess() {
     // given
     Long userId = 1L;
-    Long cursorId = 0L;
-    int size = 2;
+    Pageable pageable = PageRequest.of(0, 2);
 
     Accommodation acc1 = Accommodation.builder()
         .id(100L)
         .name("숙소1")
         .thumbnailUrl("thumb1.jpg")
         .address("서울시 강남구")
+        .totalRating(4.7)
         .build();
 
     Accommodation acc2 = Accommodation.builder()
@@ -157,71 +162,56 @@ class WishlistServiceTest {
         .name("숙소2")
         .thumbnailUrl("thumb2.jpg")
         .address("서울시 종로구")
-        .build();
-
-    Accommodation acc3 = Accommodation.builder()
-        .id(102L)
-        .name("숙소3")
-        .thumbnailUrl("thumb3.jpg")
-        .address("서울시 마포구")
+        .totalRating(4.8)
         .build();
 
     Wishlist w1 = Wishlist.builder().id(1L).accommodation(acc1).build();
     Wishlist w2 = Wishlist.builder().id(2L).accommodation(acc2).build();
-    Wishlist w3 = Wishlist.builder().id(3L).accommodation(acc3).build();
 
-    List<Wishlist> wishlistMock = List.of(w1, w2, w3); // size+1 → hasNext true
+    Page<Wishlist> page = new PageImpl<>(List.of(w1, w2), pageable, 2);
 
-    when(wishlistRepository.findByUserId(userId, cursorId, size + 1)).thenReturn(wishlistMock);
+    when(wishlistRepository.findByUserId(userId, pageable)).thenReturn(page);
 
     // when
-    CustomWishlistResponse<WishlistResponse> result = wishlistService.getUserWishlists(userId, cursorId, size);
+    PageResponse<WishlistResponse> result = wishlistService.getUserWishlists(userId, pageable);
 
     // then
-    assertThat(result.getContent()).hasSize(2);
-    assertThat(result.isHasNext()).isTrue();
-    assertThat(result.getNextCursor()).isEqualTo(3L);
+    assertThat(result.content()).hasSize(2);
+    assertThat(result.totalElements()).isEqualTo(2);
+    assertThat(result.totalPages()).isEqualTo(1);
+    assertThat(result.page()).isEqualTo(0);
+    assertThat(result.first()).isTrue();
+    assertThat(result.last()).isTrue();
 
-    WishlistResponse first = result.getContent().get(0);
-    assertThat(first.getAccommodationName()).isEqualTo("숙소1");
-    assertThat(first.getAddress()).isEqualTo("서울시 강남구");
+    assertThat(result.content().get(0).getAccommodationName()).isEqualTo("숙소1");
+    assertThat(result.content().get(1).getAccommodationName()).isEqualTo("숙소2");
   }
 
   @Test
-  @DisplayName("찜 목록 조회 - hasNext 없음")
-  void getUserWishlists_HasNextFalse() {
+  @DisplayName("찜 목록 조회 - 여러 페이지 중 일부 조회")
+  void getUserWishlists_MiddlePage() {
     // given
     Long userId = 1L;
-    Long cursorId = 0L;
-    int size = 2;
+    Pageable pageable = PageRequest.of(1, 2); // 두 번째 페이지
 
-    Accommodation acc1 = Accommodation.builder()
-        .id(100L)
-        .name("숙소1")
-        .thumbnailUrl("thumb1.jpg")
-        .address("서울시 강남구")
-        .build();
+    Accommodation acc1 = Accommodation.builder().id(1L).name("숙소1").address("서울시").thumbnailUrl("thumb1").build();
+    Accommodation acc2 = Accommodation.builder().id(2L).name("숙소2").address("부산시").thumbnailUrl("thumb2").build();
 
-    Accommodation acc2 = Accommodation.builder()
-        .id(101L)
-        .name("숙소2")
-        .thumbnailUrl("thumb2.jpg")
-        .address("서울시 종로구")
-        .build();
+    Wishlist w1 = Wishlist.builder().id(101L).accommodation(acc1).build();
+    Wishlist w2 = Wishlist.builder().id(102L).accommodation(acc2).build();
 
-    Wishlist w1 = Wishlist.builder().id(1L).accommodation(acc1).build();
-    Wishlist w2 = Wishlist.builder().id(2L).accommodation(acc2).build();
+    List<Wishlist> wishlists = List.of(w1, w2);
+    Page<Wishlist> page = new PageImpl<>(wishlists, pageable, 6); // 총 6개, 총 3페이지
 
-    List<Wishlist> wishlistMock = List.of(w1, w2); // size == list.size → hasNext false
-
-    when(wishlistRepository.findByUserId(userId, cursorId, size + 1)).thenReturn(wishlistMock);
+    when(wishlistRepository.findByUserId(userId, pageable)).thenReturn(page);
 
     // when
-    CustomWishlistResponse<WishlistResponse> result = wishlistService.getUserWishlists(userId, cursorId, size);
+    PageResponse<WishlistResponse> response = wishlistService.getUserWishlists(userId, pageable);
 
     // then
-    assertThat(result.getContent()).hasSize(2);
-    assertThat(result.isHasNext()).isFalse();
-    assertThat(result.getNextCursor()).isNull();
+    assertThat(response.page()).isEqualTo(1);
+    assertThat(response.totalPages()).isEqualTo(3);
+    assertThat(response.first()).isFalse();
+    assertThat(response.last()).isFalse();
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #190 

## 📝 변경 사항
### AS-IS
- 찜 목록 조회 시 cursor 기반 페이징
- 숙소 검색 offset 캐스팅: `(int) pageable.getOffset()`

### TO-BE
- 찜 목록 조회 API를 Pageable 방식으로 수정
- 숙소 검색 시 `.from(Math.toIntExact(pageable.getOffset()))` 적용

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 찜 목목 조회(페이징 처리)
![image](https://github.com/user-attachments/assets/09920061-c5bf-4c27-9b7b-2837c4a857f0)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다
