### PR TITLE
[hotfix]: 채팅 서비스 테스트에서 안 읽은 메시지 수를 가져오는 쿼리 메서드 변경

### DIFF
--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ChatServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ChatServiceTest.java
@@ -303,9 +303,9 @@ class ChatServiceTest {
     when(chatReadStatusRepository.findByChatRoomIdAndParticipantIdAndParticipantType(
         chatRoomId2, userId, senderType)).thenReturn(Optional.empty());
 
-    when(chatMessageRepository.countUnreadMessages(
+    when(chatMessageRepository.countByChatRoomIdAndSenderTypeAndCreatedAtGreaterThan(
         chatRoomId1, SenderType.HOST, userReadStatus.getLastReadTime())).thenReturn(2);
-    when(chatMessageRepository.countUnreadMessages(
+    when(chatMessageRepository.countByChatRoomIdAndSenderTypeAndCreatedAtGreaterThan(
         chatRoomId2, SenderType.HOST, DEFAULT_LAST_READ_TIME)).thenReturn(0);
 
     // when
@@ -373,9 +373,9 @@ class ChatServiceTest {
     when(chatReadStatusRepository.findByChatRoomIdAndParticipantIdAndParticipantType(
         chatRoomId2, hostId, senderType)).thenReturn(Optional.empty());
 
-    when(chatMessageRepository.countUnreadMessages(
+    when(chatMessageRepository.countByChatRoomIdAndSenderTypeAndCreatedAtGreaterThan(
         chatRoomId1, SenderType.USER, userReadStatus.getLastReadTime())).thenReturn(0);
-    when(chatMessageRepository.countUnreadMessages(
+    when(chatMessageRepository.countByChatRoomIdAndSenderTypeAndCreatedAtGreaterThan(
         chatRoomId2, SenderType.USER, DEFAULT_LAST_READ_TIME)).thenReturn(3);
 
     // when


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 채팅 서비스 테스트에서 countUnreadMessages 메서드 사용 중
- 해당 메서드는 리팩토링 과정에서 제거됐기 때문에 메서드 변경 필요

### TO-BE
- countByChatRoomIDAndSenderTypeAndCretaeedAtGreaterThan 메서드 사용하도록 수정
- JPA 명명규칙을 사용한 메서드

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.