### PR TITLE
[Feature] 데이터 생성, 삭제, 조회 로직 수정, 관리자만 호출할 수 있도록 수정

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
@@ -69,7 +69,7 @@ public class SecurityConfig {
             .requestMatchers("/api/v1/recommendations/user-pet/**").hasAuthority("ROLE_USER")
             .requestMatchers("/api/v1/recommendations/most-viewed").hasAuthority("ROLE_USER")
             .requestMatchers("/api/v1/hosts/**").hasAuthority("ROLE_HOST")
-            .requestMatchers("/api/v1/admin/**").hasAuthority("ROLE_ADMIN")
+            .requestMatchers("/api/v1/admin/**", "/api/v1/dummy-data/**").hasAuthority("ROLE_ADMIN")
             .requestMatchers("/api/v1/account/**").hasAnyAuthority("ROLE_USER", "ROLE_HOST")
             .requestMatchers("/api/v1/reviews/**").hasAnyAuthority("ROLE_USER", "ROLE_HOST")
             .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dev/DataConstant.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dev/DataConstant.java
@@ -8,15 +8,6 @@ import java.util.Map;
  */
 public class DataConstant {
 
-  // 이미지 URL 목록 - 실제 서비스에서는 S3에 있는 이미지 URL로 대체
-  public static final List<String> IMAGE_URLS = List.of(
-      "https://s3.ap-northeast-2.amazonaws.com/jjae-3.3-storage/image/72015682-b942-44da-825d-89d3b0004b99.png.",
-      "https://s3.ap-northeast-2.amazonaws.com/jjae-3.3-storage/image/ef298fbb-d4f6-4510-9861-0465fc4ac4b6.png",
-      "https://s3.ap-northeast-2.amazonaws.com/jjae-3.3-storage/image/199836da-d9fa-4053-a080-62600c350404.png",
-      "https://s3.ap-northeast-2.amazonaws.com/jjae-3.3-storage/image/199836da-d9fa-4053-a080-62600c350404.png",
-      "https://s3.ap-northeast-2.amazonaws.com/jjae-3.3-storage/image/f6706acc-97be-4be5-9f84-9331cc604ebd.png"
-  );
-
   // 지역 정보
   public static final List<String> AREAS = List.of(
       "서울", "부산", "제주", "인천", "대구", "광주", "대전", "울산", "경기", "강원");
@@ -236,14 +227,22 @@ public class DataConstant {
       "반려동물과 함께 묵기에 적합하지 않은 곳이에요."
   );
 
-  // 비밀번호 상수
+  public static final List<String> REPORT_REASON = List.of(
+      "욕설이 포함되어 있어요.",
+      "리뷰가 사실과 달라요.",
+      "부적절한 사진이 있어요.",
+      "광고/홍보 목적의 리뷰 같아요.",
+      "혼내주세요.",
+      "기타"
+  );
+
   public static final String USER_PASSWORD = "!User123";
   public static final String HOST_PASSWORD = "!Host123";
   public static final String LOCALE = "ko";
   public static final int REQUIRE_COUNT = 1;
   public static final int MAX_RESERVATION_FIND_DATE_ATTEMPT_COUNT = 20;
 
-  private DataConstant(){
+  private DataConstant() {
     throw new UnsupportedOperationException("유틸리티 클래스는 인스턴스화할 수 없습니다.");
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dev/DummyDataController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dev/DummyDataController.java
@@ -34,9 +34,7 @@ public class DummyDataController {
    */
   @DeleteMapping
   public ResponseEntity<Map<String, Object>> clearDummyData() {
-    // 더미 데이터 삭제
     Map<String, Object> result = dummyDataDeleteService.clearData();
-
     return ResponseEntity.ok(result);
   }
 
@@ -46,12 +44,13 @@ public class DummyDataController {
   @GetMapping
   public ResponseEntity<Map<String, Object>> getDummyDataStatus() {
     Map<String, Object> status = Map.of(
+        "users", dataCreateService.getUserCount(),
         "hosts", dataCreateService.getHostCount(),
         "accommodations", dataCreateService.getAccommodationCount(),
         "rooms", dataCreateService.getRoomCount(),
-        "users", dataCreateService.getUserCount(),
         "reservations", dataCreateService.getReservationCount(),
-        "reviews", dataCreateService.getReviewCount()
+        "reviews", dataCreateService.getReviewCount(),
+        "report", dataCreateService.getReportCount()
     );
     return ResponseEntity.ok(status);
   }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dev/DummyDataCreateService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dev/DummyDataCreateService.java
@@ -1,16 +1,20 @@
 package com.meongnyangerang.meongnyangerang.dev;
 
 import static com.meongnyangerang.meongnyangerang.dev.DataConstant.AREAS;
-import static com.meongnyangerang.meongnyangerang.dev.DataConstant.IMAGE_URLS;
+import static com.meongnyangerang.meongnyangerang.dev.DataConstant.REPORT_REASON;
 import static com.meongnyangerang.meongnyangerang.dev.DataConstant.REQUIRE_COUNT;
 import static com.meongnyangerang.meongnyangerang.dev.DataConstant.TOWNS_BY_AREA;
 import static com.meongnyangerang.meongnyangerang.dev.DataGeneratorUtils.generateRealisticAccommodationDescription;
 import static com.meongnyangerang.meongnyangerang.dev.DataGeneratorUtils.generateRealisticAccommodationName;
 import static com.meongnyangerang.meongnyangerang.dev.DataGeneratorUtils.generateRealisticRoomDesc;
 import static com.meongnyangerang.meongnyangerang.dev.DataGeneratorUtils.generateRealisticRoomName;
-import static javax.swing.text.html.HTML.Tag.AREA;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import com.meongnyangerang.meongnyangerang.domain.AccommodationRoomDocument;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationDocument;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationImage;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationType;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.AllowPet;
@@ -24,8 +28,11 @@ import com.meongnyangerang.meongnyangerang.domain.host.HostStatus;
 import com.meongnyangerang.meongnyangerang.domain.reservation.Reservation;
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationSlot;
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
+import com.meongnyangerang.meongnyangerang.domain.review.ReportStatus;
+import com.meongnyangerang.meongnyangerang.domain.review.ReporterType;
 import com.meongnyangerang.meongnyangerang.domain.review.Review;
 import com.meongnyangerang.meongnyangerang.domain.review.ReviewImage;
+import com.meongnyangerang.meongnyangerang.domain.review.ReviewReport;
 import com.meongnyangerang.meongnyangerang.domain.room.Room;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.Hashtag;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.HashtagType;
@@ -40,6 +47,7 @@ import com.meongnyangerang.meongnyangerang.repository.HostRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReservationSlotRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReviewImageRepository;
+import com.meongnyangerang.meongnyangerang.repository.ReviewReportRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationFacilityRepository;
@@ -52,13 +60,16 @@ import com.meongnyangerang.meongnyangerang.repository.room.RoomFacilityRepositor
 import com.meongnyangerang.meongnyangerang.repository.room.RoomPetFacilityRepository;
 import com.meongnyangerang.meongnyangerang.repository.room.RoomRepository;
 import com.meongnyangerang.meongnyangerang.service.AccommodationRoomSearchService;
+import com.meongnyangerang.meongnyangerang.service.image.S3FileService;
+import java.io.IOException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.datafaker.Faker;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -90,11 +101,16 @@ public class DummyDataCreateService {
 
   private final ReviewRepository reviewRepository;
   private final ReviewImageRepository reviewImageRepository;
+  private final ReviewReportRepository reviewReportRepository;
 
-  private final AccommodationRoomSearchService searchService;
+  private final S3FileService s3FileService;
+  private final ElasticsearchClient elasticsearchClient;
+
+  private List<String> imageUrls;
 
   @Transactional
   public Map<String, Object> generateData(DummyDataGenerateRequest request) {
+    imageUrls = s3FileService.getAllImageUrls();
     Faker faker = new Faker(new Locale(DataConstant.LOCALE));
     Random random = new Random();
     Map<String, Object> result = new HashMap<>();
@@ -115,71 +131,116 @@ public class DummyDataCreateService {
           .toList();
 
       // 1. 사용자 생성 (예약 및 리뷰 작성을 위해)
-      List<User> users = createUsers(faker, random, savedUserEmails, usedNicknames);
+      List<User> users = createUsers(
+          request.getUserCount(), faker, random, savedUserEmails, usedNicknames);
       userRepository.saveAll(users);
+      log.debug("Created {} users", users.size());
 
       // 2. 호스트 생성 (숙소 개수만큼)
-      List<Host> hosts = createHosts(request, faker, random, savedHostEmails, usedNicknames);
+      List<Host> hosts = createHosts(
+          request.getAccommodationCount(), faker, random, savedHostEmails, usedNicknames);
       hostRepository.saveAll(hosts);
+      log.debug("Created {} hosts", hosts.size());
 
       // 3. 숙소 생성 (호스트당 1개)
       List<Accommodation> accommodations = createAccommodations(request, faker, random, hosts);
       accommodationRepository.saveAll(accommodations);
+      log.debug("Created {} accommodations", accommodations.size());
 
       // 4. 숙소 이미지 생성 (숙소당 정확히 4개)
       List<AccommodationImage> accommodationImages = createAccommodationImages(
           accommodations, random);
       accommodationImageRepository.saveAll(accommodationImages);
+      log.debug("Created {} accommodationImages", accommodationImages.size());
 
       // 5. 숙소 애완동물 유형 설정
       List<AllowPet> allowPets = createAllowPets(accommodations, random);
       allowPetRepository.saveAll(allowPets);
+      log.debug("Created {} allowPets", allowPets.size());
 
-      // 6. 숙소 시설 설정
+      // 6. 숙소 편의시설 설정
       List<AccommodationFacility> accommodationFacilities = createAccommodationFacilities(
           accommodations, random);
       accommodationFacilityRepository.saveAll(accommodationFacilities);
+      log.debug("Created {} accommodationFacilities", accommodationFacilities.size());
 
-      // 7. 숙소 애완동물 시설 설정
+      // 7. 숙소 애완동물 편의시설 설정
       List<AccommodationPetFacility> accommodationPetFacilities = createAccommodationPetFacilities(
           accommodations, random);
       accommodationPetFacilityRepository.saveAll(accommodationPetFacilities);
+      log.debug("Created {} accommodationPetFacilities", accommodationPetFacilities.size());
 
       // 8. 객실 생성
-      List<Room> rooms = createRooms(request, accommodations, random, faker);
+      List<Room> rooms = createRooms(request, accommodations, random);
       roomRepository.saveAll(rooms);
+      log.debug("Created {} rooms", rooms.size());
 
       // 9. 객실 해시태그 설정
       List<Hashtag> roomHashtags = createRoomHashtags(rooms, random);
       hashtagRepository.saveAll(roomHashtags);
+      log.debug("Created {} roomHashtags", roomHashtags.size());
 
-      // 10. 객실 시설 설정
+      // 10. 객실 편의시설 설정
       List<RoomFacility> roomFacilities = createRoomFacilities(rooms, random);
       roomFacilityRepository.saveAll(roomFacilities);
+      log.debug("Created {} roomFacilities", roomFacilities.size());
 
       // 11. 객실 애완동물 시설 설정
       List<RoomPetFacility> roomPetFacilities = createRoomPetFacilities(rooms, random);
       roomPetFacilityRepository.saveAll(roomPetFacilities);
+      log.debug("Created {} roomPetFacilities", roomPetFacilities.size());
 
       // 12. 예약 생성
-      List<Reservation> reservations = createReservations(request, rooms, random, users, faker);
+      List<Reservation> reservations = createReservations(
+          request.getReservationCount(), rooms, random, users, faker);
       reservationRepository.saveAll(reservations);
+      log.debug("Created {} roomPetFacilities", roomPetFacilities.size());
 
       // 13. 리뷰 생성
       List<Review> reviews = createAndSaveReviews(
-          request, reservations, random, faker, accommodations);
+          request.getReviewCount(), reservations, random, accommodations);
 
-      // Elasticsearch 색인 저장
-      saveIndex(accommodations, rooms);
+      // 14. 리뷰 신고 생성
+      List<ReviewReport> reports = createReports(reviews, users, random);
+      reviewReportRepository.saveAll(reports);
+      log.debug("Created {} roomPetFacilities", roomPetFacilities.size());
+
+      // 각 엔티티 간 관계 매핑을 위한 맵 생성
+      Map<Long, List<AllowPet>> allowPetsByAccId = allowPets.stream()
+          .collect(Collectors.groupingBy(pet -> pet.getAccommodation().getId()));
+
+      Map<Long, List<AccommodationPetFacility>> accPetFacilitiesByAccId = accommodationPetFacilities.stream()
+          .collect(Collectors.groupingBy(f -> f.getAccommodation().getId()));
+
+      Map<Long, List<AccommodationFacility>> accFacilitiesByAccId = accommodationFacilities.stream()
+          .collect(Collectors.groupingBy(f -> f.getAccommodation().getId()));
+
+      Map<Long, List<RoomPetFacility>> roomPetFacilitiesByRoomId = roomPetFacilities.stream()
+          .collect(Collectors.groupingBy(f -> f.getRoom().getId()));
+
+      Map<Long, List<RoomFacility>> roomFacilitiesByRoomId = roomFacilities.stream()
+          .collect(Collectors.groupingBy(f -> f.getRoom().getId()));
+
+      Map<Long, List<Hashtag>> hashtagsByRoomId = roomHashtags.stream()
+          .collect(Collectors.groupingBy(h -> h.getRoom().getId()));
+
+      // 최적화된 벌크 인덱싱
+      bulkIndexToElasticsearch(
+          accommodations, rooms,
+          allowPetsByAccId, accPetFacilitiesByAccId, accFacilitiesByAccId,
+          roomPetFacilitiesByRoomId, roomFacilitiesByRoomId, hashtagsByRoomId
+      );
+      log.debug("Success save indexes");
 
       // 결과 집계
       result.put("success", true);
+      result.put("userCount", users.size());
       result.put("hostCount", hosts.size());
       result.put("accommodationCount", accommodations.size());
       result.put("roomCount", rooms.size());
-      result.put("userCount", users.size());
       result.put("reservationCount", reservations.size());
       result.put("reviewCount", reviews.size());
+      result.put("reportCount", reports.size());
       result.put("message", "더미 데이터가 성공적으로 생성되었습니다.");
 
     } catch (Exception e) {
@@ -208,6 +269,7 @@ public class DummyDataCreateService {
   }
 
   private List<User> createUsers(
+      int userCount,
       Faker faker,
       Random random,
       List<String> savedUserEmails,
@@ -216,7 +278,7 @@ public class DummyDataCreateService {
     List<User> users = new ArrayList<>();
     Set<String> usedUserEmails = new HashSet<>(savedUserEmails); // 중복 닉네임 방지를 위한 Set
 
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < userCount; i++) {
       String email;
       String nickname;
 
@@ -235,7 +297,7 @@ public class DummyDataCreateService {
           .nickname(nickname)
           .password(passwordEncoder.encode(DataConstant.USER_PASSWORD))
           .profileImage( // 50% 확률로 이미지 있거나, null
-              random.nextBoolean() ? IMAGE_URLS.get(random.nextInt(IMAGE_URLS.size())) : null)
+              random.nextBoolean() ? imageUrls.get(random.nextInt(imageUrls.size())) : null)
           .status(UserStatus.ACTIVE)
           .role(Role.ROLE_USER)
           .createdAt(LocalDateTime.now())
@@ -248,7 +310,7 @@ public class DummyDataCreateService {
   }
 
   private List<Host> createHosts(
-      DummyDataGenerateRequest request,
+      int accommodationCount,
       Faker faker,
       Random random,
       List<String> savedHostEmails,
@@ -257,7 +319,7 @@ public class DummyDataCreateService {
     List<Host> hosts = new ArrayList<>();
     Set<String> usedEmails = new HashSet<>(savedHostEmails);
 
-    for (int i = 0; i < request.getAccommodationCount(); i++) {
+    for (int i = 0; i < accommodationCount; i++) {
       String email;
       String nickname;
 
@@ -277,9 +339,9 @@ public class DummyDataCreateService {
           .nickname(nickname)
           .password(passwordEncoder.encode(DataConstant.HOST_PASSWORD))
           .profileImageUrl(
-              random.nextBoolean() ? IMAGE_URLS.get(random.nextInt(IMAGE_URLS.size())) : null)
-          .businessLicenseImageUrl(IMAGE_URLS.get(random.nextInt(IMAGE_URLS.size())))
-          .submitDocumentImageUrl(IMAGE_URLS.get(random.nextInt(IMAGE_URLS.size())))
+              random.nextBoolean() ? imageUrls.get(random.nextInt(imageUrls.size())) : null)
+          .businessLicenseImageUrl(imageUrls.get(random.nextInt(imageUrls.size())))
+          .submitDocumentImageUrl(imageUrls.get(random.nextInt(imageUrls.size())))
           .phoneNumber(createRandomPhoneNumber(faker))
           .status(HostStatus.ACTIVE)
           .role(Role.ROLE_HOST)
@@ -322,7 +384,7 @@ public class DummyDataCreateService {
         for (int i = 0; i < imageCount; i++) {
           ReviewImage reviewImage = ReviewImage.builder()
               .review(review)
-              .imageUrl(IMAGE_URLS.get(random.nextInt(IMAGE_URLS.size())))
+              .imageUrl(imageUrls.get(random.nextInt(imageUrls.size())))
               .createdAt(review.getCreatedAt())
               .build();
 
@@ -333,26 +395,38 @@ public class DummyDataCreateService {
     return reviewImages;
   }
 
-  private List<Review> createReviews(DummyDataGenerateRequest request,
+  private List<Review> createReviews(
+      int reviewCount,
       List<Reservation> completedReservations,
-      Random random,
-      Faker faker
+      Random random
   ) {
     List<Review> reviews = new ArrayList<>();
-    int totalReviewCount = Math.min(request.getReviewCount(), completedReservations.size());
+    // 리뷰 생성 비율 적용 (기본값은 0.7, 즉 70%의 완료된 예약에 리뷰가 있음)
+    // 완료된 예약 중 리뷰가 있는 비율
+    double REVIEW_RATIO = 0.7;
+    int maxReviewCount = (int) (completedReservations.size() * REVIEW_RATIO);
+    int totalReviewCount = Math.min(reviewCount, maxReviewCount);
 
-    for (int i = 0; i < totalReviewCount; i++) {
-      Reservation reservation = completedReservations.get(i % completedReservations.size());
+    // 리뷰를 작성할 예약을 무작위로 선택
+    List<Reservation> reservationsCopy = new ArrayList<>(completedReservations);
+    Collections.shuffle(reservationsCopy, random);
+
+    // 배열 범위 체크 - totalReviewCount가 reservationsCopy 크기보다 클 수 없음
+    totalReviewCount = Math.min(totalReviewCount, reservationsCopy.size());
+    List<Reservation> reservationsForReview = reservationsCopy.subList(0, totalReviewCount);
+
+    for (Reservation reservation : reservationsForReview) {
       Accommodation accommodation = reservation.getRoom().getAccommodation();
 
       double userRating = 0.5 + random.nextInt(10) * 0.5;
       double petFriendlyRating = 0.5 + random.nextInt(10) * 0.5;
       double avgRating = (userRating + petFriendlyRating) / 2.0;
 
-      LocalDateTime randomReviewCreatedAt = reservation.getCheckOutDate()
-          .atTime(12, 0).plusDays(random.nextInt(5));
-
-      int reportCount = random.nextInt(21);
+      // 리뷰 작성 시간 - 체크아웃 후 0~6일 사이
+      LocalDateTime checkOutDateTime = reservation.getCheckOutDate()
+          .atTime(random.nextInt(13), random.nextInt(59));
+      LocalDateTime randomReviewCreatedAt = checkOutDateTime
+          .plusDays(random.nextInt(7)); // 체크아웃 당일 ~ 6일 후
 
       int stayDuration = (int) ChronoUnit.DAYS.between(
           reservation.getCheckInDate(), reservation.getCheckOutDate());
@@ -368,7 +442,7 @@ public class DummyDataCreateService {
           .userRating(userRating)
           .petFriendlyRating(petFriendlyRating)
           .content(content)
-          .reportCount(reportCount)
+          .reportCount(0)
           .createdAt(randomReviewCreatedAt)
           .updatedAt(randomReviewCreatedAt)
           .build();
@@ -379,13 +453,20 @@ public class DummyDataCreateService {
   }
 
   private List<Reservation> createReservations(
-      DummyDataGenerateRequest request,
+      int reservationCount,
       List<Room> rooms,
       Random random,
       List<User> users,
       Faker faker
   ) {
     List<Reservation> reservations = new ArrayList<>();
+    LocalDate now = LocalDate.now();
+
+    // 과거/미래 예약 수 계산
+    // 과거 예약 비율
+    double PAST_RESERVATION_RATIO = 0.6;
+    int pastReservations = (int) (reservationCount * PAST_RESERVATION_RATIO);
+    int futureReservations = reservationCount - pastReservations;
 
     // 각 객실별로 예약 날짜를 관리하기 위한 Map
     Map<Long, Set<LocalDate>> roomBookedDatesMap = new HashMap<>();
@@ -393,22 +474,21 @@ public class DummyDataCreateService {
       roomBookedDatesMap.put(room.getId(), new HashSet<>());
     }
 
-    int totalReservations = request.getReservationCount();
-    int successCount = 0;
-    int attemptCount = 0;
-    int maxAttempts = totalReservations * 3; // 최대 시도 횟수 제한
+    // 과거 예약 생성
+    int pastSuccess = 0;
+    int pastAttempts = 0;
+    int maxPastAttempts = pastReservations * 3; // 최대 시도 횟수 제한
 
-    while (successCount < totalReservations && attemptCount < maxAttempts) {
-      attemptCount++;
+    while (pastSuccess < pastReservations && pastAttempts < maxPastAttempts) {
+      pastAttempts++;
 
       // 객실 선택
       Room room = rooms.get(random.nextInt(rooms.size()));
       User user = users.get(random.nextInt(users.size()));
 
       // 현재 날짜 기준으로 예약 가능한 기간 설정
-      LocalDate now = LocalDate.now();
-      LocalDate minDate = now.minusDays(60); // 과거 60일부터
-      LocalDate maxDate = now.plusDays(90); // 향후 90일 이내
+      LocalDate minDate = now.minusDays(120); // 과거 120일부터
+      LocalDate maxDate = now.plusDays(1); // 어제까지
 
       // 이 객실의 이미 예약된 날짜들
       Set<LocalDate> bookedDates = roomBookedDatesMap.get(room.getId());
@@ -466,22 +546,20 @@ public class DummyDataCreateService {
 
         long totalPrice = basePrice + extraPeoplePrice + extraPetPrice + room.getExtraFee();
 
-        // 예약 상태 설정
-        ReservationStatus status;
-        LocalDateTime createdAt = LocalDateTime.now().minusDays(random.nextInt(100));
-        LocalDateTime updatedAt = createdAt;
+        // 예약 생성 날짜 계산 (체크인 이전의 랜덤한 날짜)
+        LocalDateTime createdAt = checkInDate
+            .atTime(random.nextInt(24), random.nextInt(60))
+            .minusDays(random.nextInt(30) + 1); // 체크인 최소 1일 전, 최대 30일 전
         LocalDateTime canceledAt = null;
+        LocalDateTime updatedAt = createdAt;
 
-        if (checkInDate.isBefore(now)) {
-          status = ReservationStatus.COMPLETED;
-        } else {
-          if (random.nextInt(10) < 8) {
-            status = ReservationStatus.RESERVED; // 80% 확률로 RESERVED
-          } else {
-            status = ReservationStatus.CANCELED; // 20% 확률로 CANCELED
-            canceledAt = createdAt.plusDays(random.nextInt(5) + 1);
-            updatedAt = canceledAt;
-          }
+        ReservationStatus status = ReservationStatus.COMPLETED;
+
+        // 체크아웃 날짜가 현재보다 이전인 예약 중 10%는 취소 상태로 설정
+        if (checkOutDate.isBefore(now) && random.nextInt(10) < 1) {
+          status = ReservationStatus.CANCELED;
+          canceledAt = createdAt.plusDays(random.nextInt(5) + 1);
+          updatedAt = canceledAt;
         }
 
         // 예약 객체 생성
@@ -504,13 +582,120 @@ public class DummyDataCreateService {
             .build();
 
         reservations.add(reservation);
-        successCount++;
+        pastSuccess++;
       }
     }
 
-    if (successCount < totalReservations) {
-      log.warn("생성된 예약 수({})가 요청된 수({})보다 적습니다. 가능한 날짜가 부족합니다.",
-          successCount, totalReservations);
+    // 미래 예약 생성
+    int futureSuccess = 0;
+    int futureAttempts = 0;
+    int maxFutureAttempts = futureReservations * 3;
+
+    while (futureSuccess < futureReservations && futureAttempts < maxFutureAttempts) {
+      futureAttempts++;
+
+      // 객실 선택
+      Room room = rooms.get(random.nextInt(rooms.size()));
+      User user = users.get(random.nextInt(users.size()));
+
+      // 미래 날짜 범위 설정
+      LocalDate maxDate = now.plusDays(90); // 향후 90일까지
+
+      // 이 객실의 이미 예약된 날짜들
+      Set<LocalDate> bookedDates = roomBookedDatesMap.get(room.getId());
+
+      // 예약 기간 선택
+      LocalDate checkInDate = findAvailableDate(now, maxDate, bookedDates, random);
+      int stayDays = 1 + random.nextInt(5); // 1~5일 숙박
+      LocalDate checkOutDate = checkInDate.plusDays(stayDays);
+
+      // 선택한 날짜가 모두 예약 가능한지 확인
+      boolean allDatesAvailable = true;
+      Set<LocalDate> reservingDates = new HashSet<>();
+
+      for (LocalDate date = checkInDate; date.isBefore(checkOutDate); date = date.plusDays(1)) {
+        if (bookedDates.contains(date)) {
+          allDatesAvailable = false;
+          break;
+        }
+        reservingDates.add(date);
+      }
+
+      // 날짜가 모두 예약 가능하면 예약 생성 진행
+      if (allDatesAvailable) {
+        // 예약 슬롯 생성
+        List<ReservationSlot> reservationSlots = new ArrayList<>();
+        for (LocalDate date : reservingDates) {
+          ReservationSlot slot = new ReservationSlot();
+          slot.setRoom(room);
+          slot.setReservedDate(date);
+          slot.setIsReserved(true);
+
+          reservationSlots.add(slot);
+          bookedDates.add(date); // 예약된 날짜 맵에 추가
+        }
+        reservationSlotRepository.saveAll(reservationSlots);
+
+        // 인원 및 반려동물 수
+        int peopleCount = 1 + random.nextInt(room.getMaxPeopleCount());
+        int petCount = 1 + random.nextInt(room.getMaxPetCount());
+
+        // 가격 계산
+        long basePrice = room.getPrice() * stayDays;
+        long extraPeoplePrice = 0;
+
+        if (peopleCount > room.getStandardPeopleCount()) {
+          extraPeoplePrice =
+              (room.getExtraPeopleFee() * (peopleCount - room.getStandardPeopleCount())) * stayDays;
+        }
+
+        long extraPetPrice = 0;
+        if (petCount > room.getStandardPetCount()) {
+          extraPetPrice =
+              (room.getExtraPetFee() * (petCount - room.getStandardPetCount())) * stayDays;
+        }
+
+        long totalPrice = basePrice + extraPeoplePrice + extraPetPrice + room.getExtraFee();
+
+        // 예약 생성 날짜 계산 (현재 시점 이전 랜덤한 날짜)
+        LocalDateTime createdAt = LocalDateTime.now()
+            .minusDays(random.nextInt(30)); // 최대 30일 전에 예약
+
+        // 예약 상태 설정 (미래 예약은 RESERVED 또는 CANCELED)
+        ReservationStatus status;
+        LocalDateTime canceledAt = null;
+        LocalDateTime updatedAt = createdAt;
+
+        if (random.nextInt(10) < 8) {
+          status = ReservationStatus.RESERVED; // 80% 확률로 RESERVED
+        } else {
+          status = ReservationStatus.CANCELED; // 20% 확률로 CANCELED
+          canceledAt = createdAt.plusDays(random.nextInt(5) + 1);
+          updatedAt = canceledAt;
+        }
+
+        // 예약 객체 생성
+        Reservation reservation = Reservation.builder()
+            .user(user)
+            .room(room)
+            .accommodationName(room.getAccommodation().getName())
+            .checkInDate(checkInDate)
+            .checkOutDate(checkOutDate)
+            .peopleCount(peopleCount)
+            .petCount(petCount)
+            .reserverName(faker.name().fullName().replaceAll("\\s+", ""))
+            .reserverPhoneNumber(createRandomPhoneNumber(faker))
+            .hasVehicle(random.nextBoolean())
+            .totalPrice(totalPrice)
+            .status(status)
+            .createdAt(createdAt)
+            .updatedAt(updatedAt)
+            .canceledAt(canceledAt)
+            .build();
+
+        reservations.add(reservation);
+        futureSuccess++;
+      }
     }
     return reservations;
   }
@@ -521,7 +706,8 @@ public class DummyDataCreateService {
       Set<LocalDate> bookedDates,
       Random random
   ) {
-    for (int attempt = 0; attempt < DataConstant.MAX_RESERVATION_FIND_DATE_ATTEMPT_COUNT; attempt++) {
+    for (int attempt = 0; attempt < DataConstant.MAX_RESERVATION_FIND_DATE_ATTEMPT_COUNT;
+        attempt++) {
       // 최소 날짜(minDate)와 최대 날짜(maxDate) 사이의 일수를 계산
       long daysBetween = ChronoUnit.DAYS.between(minDate, maxDate);
 
@@ -613,8 +799,7 @@ public class DummyDataCreateService {
   private List<Room> createRooms(
       DummyDataGenerateRequest request,
       List<Accommodation> accommodations,
-      Random random,
-      Faker faker
+      Random random
   ) {
     List<Room> rooms = new ArrayList<>();
 
@@ -633,7 +818,7 @@ public class DummyDataCreateService {
         int maxPetCount = standardPetCount + random.nextInt(2);
 
         // 이미지 및 가격 설정
-        String roomImageUrl = IMAGE_URLS.get(random.nextInt(IMAGE_URLS.size()));
+        String roomImageUrl = imageUrls.get(random.nextInt(imageUrls.size()));
         Long price = 50000L + (random.nextInt(20) * 10000L); // 5~25만원
 
         // 추가 요금 설정
@@ -761,7 +946,7 @@ public class DummyDataCreateService {
       for (int i = 0; i < imageCount; i++) {
         AccommodationImage image = AccommodationImage.builder()
             .accommodation(accommodation)
-            .imageUrl(IMAGE_URLS.get(random.nextInt(IMAGE_URLS.size())))
+            .imageUrl(imageUrls.get(random.nextInt(imageUrls.size())))
             .createdAt(accommodation.getCreatedAt())
             .build();
 
@@ -787,13 +972,12 @@ public class DummyDataCreateService {
       String detailedAddress = faker.address().streetAddress(); // 무작위 도로명 주소
       String description = generateRealisticAccommodationDescription(name, area, random);
 
-
       // 위치 정보 (위도, 경도)
       Double latitude = 33.0 + random.nextDouble() * 10.0; // 33~43 범위의 위도
       Double longitude = 125.0 + random.nextDouble() * 10.0; // 125~135 범위의 경도
 
       AccommodationType type = randomEnum(AccommodationType.class, random); // 무작위 숙소 유형
-      String thumbnailUrl = IMAGE_URLS.get(random.nextInt(IMAGE_URLS.size())); // 썸네일 이미지
+      String thumbnailUrl = imageUrls.get(random.nextInt(imageUrls.size())); // 썸네일 이미지
 
       // 평점 및 조회수
       Double totalRating =
@@ -822,10 +1006,9 @@ public class DummyDataCreateService {
   }
 
   private List<Review> createAndSaveReviews(
-      DummyDataGenerateRequest request,
+      int reviewCount,
       List<Reservation> reservations,
       Random random,
-      Faker faker,
       List<Accommodation> accommodations
   ) {
     List<Review> reviews = new ArrayList<>();
@@ -836,12 +1019,14 @@ public class DummyDataCreateService {
         .toList();
 
     if (!completedReservations.isEmpty()) {
-      reviews = createReviews(request, completedReservations, random, faker);
+      reviews = createReviews(reviewCount, completedReservations, random);
       reviewRepository.saveAll(reviews);
+      log.info("Created {} reviews", reviews.size());
 
       // 리뷰 이미지 생성
       List<ReviewImage> reviewImages = createReviewImages(reviews, random);
       reviewImageRepository.saveAll(reviewImages);
+      log.info("Created {} reviewImages", reviewImages.size());
 
       // 숙소 평점 업데이트
       updateAccommodationRating(accommodations, reviews);
@@ -850,23 +1035,293 @@ public class DummyDataCreateService {
     return reviews;
   }
 
-  private void saveIndex(List<Accommodation> accommodations, List<Room> rooms) {
-    for (Accommodation accommodation : accommodations) {
-      List<Room> relatedRooms = rooms.stream()
-          .filter(room -> room.getAccommodation().getId().equals(accommodation.getId()))
-          .toList();
+  public List<ReviewReport> createReports(List<Review> reviews, List<User> users, Random random) {
+    List<ReviewReport> reports = new ArrayList<>();
+    Map<Review, Set<Long>> reviewToReportedUserIds = new HashMap<>();
 
-      Room firstRoom = relatedRooms.get(0);
-      searchService.indexAccommodationDocument(accommodation, firstRoom);
+    // 신고가 많이 달린 리뷰와 적게 달린 리뷰를 구분
+    // reportedReviewRatio 비율의 리뷰는 많은 신고(15-20개)를 받음
+    // 높은 신고를 받는 리뷰 비율
+    double REPORTED_REVIEW_RATIO = 0.1;
+    int highlyReportedCount = (int) (reviews.size() * REPORTED_REVIEW_RATIO);
 
-      for (Room room : relatedRooms) {
-        searchService.save(accommodation, room);
+    // 리뷰 목록을 무작위로 섞어서 일부는 많은 신고, 일부는 적은 신고를 받도록 함
+    List<Review> reviewsCopy = new ArrayList<>(reviews);
+    Collections.shuffle(reviewsCopy, random);
+
+    // 높은 신고를 받을 리뷰들에 대한 처리
+    for (int i = 0; i < highlyReportedCount && i < reviewsCopy.size(); i++) {
+      Review review = reviews.get(i % reviewsCopy.size());
+      Set<Long> usedUserIds = new HashSet<>();
+
+      // 신고 개수는 15-20개 사이에서 랜덤하게 결정
+      int highlyReportRandomCount = 15 + random.nextInt(6);
+      // 자기 자신의 리뷰는 신고 못하도록
+      int actualReportCount = Math.min(highlyReportRandomCount, users.size() - 1);
+
+      // 실제 신고할 사용자 선택 (리뷰 작성자 자신은 제외)
+      Long reviewAuthorId = review.getUser().getId();
+      List<User> potentialReporters = new ArrayList<>(users.stream()
+          .filter(user -> !user.getId().equals(reviewAuthorId))
+          .toList());
+
+      // 중복 없이 사용자 선택해서 신고 생성
+      Collections.shuffle(potentialReporters, random);
+      for (int j = 0; j < actualReportCount && j < potentialReporters.size(); j++) {
+        User reporter = potentialReporters.get(j);
+
+        if (usedUserIds.add(reporter.getId())) {
+          ReviewReport report = createSingleReviewReport(review, reporter, random);
+          reports.add(report);
+        }
+      }
+      // 신고 수 업데이트
+      review.setReportCount(usedUserIds.size());
+      reviewToReportedUserIds.put(review, usedUserIds);
+    }
+
+    // 나머지 리뷰에 대해서는 적은 수의 신고 생성
+    for (int i = highlyReportedCount; i < reviewsCopy.size(); i++) {
+      Review review = reviewsCopy.get(i);
+
+      // 이미 많이 신고된 리뷰는 건너뜀
+      if (reviewToReportedUserIds.containsKey(review)) {
+        continue;
       }
 
-      if (relatedRooms.size() > 1) {
-        searchService.updateAccommodationDocument(accommodation);
+      int maxReport = random.nextInt(4); // 0-3개 정도의 적은 신고
+      if (maxReport == 0) {
+        continue; // 신고가 없는 리뷰도 많이 있음
+      }
+
+      Set<Long> usedUserIds = new HashSet<>();
+      Long reviewAuthorId = review.getUser().getId();
+
+      // 신고자 선택 (리뷰 작성자 자신은 제외)
+      List<User> potentialReporters = new ArrayList<>(users.stream()
+          .filter(user -> !user.getId().equals(reviewAuthorId))
+          .toList());
+
+      Collections.shuffle(potentialReporters, random);
+      for (int j = 0; j < maxReport && j < potentialReporters.size(); j++) {
+        User reporter = potentialReporters.get(j);
+
+        if (usedUserIds.add(reporter.getId())) {
+          ReviewReport report = createSingleReviewReport(review, reporter, random);
+          reports.add(report);
+        }
+      }
+
+      if (!usedUserIds.isEmpty()) { // 신고가 있는 경우에만 리뷰 신고 수 업데이트
+        review.setReportCount(usedUserIds.size());
+        reviewToReportedUserIds.put(review, usedUserIds);
       }
     }
+    return reports;
+  }
+
+  private void bulkIndexToElasticsearch(
+      List<Accommodation> accommodations,
+      List<Room> rooms,
+      Map<Long, List<AllowPet>> allowPetsByAccId,
+      Map<Long, List<AccommodationPetFacility>> accPetFacilitiesByAccId,
+      Map<Long, List<AccommodationFacility>> accFacilitiesByAccId,
+      Map<Long, List<RoomPetFacility>> roomPetFacilitiesByRoomId,
+      Map<Long, List<RoomFacility>> roomFacilitiesByRoomId,
+      Map<Long, List<Hashtag>> hashtagsByRoomId
+  ) {
+    log.info("벌크 인덱싱 시작: 숙소 {}개, 객실 {}개", accommodations.size(), rooms.size());
+
+    // 숙소별 객실 매핑
+    Map<Long, List<Room>> roomsByAccommodationId = rooms.stream()
+        .collect(Collectors.groupingBy(room -> room.getAccommodation().getId()));
+
+    // ES에 색인할 모든 문서를 모으는 부분
+    List<BulkOperation> operations = new ArrayList<>();
+
+    for (Accommodation accommodation : accommodations) {
+      Long accommodationId = accommodation.getId();
+      List<Room> accRooms = roomsByAccommodationId.getOrDefault(
+          accommodationId, Collections.emptyList());
+
+      if (accRooms.isEmpty()) {
+        continue;
+      }
+
+      // 첫 번째 객실 기준으로 숙소 문서 생성
+      Room firstRoom = accRooms.get(0);
+
+      // 1. accommodation 인덱스에 저장할 문서 생성
+      Set<String> allowedPetTypes = getAllowedPetTypesFromMap(allowPetsByAccId, accommodationId);
+      Set<String> accommodationPetFacilities = getAccommodationPetFacilitiesFromMap(
+          accPetFacilitiesByAccId, accommodationId);
+      Set<String> firstRoomPetFacilities = getRoomPetFacilitiesFromMap(roomPetFacilitiesByRoomId,
+          firstRoom.getId());
+
+      // searchService의 toDocument 메서드를 직접 호출하기 어려울 수 있어서
+      // 새로운 문서 객체를 생성합니다
+      AccommodationDocument accommodationDoc = AccommodationDocument.builder()
+          .id(accommodation.getId())
+          .name(accommodation.getName())
+          .thumbnailUrl(accommodation.getThumbnailUrl())
+          .price(firstRoom.getPrice())
+          .totalRating(accommodation.getTotalRating())
+          .accommodationPetFacilities(accommodationPetFacilities)
+          .allowedPetTypes(allowedPetTypes)
+          .roomPetFacilities(firstRoomPetFacilities)
+          .build();
+
+      // accommodation 인덱스에 추가할 문서 작업 추가
+      operations.add(new BulkOperation.Builder()
+          .index(idx -> idx
+              .index("accommodations")
+              .id(accommodationId.toString())
+              .document(accommodationDoc)
+          ).build());
+
+      // 2. 각 객실별 accommodation_rooms 인덱스 문서 생성
+      for (Room room : accRooms) {
+        Long roomId = room.getId();
+
+        // 객실별 데이터 준비
+        List<AccommodationFacility> accFacilities = accFacilitiesByAccId.getOrDefault(
+            accommodationId, Collections.emptyList());
+        List<AccommodationPetFacility> accPetFacilities = accPetFacilitiesByAccId.getOrDefault(
+            accommodationId, Collections.emptyList());
+        List<AllowPet> allowPets = allowPetsByAccId.getOrDefault(accommodationId,
+            Collections.emptyList());
+
+        List<RoomFacility> roomFacilities = roomFacilitiesByRoomId.getOrDefault(roomId,
+            Collections.emptyList());
+        List<RoomPetFacility> roomPetFacilities = roomPetFacilitiesByRoomId.getOrDefault(roomId,
+            Collections.emptyList());
+        List<Hashtag> hashtags = hashtagsByRoomId.getOrDefault(roomId, Collections.emptyList());
+
+        // 여기도 매퍼를 직접 호출하기 어려울 수 있어 객체를 새로 생성합니다
+        AccommodationRoomDocument accRoomDoc = createAccommodationRoomDocument(
+            accommodation, room, accFacilities, accPetFacilities,
+            roomFacilities, roomPetFacilities, hashtags, allowPets);
+
+        // accommodation_rooms 인덱스에 추가할 문서 작업 추가
+        operations.add(new BulkOperation.Builder()
+            .index(idx -> idx
+                .index("accommodation_rooms")
+                .id(accommodationId + "_" + roomId)
+                .document(accRoomDoc)
+            ).build());
+      }
+    }
+
+    // 벌크 요청 실행
+    try {
+      if (!operations.isEmpty()) {
+        BulkRequest bulkRequest = new BulkRequest.Builder()
+            .operations(operations)
+            .build();
+
+        elasticsearchClient.bulk(bulkRequest);
+        log.info("총 {}개 문서 벌크 인덱싱 완료", operations.size());
+      }
+    } catch (IOException e) {
+      log.error("Elasticsearch 벌크 인덱싱 실패", e);
+      throw new RuntimeException("Elasticsearch 벌크 인덱싱 실패", e);
+    }
+  }
+
+  private Set<String> getAllowedPetTypesFromMap(
+      Map<Long, List<AllowPet>> map,
+      Long accommodationId
+  ) {
+    return map.getOrDefault(accommodationId, Collections.emptyList())
+        .stream().map(AllowPet::getPetType).map(Enum::name).collect(Collectors.toSet());
+  }
+
+  private Set<String> getAccommodationPetFacilitiesFromMap(
+      Map<Long, List<AccommodationPetFacility>> map,
+      Long accommodationId
+  ) {
+    return map.getOrDefault(accommodationId, Collections.emptyList())
+        .stream().map(AccommodationPetFacility::getType).map(Enum::name)
+        .collect(Collectors.toSet());
+  }
+
+  private Set<String> getRoomPetFacilitiesFromMap(
+      Map<Long, List<RoomPetFacility>> map,
+      Long roomId
+  ) {
+    return map.getOrDefault(roomId, Collections.emptyList())
+        .stream().map(RoomPetFacility::getType).map(Enum::name).collect(Collectors.toSet());
+  }
+
+  // AccommodationRoomDocument 생성
+  private AccommodationRoomDocument createAccommodationRoomDocument(
+      Accommodation accommodation,
+      Room room,
+      List<AccommodationFacility> accFacilities,
+      List<AccommodationPetFacility> accPetFacilities,
+      List<RoomFacility> roomFacilities,
+      List<RoomPetFacility> roomPetFacilities,
+      List<Hashtag> hashtags,
+      List<AllowPet> allowPets
+  ) {
+    return AccommodationRoomDocument.builder()
+        .id(accommodation.getId() + "_" + room.getId())
+        .accommodationId(accommodation.getId())
+        .roomId(room.getId())
+        .accommodationName(accommodation.getName())
+        .roomName(room.getName())
+        .address(accommodation.getAddress())
+        .thumbnailUrl(accommodation.getThumbnailUrl())
+        .accommodationType(accommodation.getType())
+        .totalRating(accommodation.getTotalRating())
+        .price(room.getPrice())
+        .standardPeopleCount(room.getStandardPeopleCount())
+        .maxPeopleCount(room.getMaxPeopleCount())
+        .standardPetCount(room.getStandardPetCount())
+        .maxPetCount(room.getMaxPetCount())
+        .accommodationFacilities(extractEnumNames(accFacilities, AccommodationFacility::getType))
+        .accommodationPetFacilities(
+            extractEnumNames(accPetFacilities, AccommodationPetFacility::getType))
+        .roomFacilities(extractEnumNames(roomFacilities, RoomFacility::getType))
+        .roomPetFacilities(extractEnumNames(roomPetFacilities, RoomPetFacility::getType))
+        .hashtags(extractEnumNames(hashtags, Hashtag::getType))
+        .allowPets(extractEnumNames(allowPets, AllowPet::getPetType))
+        .build();
+  }
+
+  private <T> List<String> extractEnumNames(List<T> list, Function<T, Enum<?>> extractor) {
+    if (list == null || list.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return list.stream()
+        .map(extractor)
+        .map(Enum::name)
+        .toList();
+  }
+
+  private ReviewReport createSingleReviewReport(Review review, User reporter, Random random) {
+    // 신고 이유와 상태를 무작위로 선택
+    String reason = REPORT_REASON.get(random.nextInt(REPORT_REASON.size()));
+    ReportStatus status = randomEnum(ReportStatus.class, random);
+
+    // 신고 시간은 리뷰 작성 이후로 설정
+    LocalDateTime reportCreatedAt = review.getCreatedAt()
+        .plusHours(random.nextInt(24))
+        .plusDays(random.nextInt(30)); // 리뷰 작성 후 최대 30일 이내
+
+    // 이미지 유무는 50% 확률로 결정
+    String evidenceImageUrl = random.nextBoolean() ?
+        imageUrls.get(random.nextInt(imageUrls.size())) : null;
+
+    return ReviewReport.builder()
+        .review(review)
+        .reporterId(reporter.getId())
+        .type(ReporterType.USER) // 사용자에 의한 신고
+        .reason(reason)
+        .evidenceImageUrl(evidenceImageUrl)
+        .status(status)
+        .createdAt(reportCreatedAt)
+        .build();
   }
 
   public int createRandomCount(Random random, int typeSize) {
@@ -877,7 +1332,6 @@ public class DummyDataCreateService {
     return "010-" + faker.number().digits(4) + "-" + faker.number().digits(4);
   }
 
-  // Enum 클래스들의 값을 가져오기 위한 헬퍼 메서드
   private <T extends Enum<?>> T randomEnum(Class<T> enumClass, Random random) {
     T[] values = enumClass.getEnumConstants();
     return values[random.nextInt(values.length)];
@@ -906,5 +1360,9 @@ public class DummyDataCreateService {
 
   public long getReviewCount() {
     return reviewRepository.count();
+  }
+
+  public long getReportCount() {
+    return reviewReportRepository.count();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dev/DummyDataDeleteService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dev/DummyDataDeleteService.java
@@ -73,7 +73,7 @@ public class DummyDataDeleteService {
 
   private void clearAllElasticsearchIndices() {
     try {
-      List<String> indicesToClear = Arrays.asList("accommodations", "accommodation_rooms");
+      List<String> indicesToClear = Arrays.asList("accommodations", "accommodation_room");
 
       for (String index : indicesToClear) {
         try {

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dev/DummyDataDeleteService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dev/DummyDataDeleteService.java
@@ -1,107 +1,67 @@
 package com.meongnyangerang.meongnyangerang.dev;
 
-import com.meongnyangerang.meongnyangerang.domain.auth.AuthenticationCode;
-import com.meongnyangerang.meongnyangerang.domain.review.ReviewReport;
-import com.meongnyangerang.meongnyangerang.dto.ReviewRequest;
-import com.meongnyangerang.meongnyangerang.repository.AuthenticationCodeRepository;
-import com.meongnyangerang.meongnyangerang.repository.HostRepository;
-import com.meongnyangerang.meongnyangerang.repository.NotificationRepository;
-import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
-import com.meongnyangerang.meongnyangerang.repository.ReservationSlotRepository;
-import com.meongnyangerang.meongnyangerang.repository.ReviewImageRepository;
-import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
-import com.meongnyangerang.meongnyangerang.repository.UserRepository;
-import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
-import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationFacilityRepository;
-import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationImageRepository;
-import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationPetFacilityRepository;
-import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
-import com.meongnyangerang.meongnyangerang.repository.accommodation.AllowPetRepository;
-import com.meongnyangerang.meongnyangerang.repository.chat.ChatMessageRepository;
-import com.meongnyangerang.meongnyangerang.repository.chat.ChatReadStatusRepository;
-import com.meongnyangerang.meongnyangerang.repository.chat.ChatRoomRepository;
-import com.meongnyangerang.meongnyangerang.repository.room.HashtagRepository;
-import com.meongnyangerang.meongnyangerang.repository.room.RoomFacilityRepository;
-import com.meongnyangerang.meongnyangerang.repository.room.RoomPetFacilityRepository;
-import com.meongnyangerang.meongnyangerang.repository.room.RoomRepository;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.indices.DeleteIndexRequest;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DummyDataDeleteService {
 
-  private final HostRepository hostRepository;
-  private final UserRepository userRepository;
-  private final AuthenticationCodeRepository authenticationCodeRepository;
-  private final WishlistRepository wishlistRepository;
-
-  private final AccommodationRepository accommodationRepository;
-  private final AccommodationImageRepository accommodationImageRepository;
-  private final AllowPetRepository allowPetRepository;
-  private final AccommodationFacilityRepository accommodationFacilityRepository;
-  private final AccommodationPetFacilityRepository accommodationPetFacilityRepository;
-
-  private final RoomRepository roomRepository;
-  private final HashtagRepository hashtagRepository;
-  private final RoomFacilityRepository roomFacilityRepository;
-  private final RoomPetFacilityRepository roomPetFacilityRepository;
-
-  private final ReservationRepository reservationRepository;
-  private final ReservationSlotRepository reservationSlotRepository;
-
-  private final ReviewRepository reviewRepository;
-  private final ReviewImageRepository reviewImageRepository;
-
-  private final ChatRoomRepository chatRoomRepository;
-  private final ChatMessageRepository chatMessageRepository;
-  private final ChatReadStatusRepository chatReadStatusRepository;
-
-  private final NotificationRepository notificationRepository;
+  private final JdbcTemplate jdbcTemplate;
+  private final ElasticsearchClient elasticsearchClient;
 
   /**
-   * 관계 순서를 고려하여 역순으로 삭제
-   * admin, notice는 삭제하지 않습니다. (필요하다면 추가)
+   * 관계 순서를 고려하여 역순으로 삭제 admin, notice는 삭제하지 않습니다. (필요하다면 추가)
    */
   @Transactional
   public Map<String, Object> clearData() {
     Map<String, Object> result = new HashMap<>();
 
     try {
-      notificationRepository.deleteAll();
+      jdbcTemplate.execute("DELETE FROM notification");
+      jdbcTemplate.execute("DELETE FROM chat_read_status");
+      jdbcTemplate.execute("DELETE FROM chat_message");
+      jdbcTemplate.execute("DELETE FROM chat_room");
 
-      chatReadStatusRepository.deleteAll();
-      chatMessageRepository.deleteAll();
-      chatRoomRepository.deleteAll();
+      jdbcTemplate.execute("DELETE FROM review_report");
+      jdbcTemplate.execute("DELETE FROM review_image");
+      jdbcTemplate.execute("DELETE FROM review");
 
-      // 신고 기능 추가 시, 리뷰 신고 제거도 필요
-      reviewImageRepository.deleteAll();
-      reviewRepository.deleteAll();
+      jdbcTemplate.execute("DELETE FROM reservation_slot");
+      jdbcTemplate.execute("DELETE FROM reservation");
 
-      reservationSlotRepository.deleteAll();
-      reservationRepository.deleteAll();
+      jdbcTemplate.execute("DELETE FROM room_pet_facility");
+      jdbcTemplate.execute("DELETE FROM room_facility");
+      jdbcTemplate.execute("DELETE FROM hashtag");
+      jdbcTemplate.execute("DELETE FROM room");
 
-      roomPetFacilityRepository.deleteAll();
-      roomFacilityRepository.deleteAll();
-      hashtagRepository.deleteAll();
-      roomRepository.deleteAll();
+      jdbcTemplate.execute("DELETE FROM accommodation_pet_facility");
+      jdbcTemplate.execute("DELETE FROM accommodation_facility");
+      jdbcTemplate.execute("DELETE FROM allow_pet");
+      jdbcTemplate.execute("DELETE FROM accommodation_image");
+      jdbcTemplate.execute("DELETE FROM accommodation");
 
-      accommodationPetFacilityRepository.deleteAll();
-      accommodationFacilityRepository.deleteAll();
-      allowPetRepository.deleteAll();
-      accommodationImageRepository.deleteAll();
-      accommodationRepository.deleteAll();
+      jdbcTemplate.execute("DELETE FROM wishlist");
+      jdbcTemplate.execute("DELETE FROM authentication_code");
+      jdbcTemplate.execute("DELETE FROM user");
+      jdbcTemplate.execute("DELETE FROM host");
 
-      wishlistRepository.deleteAll();
-      authenticationCodeRepository.deleteAll();
-      userRepository.deleteAll();
-      hostRepository.deleteAll();
+      clearAllElasticsearchIndices(); // ES 인덱스 삭제
 
       result.put("success", true);
       result.put("message", "모든 더미 데이터가 삭제되었습니다.");
+
+      log.info("모든 데이터 삭제 작업 완료");
     } catch (Exception e) {
       result.put("success", false);
       result.put("error", e.getMessage());
@@ -109,5 +69,26 @@ public class DummyDataDeleteService {
       throw new RuntimeException("더미 데이터 삭제 실패", e);
     }
     return result;
+  }
+
+  private void clearAllElasticsearchIndices() {
+    try {
+      List<String> indicesToClear = Arrays.asList("accommodations", "accommodation_rooms");
+
+      for (String index : indicesToClear) {
+        try {
+          // 각 인덱스 삭제
+          DeleteIndexRequest request = DeleteIndexRequest.of(r -> r.index(index));
+          elasticsearchClient.indices().delete(request);
+          log.info("인덱스 삭제 완료: {}", index);
+        } catch (Exception e) {
+          log.warn("인덱스 {} 삭제 중 오류 발생: {}", index, e.getMessage());
+        }
+      }
+      log.info("모든 인덱스 삭제 작업 완료");
+    } catch (Exception e) {
+      log.error("Elasticsearch 인덱스 삭제 중 오류 발생", e);
+      throw new RuntimeException("Elasticsearch 인덱스 삭제 실패", e);
+    }
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dev/DummyDataGenerateRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dev/DummyDataGenerateRequest.java
@@ -1,12 +1,15 @@
 package com.meongnyangerang.meongnyangerang.dev;
 
 import lombok.Getter;
-
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 @Getter
 public class DummyDataGenerateRequest {
+
+  @Min(value = 1, message = "최소 1개 이상의 회원을 생성해야 합니다")
+  @Max(value = 500, message = "최대 500명까지 회원을 생성할 수 있습니다")
+  private int userCount;
 
   @Min(value = 1, message = "최소 1개 이상의 숙소를 생성해야 합니다")
   @Max(value = 1000, message = "최대 1000개까지 숙소를 생성할 수 있습니다")
@@ -17,10 +20,10 @@ public class DummyDataGenerateRequest {
   private int roomCount;
 
   @Min(value = 1, message = "예약 수는 1 이상이어야 합니다")
-  @Max(value = 1000, message = "최대 1000개까지 예약을 생성할 수 있습니다")
+  @Max(value = 2000, message = "최대 2000개까지 예약을 생성할 수 있습니다")
   private int reservationCount;
 
   @Min(value = 1, message = "리뷰 수는 1이상이어야 합니다")
-  @Max(value = 1000, message = "최대 1000개까지 리뷰를 생성할 수 있습니다")
+  @Max(value = 2000, message = "최대 2000개까지 리뷰를 생성할 수 있습니다")
   private int reviewCount;
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -67,6 +67,7 @@ public enum ErrorCode {
   NOT_EXIST_WISHLIST(HttpStatus.NOT_FOUND, "존재하지 않는 찜 목록입니다."),
   NOT_EXIST_NOTICE(HttpStatus.NOT_FOUND, "존재하지 않는 공지사항입니다."),
   NOT_EXIST_CHAT_ROOM(HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다."),
+  NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "버킷에서 가져올 이미지가 없습니다."),
 
 
   // 409 Conflict

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRoomSearchService.java
@@ -24,12 +24,10 @@ import com.meongnyangerang.meongnyangerang.repository.room.RoomFacilityRepositor
 import com.meongnyangerang.meongnyangerang.repository.room.RoomPetFacilityRepository;
 import com.meongnyangerang.meongnyangerang.repository.room.RoomRepository;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/image/S3FileServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/image/S3FileServiceTest.java
@@ -9,9 +9,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
-import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import software.amazon.awssdk.core.sync.RequestBody;
 import java.net.MalformedURLException;
@@ -27,14 +26,16 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Utilities;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 @ExtendWith(MockitoExtension.class)
 class S3FileServiceTest {
@@ -48,7 +49,6 @@ class S3FileServiceTest {
   @InjectMocks
   private S3FileService s3FileService;
 
-  private static final String IMAGE_PATH_PREFIX = "image";
   private static final String BUCKET = "test-bucket";
   private static final UUID MOCK_UUID =
       UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
@@ -154,5 +154,35 @@ class S3FileServiceTest {
         .hasSize(expectedKeys.size())
         .extracting(ObjectIdentifier::key)
         .containsExactlyElementsOf(expectedKeys);
+  }
+
+  @Test
+  void getAllImageUrls_Success() throws MalformedURLException {
+    // given
+    when(s3Client.utilities()).thenReturn(s3Utilities);
+    doReturn(new URL(MOCK_FILE_URL)).when(s3Utilities).getUrl(any(GetUrlRequest.class));
+
+    List<S3Object> objects = new ArrayList<>();
+    objects.add(S3Object.builder().key(MOCK_FILE_URL).build());
+    objects.add(S3Object.builder().key("document.pdf").build()); // 이미지가 아닌 객체
+
+    ArgumentCaptor<ListObjectsV2Request> listObjectsV2RequestArgumentCaptor = ArgumentCaptor
+        .forClass(ListObjectsV2Request.class);
+
+    ListObjectsV2Response mockResponse = ListObjectsV2Response.builder()
+        .contents(objects)
+        .keyCount(3)
+        .build();
+
+    when(s3Client.listObjectsV2(listObjectsV2RequestArgumentCaptor.capture()))
+        .thenReturn(mockResponse);
+
+    // when
+    List<String> result = s3FileService.getAllImageUrls();
+
+    // then
+    assertEquals(1, result.size());
+    assertTrue(result.contains(MOCK_FILE_URL));
+    assertFalse(result.contains("https://test-bucket.s3.amazonaws.com/document.pdf"));
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #209 

## 📝 변경 사항
### AS-IS
- 더미 데이터 관련 API를 모든 회원이 호출할 수 있음
- 더미 데이터 생성 시, 신고 데이터 생성 부재
- 더미 데이터 생성 시, User의 수를 100으로 고정하여 생성
- RDB 데이터 삭제 시, RDB 데이터를 영속성 컨텍스트를 통해 레코드 하나씩 삭제
- RDB 데이터 삭제 시, ES의 인덱스는 삭제하지 않음
- S3 이미지 URL을 직접 선언한 URL을 가져옴

### TO-BE

- 더미 데이터 관련 API 관리자 계정만 호출할 수 있도록 설정
- 데이터 생성 시, 리뷰 신고 데이터 추가
- User 생성 수 요청 값 추가
- 데이터 삭제 시, 직접 DELETE 쿼리를 실행하여 DB 수준에서 한 번의 쿼리로 모든 레코드를 삭제하도록 변경
- ES 인덱스 제거 로직 추가
- 이미지 URL을 S3에서 직접 가져오도록 구현
- S3에서 객체를 가져오는 메서드의 단위 테스트 구현

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 더미 데이터 생성 성공
![new_success](https://github.com/user-attachments/assets/827a8131-72ab-40a6-92d5-04b95830ce66)

- ES 인덱싱 성공
![new_es_success](https://github.com/user-attachments/assets/c717ad19-36c4-4d5b-8ca6-61b7d43782db)

- 더미 데이터 삭제 성공
![new_delete_success](https://github.com/user-attachments/assets/71e5b331-92e9-450c-ba09-11762d2cce5a)

- ES 인덱스 삭제 성공
![new_delete_es](https://github.com/user-attachments/assets/41b6c772-d2dd-4757-9be9-9893a564d122)

- RDB 데이터 조회 성공
![new_get_duumy_data](https://github.com/user-attachments/assets/adc47ef3-3f3f-48a1-9bbf-997f86aa0402)]

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
특히, 인덱스 생성, 삭제 부분 유심히 봐주세요.
빠트린 부분 말씀 주세요.