### PR TITLE
[Fix] 예약 취소 시, 알림 타입이 COMPLETED인 버그 수정

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/notification/NotificationType.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/notification/NotificationType.java
@@ -11,6 +11,7 @@ public enum NotificationType {
   RESERVATION_CONFIRMED("예약 확인"),    // 사용자에게
   RESERVATION_REGISTERED("예약 등록"),  // 호스트에게
   RESERVATION_REMINDER("예약 리마인더"), // 사용자에게
+  RESERVATION_CANCELED("예약 취소"),
   REVIEW("리뷰");
 
   private final String value;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
@@ -1,6 +1,7 @@
 package com.meongnyangerang.meongnyangerang.service;
 
 import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
+import com.meongnyangerang.meongnyangerang.domain.notification.NotificationType;
 import com.meongnyangerang.meongnyangerang.domain.reservation.Reservation;
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationSlot;
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
@@ -248,7 +249,8 @@ public class ReservationService {
         reservation.getUser(),
         reservation.getRoom().getAccommodation().getHost(),
         reservationConfirmedContent,
-        reservationRegisteredContent
+        reservationRegisteredContent,
+        NotificationType.RESERVATION_CONFIRMED
     );
   }
 
@@ -264,7 +266,8 @@ public class ReservationService {
         reservation.getUser(),
         reservation.getRoom().getAccommodation().getHost(),
         reservationConfirmedContent,
-        reservationRegisteredContent
+        reservationRegisteredContent,
+        NotificationType.RESERVATION_CANCELED
     );
   }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/notification/NotificationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/notification/NotificationService.java
@@ -60,12 +60,13 @@ public class NotificationService {
       User user,
       Host host,
       String contentToUser,
-      String contentToHost
+      String contentToHost,
+      NotificationType notificationType
   ) {
     // 사용자에게 예약 확정 알림 전송 및 저장
-    sendReservationNotificationToUser(reservationId, user, contentToUser);
+    sendReservationNotificationToUser(reservationId, user, contentToUser, notificationType);
     // 호스트에게 예약 등록 알림 전송 및 저장
-    sendReservationNotificationToHost(reservationId, host, contentToHost);
+    sendReservationNotificationToHost(reservationId, host, contentToHost, notificationType);
   }
 
   /**
@@ -148,9 +149,13 @@ public class NotificationService {
     );
   }
 
-  private void sendReservationNotificationToUser(Long reservationId, User user, String content) {
-    Notification savedNotification = saveNotificationAsUser(
-        user, content, NotificationType.RESERVATION_CONFIRMED);
+  private void sendReservationNotificationToUser(
+      Long reservationId,
+      User user,
+      String content,
+      NotificationType notificationType
+  ) {
+    Notification savedNotification = saveNotificationAsUser(user, content, notificationType);
 
     notificationAsyncSender.sendReservationNotification(
         savedNotification.getId(),
@@ -158,13 +163,17 @@ public class NotificationService {
         content,
         user.getId(),
         SenderType.USER,
-        NotificationType.RESERVATION_CONFIRMED
+        notificationType
     );
   }
 
-  private void sendReservationNotificationToHost(Long reservationId, Host host, String content) {
-    Notification savedNotification = saveNotificationAsHost(
-        host, content, NotificationType.RESERVATION_REGISTERED);
+  private void sendReservationNotificationToHost(
+      Long reservationId,
+      Host host,
+      String content,
+      NotificationType notificationType
+  ) {
+    Notification savedNotification = saveNotificationAsHost(host, content, notificationType);
 
     notificationAsyncSender.sendReservationNotification(
         savedNotification.getId(),
@@ -172,7 +181,7 @@ public class NotificationService {
         content,
         host.getId(),
         SenderType.HOST,
-        NotificationType.RESERVATION_REGISTERED
+        notificationType
     );
   }
 

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
 import com.meongnyangerang.meongnyangerang.domain.host.Host;
+import com.meongnyangerang.meongnyangerang.domain.notification.NotificationType;
 import com.meongnyangerang.meongnyangerang.domain.reservation.Reservation;
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationSlot;
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
@@ -140,7 +141,8 @@ class ReservationServiceTest {
         user,
         host,
         reservationConfirmedContent,
-        reservationRegisteredContent
+        reservationRegisteredContent,
+        NotificationType.RESERVATION_CONFIRMED
     );
   }
 
@@ -419,7 +421,8 @@ class ReservationServiceTest {
         user,
         room.getAccommodation().getHost(),
         reservationConfirmedContent,
-        reservationRegisteredContent
+        reservationRegisteredContent,
+        NotificationType.RESERVATION_CANCELED
     );
   }
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #220

## 📝 변경 사항
### AS-IS
- 예약 취소 시, 알림 타입이 COMPLETED

### TO-BE
- 예약 취소 시, 알림 타입이 DELETED이어야 함

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 사용자에게 발송된 알림
![new_reservation_canceled2](https://github.com/user-attachments/assets/11945dd1-05a5-4813-a4ea-e09707c72d85)

- 호스트에게 발송된 알림
![new_reservation_cancled](https://github.com/user-attachments/assets/38feb8d9-3e7a-4de4-938b-f17aa6f7658f)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.