### PR TITLE
[Feat] 리뷰 등록/수정/삭제 시, 엘라스틱 서치에 저장되어 있는 문서 중 해당하는 문서에 totalRating 만 업데이트

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
@@ -144,10 +144,7 @@ public class AccommodationRoomSearchService {
   // 추가 객실 등록 또는 숙소/객실 수정, 객실 삭제 시, 기존 문서에 업데이트
   public void updateAccommodationDocument(Accommodation accommodation) {
     List<Room> rooms = roomRepository.findAllByAccommodationId(accommodation.getId());
-
-    if (rooms.isEmpty()) {
-      return;
-    }
+    if (rooms.isEmpty()) return;
 
     Set<String> updatedAccommodationPetFacilities = getAccommodationPetFacilities(accommodation);
     Set<String> updatedRoomPetFacilities = collectRoomPetFacilities(rooms);
@@ -162,11 +159,21 @@ public class AccommodationRoomSearchService {
         "allowedPetTypes", getAllowedPetTypes(accommodation)
     );
 
+    updateFields(accommodation.getId(), doc);
+  }
+
+  // 리뷰 등록/수정/삭제 시 기존 문서에 업데이트
+  public void updateAccommodationTotalRating(Accommodation accommodation, Double totalRating) {
+    Map<String, Object> doc = Map.of("totalRating", totalRating);
+    updateFields(accommodation.getId(), doc);
+  }
+
+  private void updateFields(Long accommodationId, Map<String, Object> fields) {
     try {
       elasticsearchClient.update(
           u -> u.index("accommodations")
-              .id(accommodation.getId().toString())
-              .doc(doc),
+              .id(accommodationId.toString())
+              .doc(fields),
           AccommodationDocument.class
       );
     } catch (IOException e) {

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewService.java
@@ -76,9 +76,7 @@ public class ReviewService {
         review.getPetFriendlyRating());
 
     // elasticsearch 색인 업데이트
-    Accommodation accommodation = savedReview.getAccommodation();
-    accommodationRoomSearchService.updateAllRooms(accommodation,
-        roomRepository.findAllByAccommodationId(accommodation.getId()));
+    updateElasticsearchDocument(savedReview.getAccommodation());
 
     notificationService.sendReviewNotification(savedReview); // 알림 발송
   }
@@ -124,8 +122,7 @@ public class ReviewService {
         petFriendlyRating);
 
     // elasticsearch 색인 업데이트
-    accommodationRoomSearchService.updateAllRooms(accommodation,
-        roomRepository.findAllByAccommodationId(accommodation.getId()));
+    updateElasticsearchDocument(accommodation);
   }
 
   @Transactional
@@ -153,9 +150,7 @@ public class ReviewService {
         request.getPetFriendlyRating());
 
     // elasticsearch 색인 업데이트
-    Accommodation accommodation = review.getAccommodation();
-    accommodationRoomSearchService.updateAllRooms(accommodation,
-        roomRepository.findAllByAccommodationId(accommodation.getId()));
+    updateElasticsearchDocument(review.getAccommodation());
   }
 
   /**
@@ -389,5 +384,12 @@ public class ReviewService {
 
   private double calculateReviewRating(double userRating, double petFriendlyRating) {
     return Math.round(((userRating + petFriendlyRating) / 2) * 10) / 10.0;
+  }
+
+  private void updateElasticsearchDocument(Accommodation accommodation) {
+    accommodationRoomSearchService.updateAllRooms(accommodation,
+        roomRepository.findAllByAccommodationId(accommodation.getId()));
+    accommodationRoomSearchService.updateAccommodationTotalRating(accommodation,
+        accommodation.getTotalRating());
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #204 

## 📝 변경 사항
### AS-IS
- 기존에 리뷰 등록/수정/삭제 시, 엘라스틱 서치에 저장되어 있는 문서의 totalRating을 업데이트 하지 않았음.

### TO-BE
- 리뷰 등록/수정/삭제 시, 엘라스틱 서치에 저장되어 있는 문서 중 해당하는 문서에 totalRating 만 업데이트

## 🔍 테스트
- [ ] 테스트 코드 작성
- [ ] API 테스트
- [ ] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [ ] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
추후에 테스트만 추가하겠습니다.
리뷰 부탁드립니다.
