### PR TITLE
[Feature] 리뷰 신고 API 구현 및 테스트

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
@@ -71,6 +71,7 @@ public class SecurityConfig {
             .requestMatchers("/api/v1/hosts/**").hasAuthority("ROLE_HOST")
             .requestMatchers("/api/v1/admin/**").hasAuthority("ROLE_ADMIN")
             .requestMatchers("/api/v1/account/**").hasAnyAuthority("ROLE_USER", "ROLE_HOST")
+            .requestMatchers("/api/v1/reviews/**").hasAnyAuthority("ROLE_USER", "ROLE_HOST")
             .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
         )
         .addFilterBefore(jwtAuthenticationFilter,

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewController.java
@@ -104,7 +104,7 @@ public class ReviewController {
   }
 
   // 최신 리뷰 10개 조회
-  @GetMapping("users/latest-reviews")
+  @GetMapping("/users/latest-reviews")
   public ResponseEntity<List<LatestReviewResponse>> getLatestReviews() {
 
     return ResponseEntity.ok(reviewService.getLatestReviews());

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewReportController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewReportController.java
@@ -3,6 +3,7 @@ package com.meongnyangerang.meongnyangerang.controller;
 import com.meongnyangerang.meongnyangerang.dto.ReviewReportRequest;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.ReviewReportService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,7 +25,7 @@ public class ReviewReportController {
   @PostMapping("/reviews/{reviewId}/report")
   public ResponseEntity<Void> reportReview(
       @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long reviewId,
-      @RequestPart ReviewReportRequest request,
+      @RequestPart @Valid ReviewReportRequest request,
       @RequestPart(required = false) MultipartFile evidenceImage) {
 
     reviewReportService.createReport(userDetails, reviewId, request, evidenceImage);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewReportController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReviewReportController.java
@@ -1,0 +1,35 @@
+package com.meongnyangerang.meongnyangerang.controller;
+
+import com.meongnyangerang.meongnyangerang.dto.ReviewReportRequest;
+import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
+import com.meongnyangerang.meongnyangerang.service.ReviewReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ReviewReportController {
+
+  private final ReviewReportService reviewReportService;
+
+  // 리뷰 신고
+  @PostMapping("/reviews/{reviewId}/report")
+  public ResponseEntity<Void> reportReview(
+      @AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long reviewId,
+      @RequestPart ReviewReportRequest request,
+      @RequestPart(required = false) MultipartFile evidenceImage) {
+
+    reviewReportService.createReport(userDetails, reviewId, request, evidenceImage);
+
+    return ResponseEntity.ok().build();
+  }
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/review/ReportStatus.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/review/ReportStatus.java
@@ -1,0 +1,6 @@
+package com.meongnyangerang.meongnyangerang.domain.review;
+
+public enum ReportStatus {
+  PENDING,
+  COMPLETED
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/review/ReporterType.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/review/ReporterType.java
@@ -1,0 +1,6 @@
+package com.meongnyangerang.meongnyangerang.domain.review;
+
+public enum ReporterType {
+  USER,
+  HOST
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/review/ReviewReport.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/review/ReviewReport.java
@@ -5,9 +5,12 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,6 +33,10 @@ public class ReviewReport {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "review_id", nullable = false)
+  private Review review;
+
   @Column(nullable = false)
   private Long reporterId;
 
@@ -49,14 +56,6 @@ public class ReviewReport {
   @CreatedDate
   @Column(nullable = false)
   private LocalDateTime createdAt;
-
-  enum ReporterType {
-    USER, HOST;
-  }
-
-  enum ReportStatus {
-    PENDING, COMPLETED;
-  }
 }
 
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/AccommodationReviewResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/AccommodationReviewResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @Builder
 public class AccommodationReviewResponse {
 
+  private Long reviewId;
   private String roomName;
   private String nickname;
   private String profileImageUrl;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportRequest.java
@@ -6,6 +6,7 @@ import com.meongnyangerang.meongnyangerang.domain.review.Review;
 import com.meongnyangerang.meongnyangerang.domain.review.ReviewReport;
 import com.meongnyangerang.meongnyangerang.domain.user.Role;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class ReviewReportRequest {
 
+  @NotBlank
   private String reason;
 
   public ReviewReport toEntity(UserDetailsImpl userDetails, Review review,

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportRequest.java
@@ -1,0 +1,33 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import com.meongnyangerang.meongnyangerang.domain.review.ReportStatus;
+import com.meongnyangerang.meongnyangerang.domain.review.ReporterType;
+import com.meongnyangerang.meongnyangerang.domain.review.Review;
+import com.meongnyangerang.meongnyangerang.domain.review.ReviewReport;
+import com.meongnyangerang.meongnyangerang.domain.user.Role;
+import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewReportRequest {
+
+  private String reason;
+
+  public ReviewReport toEntity(UserDetailsImpl userDetails, Review review,
+      String evidenceImageUrl) {
+    return ReviewReport.builder()
+        .review(review)
+        .reporterId(userDetails.getId())
+        .type(userDetails.getRole() == Role.ROLE_USER ? ReporterType.USER : ReporterType.HOST)
+        .reason(this.reason)
+        .evidenceImageUrl(evidenceImageUrl == null ? "" : evidenceImageUrl)
+        .status(ReportStatus.PENDING)
+        .build();
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -30,8 +30,9 @@ public enum ErrorCode {
   MAX_PET_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "반려동물은 최대 10마리까지 등록할 수 있습니다."),
   ALREADY_REGISTERED_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 등록된 전화번호입니다."),
   DUPLICATE_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 사용 중인 전화번호입니다."),
-  ALREADY_REGISTERED_NAME(HttpStatus.BAD_REQUEST,"이미 등록된 이름입니다."),
+  ALREADY_REGISTERED_NAME(HttpStatus.BAD_REQUEST, "이미 등록된 이름입니다."),
   ALREADY_REGISTERED_NICKNAME(HttpStatus.BAD_REQUEST, "기존 닉네임과 동일합니다."),
+  REVIEW_REPORT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 신고된 리뷰입니다."),
 
   // 400 BAD REQUEST (JWT 관련 요청 오류)
   INVALID_JWT_FORMAT(HttpStatus.BAD_REQUEST, "JWT 형식이 올바르지 않습니다."),
@@ -52,7 +53,7 @@ public enum ErrorCode {
   NOTIFICATION_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "알림 발송 권한이 없음"),
   WEBSOCKET_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "WebSocket 권한 없음"),
 
-  // 404  NOT FOUND
+  // 404 NOT FOUND
   NOT_EXIST_ACCOUNT(HttpStatus.BAD_REQUEST, "해당 계정은 존재하지 않습니다."),
   NOT_EXISTS_HOST(HttpStatus.NOT_FOUND, "존재하지 않는 호스트입니다."),
   FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일이 존재하지 않습니다."),
@@ -91,8 +92,7 @@ public enum ErrorCode {
   SEARCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "숙소 검색 중 오류가 발생했습니다."),
   USER_RECOMMENDATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 맞춤 추천 조회 중 오류가 발생했습니다."),
   ELASTICSEARCH_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인덱스에 문서를 저장하는 도중 오류가 발생했습니다."),
-  DOCUMENT_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "해당 문서를 업데이트 하는 도중 오류가 발생했습니다.")
-  ;
+  DOCUMENT_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "해당 문서를 업데이트 하는 도중 오류가 발생했습니다.");
 
   private final HttpStatus status;
   private final String description;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewReportRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewReportRepository.java
@@ -1,0 +1,11 @@
+package com.meongnyangerang.meongnyangerang.repository;
+
+import com.meongnyangerang.meongnyangerang.domain.review.Review;
+import com.meongnyangerang.meongnyangerang.domain.review.ReviewReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewReportRepository extends JpaRepository<ReviewReport, Long> {
+
+  boolean existsByReporterIdAndReview(Long reporterId, Review review);
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
@@ -141,7 +141,7 @@ public class AccommodationRoomSearchService {
     }
   }
 
-  // 추가 객실 등록 또는 숙소/객실 수정, 객실 삭제 시, 최소 가격과 반려동물 편의시설을 기존 문서에 업데이트
+  // 추가 객실 등록 또는 숙소/객실 수정, 객실 삭제 시, 기존 문서에 업데이트
   public void updateAccommodationDocument(Accommodation accommodation) {
     List<Room> rooms = roomRepository.findAllByAccommodationId(accommodation.getId());
 
@@ -154,9 +154,12 @@ public class AccommodationRoomSearchService {
     long minPrice = calculateMinRoomPrice(rooms);
 
     Map<String, Object> doc = Map.of(
+        "name", accommodation.getName(),
+        "thumbnailUrl", accommodation.getThumbnailUrl(),
         "price", minPrice,
         "accommodationPetFacilities", updatedAccommodationPetFacilities,
-        "roomPetFacilities", updatedRoomPetFacilities
+        "roomPetFacilities", updatedRoomPetFacilities,
+        "allowedPetTypes", getAllowedPetTypes(accommodation)
     );
 
     try {

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
@@ -1,0 +1,49 @@
+package com.meongnyangerang.meongnyangerang.service;
+
+import com.meongnyangerang.meongnyangerang.domain.review.Review;
+import com.meongnyangerang.meongnyangerang.domain.review.ReviewReport;
+import com.meongnyangerang.meongnyangerang.dto.ReviewReportRequest;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
+import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import com.meongnyangerang.meongnyangerang.repository.ReviewReportRepository;
+import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
+import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
+import com.meongnyangerang.meongnyangerang.service.image.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewReportService {
+
+  private final ReviewReportRepository reviewReportRepository;
+  private final ReviewRepository reviewRepository;
+  private final ImageService imageService;
+
+  // 리뷰 신고 생성
+  @Transactional
+  public void createReport(UserDetailsImpl userDetails, Long reviewId,
+      ReviewReportRequest request, MultipartFile evidenceImage) {
+    Review review = reviewRepository.findById(reviewId)
+        .orElseThrow(() -> new MeongnyangerangException(ErrorCode.REVIEW_NOT_FOUND));
+
+    boolean check = reviewReportRepository.existsByReporterIdAndReview(userDetails.getId(), review);
+
+    if (check) {
+      throw new MeongnyangerangException(ErrorCode.REVIEW_REPORT_ALREADY_EXISTS);
+    }
+
+    review.setReportCount(review.getReportCount() + 1);
+
+    String storedImageUrl = null;
+    if (evidenceImage != null && !evidenceImage.isEmpty()) {
+      storedImageUrl = imageService.storeImage(evidenceImage);
+    }
+
+    ReviewReport report = request.toEntity(userDetails, review, storedImageUrl);
+
+    reviewReportRepository.save(report);
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
@@ -254,6 +254,7 @@ public class ReviewService {
     DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     return AccommodationReviewResponse.builder()
+        .reviewId(review.getId())
         .roomName(review.getReservation().getRoom().getName())
         .profileImageUrl(review.getUser().getProfileImage())
         .reviewImages(reviewImages.stream().map(ReviewImage::getImageUrl).toList())

--- a/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
@@ -1,0 +1,153 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.meongnyangerang.meongnyangerang.domain.review.Review;
+import com.meongnyangerang.meongnyangerang.domain.review.ReviewReport;
+import com.meongnyangerang.meongnyangerang.domain.user.Role;
+import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
+import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import com.meongnyangerang.meongnyangerang.repository.ReviewReportRepository;
+import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
+import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
+import com.meongnyangerang.meongnyangerang.service.ReviewReportService;
+import com.meongnyangerang.meongnyangerang.service.image.ImageService;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewReportServiceTest {
+
+  @Mock
+  private ReviewReportRepository reviewReportRepository;
+
+  @Mock
+  private ReviewRepository reviewRepository;
+
+  @Mock
+  private ImageService imageService;
+
+  @InjectMocks
+  private ReviewReportService reviewReportService;
+
+  @Test
+  @DisplayName("리뷰 신고 - 성공 (사진 O)")
+  void createReport_success() {
+    // given
+    long reviewId = 1L;
+
+    Review review = Review.builder().id(reviewId).reportCount(0).build();
+    ReviewReportRequest request = ReviewReportRequest.builder().reason("욕설을 사용합니다.").build();
+    MockMultipartFile file = new MockMultipartFile("image", "test-image.jpg", "image/jpeg",
+        "image content".getBytes());
+
+    when(reviewRepository.findById(reviewId)).thenReturn(Optional.ofNullable(review));
+    when(reviewReportRepository.existsByReporterIdAndReview(1L, review)).thenReturn(false);
+    when(imageService.storeImage(file)).thenReturn(
+        "https://storage.example.com/images/test-image.jpg");
+
+    ArgumentCaptor<ReviewReport> captor = ArgumentCaptor.forClass(ReviewReport.class);
+
+    // when
+    reviewReportService.createReport(
+        new UserDetailsImpl(1L, "test@gmail.com", "test1234!", Role.ROLE_USER,
+            UserStatus.valueOf("ACTIVE")), reviewId, request, file);
+
+    // then
+    verify(reviewReportRepository, times(1)).save(captor.capture());
+    ReviewReport saved = captor.getValue();
+    assertEquals(1L, saved.getReporterId());
+    assertEquals(review, saved.getReview());
+    assertEquals(1, review.getReportCount());
+    assertEquals("https://storage.example.com/images/test-image.jpg", saved.getEvidenceImageUrl());
+  }
+
+  @Test
+  @DisplayName("리뷰 신고 - 성공 (사진 X)")
+  void createReport_image_null_success() {
+    // given
+    long reviewId = 1L;
+
+    Review review = Review.builder().id(reviewId).reportCount(0).build();
+    ReviewReportRequest request = ReviewReportRequest.builder().reason("욕설을 사용합니다.").build();
+    MockMultipartFile file = null;
+
+    when(reviewRepository.findById(reviewId)).thenReturn(Optional.ofNullable(review));
+    when(reviewReportRepository.existsByReporterIdAndReview(1L, review)).thenReturn(false);
+
+    ArgumentCaptor<ReviewReport> captor = ArgumentCaptor.forClass(ReviewReport.class);
+
+    // when
+    reviewReportService.createReport(
+        new UserDetailsImpl(1L, "test@gmail.com", "test1234!", Role.ROLE_USER,
+            UserStatus.valueOf("ACTIVE")), reviewId, request, file);
+
+    // then
+    verify(reviewReportRepository, times(1)).save(captor.capture());
+    verify(imageService, times(0)).storeImage(file);
+    ReviewReport saved = captor.getValue();
+    assertEquals(1L, saved.getReporterId());
+    assertEquals(review, saved.getReview());
+    assertEquals(1, review.getReportCount());
+  }
+
+  @Test
+  @DisplayName("리뷰 신고 - 실패 (리뷰 존재 X)")
+  void createReport_review_not_found() {
+    // given
+    long reviewId = 1L;
+
+    ReviewReportRequest request = ReviewReportRequest.builder().reason("욕설을 사용합니다.").build();
+    MockMultipartFile file = new MockMultipartFile("image", "test-image.jpg", "image/jpeg",
+        "image content".getBytes());
+
+    when(reviewRepository.findById(reviewId)).thenReturn(Optional.empty());
+
+    // when
+    MeongnyangerangException e = assertThrows(MeongnyangerangException.class, () -> {
+      reviewReportService.createReport(
+          new UserDetailsImpl(1L, "test@gmail.com", "test1234!", Role.ROLE_USER,
+              UserStatus.valueOf("ACTIVE")), reviewId, request, file);
+    });
+
+    // then
+    assertEquals(ErrorCode.REVIEW_NOT_FOUND, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("리뷰 신고 - 실패 (리뷰 신고 존재 O)")
+  void createReport_review_report_already_exists() {
+    // given
+    long reviewId = 1L;
+
+    Review review = Review.builder().id(reviewId).reportCount(0).build();
+    ReviewReportRequest request = ReviewReportRequest.builder().reason("욕설을 사용합니다.").build();
+    MockMultipartFile file = new MockMultipartFile("image", "test-image.jpg", "image/jpeg",
+        "image content".getBytes());
+
+    when(reviewRepository.findById(reviewId)).thenReturn(Optional.ofNullable(review));
+    when(reviewReportRepository.existsByReporterIdAndReview(1L, review)).thenReturn(true);
+
+    // when
+    MeongnyangerangException e = assertThrows(MeongnyangerangException.class, () -> {
+      reviewReportService.createReport(
+          new UserDetailsImpl(1L, "test@gmail.com", "test1234!", Role.ROLE_USER,
+              UserStatus.valueOf("ACTIVE")), reviewId, request, file);
+    });
+
+    // then
+    assertEquals(ErrorCode.REVIEW_REPORT_ALREADY_EXISTS, e.getErrorCode());
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #200 

## 📝 변경 사항
### AS-IS
- 기존에 "최신 리뷰 조회 API" url에 `/` 가 빠져있었음.
- 기존 엘라스틱 서치 문서 업데이트 로직에 `thumbnail`, `name` 등 을 업데이트가 안되고 있었음.
- `ReviewReport` 엔티티에 `Review` 연관 관계가 빠져있었고, 내부에 enum 클래스를 관리 했었음.
- "리뷰 신고 API" 가 없어서 리뷰 신고가 불가능 했었음.
- "숙소 리뷰 목록 조회 API" 응답에 `reviewId` 가 빠져있었음.

### TO-BE
- "최신 리뷰 조회 API" URL에 누락된 /를 추가하여 정상적으로 호출 가능하도록 수정
- ReviewReport 엔티티에 Review 연관 관계를 추가하고, enum 클래스를 별도로 분리
- 엘라스틱서치 문서 업데이트 로직을 개선하여 thumbnail, name 등의 필드도 업데이트 가능하도록 수정
- 리뷰 신고 기능을 위한 "리뷰 신고 API"를 추가하여 신고 로직 구현
- "숙소 리뷰 목록 조회 API" 응답 객체에 reviewId 필드를 추가

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 성공 (비교 사진 포함)
![리뷰 신고 - 성공](https://github.com/user-attachments/assets/df2bc470-2423-4561-920d-89f131ff2a20)
![리뷰 신고 비교사진 1](https://github.com/user-attachments/assets/f51e570e-7c99-4c2a-88f4-733953408522)
![리뷰 신고 성공 후 db 사진](https://github.com/user-attachments/assets/69d7b0d1-494a-437c-99cc-000753419696)

- 실패 (존재하지 않는 리뷰)
![리뷰 신고 - 실패 리뷰가 없는 경우](https://github.com/user-attachments/assets/20c02066-f9f3-4dcf-8de8-0a87938c8f04)

- 실패 (이미 신고한 리뷰)
![리뷰 신고 - 실패 이미 신고한 경우](https://github.com/user-attachments/assets/5d29fb7a-bf52-4178-91f0-ff50d48f3f11)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.