### PR TITLE
[Feature] 리뷰 등록/수정/삭제 시 숙소 평점 색인 자동 반영 기능 추가

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
@@ -122,6 +122,10 @@ public class ReviewService {
     // 숙소 총 평점 업데이트
     updateAccommodationRatingOnDelete(accommodation, userRating,
         petFriendlyRating);
+
+    // elasticsearch 색인 업데이트
+    accommodationRoomSearchService.updateAllRooms(accommodation,
+        roomRepository.findAllByAccommodationId(accommodation.getId()));
   }
 
   @Transactional

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
@@ -151,6 +151,11 @@ public class ReviewService {
     // 숙소 총 평점 업데이트
     updateAccommodationRating(review.getAccommodation(), oldRating, request.getUserRating(),
         request.getPetFriendlyRating());
+
+    // elasticsearch 색인 업데이트
+    Accommodation accommodation = review.getAccommodation();
+    accommodationRoomSearchService.updateAllRooms(accommodation,
+        roomRepository.findAllByAccommodationId(accommodation.getId()));
   }
 
   /**


### PR DESCRIPTION
## 📌 관련 이슈
- close #197 

## 📝 변경 사항
### AS-IS
- 숙소에 대한 리뷰를 작성해도 Elasticsearch 색인(totalRating)은 0.0 그대로 유지됨
- 검색 API에서 평점 필터(minRating)가 정상 작동하지 않음

### TO-BE
- 리뷰 등록/수정/삭제 시 Elasticsearch 색인을 자동으로 갱신함
  - `accommodationRoomSearchService.updateAllRooms(...)` 호출로 숙소의 모든 객실 문서를 재색인

## 🔍 테스트
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 처음 숙소, 객실 등록 시 TotalRating = 0.0(기본값)
![image](https://github.com/user-attachments/assets/3ee133a8-a3a1-4fac-92b3-abfbd49faba4)

- 리뷰 작성/수정/삭제 시 TotalRating 값 리뷰 평점에 따라 바뀜
![image](https://github.com/user-attachments/assets/f6370075-3e94-46f9-b09c-d83650855fe0)
![image](https://github.com/user-attachments/assets/860a8aa0-018e-4d0b-82e2-7d889b1d7eec)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 색인 구조가 숙소-객실 단위이므로 숙소 전체 객실 재색인 처리가 필요했습니다.
- 중복 로직 없이 서비스 계층에서 일관성 있게 처리했습니다.
