### PR TITLE
[Feature] 메시지 이력 조회 시, 상대방의 이름과 이미지 추가

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ChatController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ChatController.java
@@ -4,6 +4,7 @@ import com.meongnyangerang.meongnyangerang.domain.chat.SenderType;
 import com.meongnyangerang.meongnyangerang.domain.user.Role;
 import com.meongnyangerang.meongnyangerang.dto.chat.ChatCreateRequest;
 import com.meongnyangerang.meongnyangerang.dto.chat.ChatCreateResponse;
+import com.meongnyangerang.meongnyangerang.dto.chat.ChatMessagePageResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.ChatMessageResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.ChatRoomResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
@@ -70,7 +71,7 @@ public class ChatController {
    * 메시지 이력 조회
    */
   @GetMapping("/{chatRoomId}/messages")
-  public ResponseEntity<PageResponse<ChatMessageResponse>> getChatMessages(
+  public ResponseEntity<ChatMessagePageResponse<ChatMessageResponse>> getChatMessages(
       @PathVariable Long chatRoomId,
       @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
       Pageable pageable,
@@ -80,10 +81,10 @@ public class ChatController {
 
     if (viewerRole == Role.ROLE_USER) {
       return ResponseEntity.ok(
-          chatService.getChatMessages(userDetails.getId(), chatRoomId, pageable, SenderType.USER));
+          chatService.getChatMessagesAsUser(userDetails.getId(), chatRoomId, pageable));
     } else if (viewerRole == Role.ROLE_HOST) {
       return ResponseEntity.ok(
-          chatService.getChatMessages(userDetails.getId(), chatRoomId, pageable, SenderType.HOST));
+          chatService.getChatMessagesAsHost(userDetails.getId(), chatRoomId, pageable));
     } else {
       throw new MeongnyangerangException(ErrorCode.INVALID_AUTHORIZED);
     }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/chat/ChatMessagePageResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/chat/ChatMessagePageResponse.java
@@ -1,0 +1,35 @@
+package com.meongnyangerang.meongnyangerang.dto.chat;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record ChatMessagePageResponse<T>(
+    List<T> content,
+    String receiverName,
+    String receiverImageUrl,
+    int page,           // 현재 페이지 번호
+    int size,           // 페이지당 항목 수
+    long totalElements, // 전체 데이터 항목 수
+    int totalPages,     // 전체 페이지 수
+    boolean first,      // 현재 페이지가 첫 번째 페이지인지 여부
+    boolean last        // 현재 페이지가 마지막 페이지인지 여부
+) {
+
+  public static <T> ChatMessagePageResponse<T> from(
+      Page<T> page,
+      String receiverName,
+      String receiverImageUrl
+  ) {
+    return new ChatMessagePageResponse<>(
+        page.getContent(),
+        receiverName,
+        receiverImageUrl,
+        page.getNumber(),
+        page.getSize(),
+        page.getTotalElements(),
+        page.getTotalPages(),
+        page.isFirst(),
+        page.isLast()
+    );
+  }
+}

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ChatServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ChatServiceTest.java
@@ -18,6 +18,7 @@ import com.meongnyangerang.meongnyangerang.domain.chat.MessageType;
 import com.meongnyangerang.meongnyangerang.domain.chat.SenderType;
 import com.meongnyangerang.meongnyangerang.domain.host.Host;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
+import com.meongnyangerang.meongnyangerang.dto.chat.ChatMessagePageResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.ChatMessageResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.ChatRoomResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
@@ -451,10 +452,11 @@ class ChatServiceTest {
         chatRoomId, userId, senderType)).thenReturn(Optional.of(chatReadStatus));
     when(chatMessageRepository.findByChatRoomId(chatRoomId, pageable))
         .thenReturn(pagedChatRooms);
+    when(accommodationRepository.findByHostId(host.getId())).thenReturn(Optional.of(accommodation));
 
     // when
-    PageResponse<ChatMessageResponse> response = chatService.getChatMessages(
-        userId, chatRoomId, pageable, SenderType.USER);
+    ChatMessagePageResponse<ChatMessageResponse> response = chatService.getChatMessagesAsUser(
+        userId, chatRoomId, pageable);
 
     // then
     List<ChatMessageResponse> messages = response.content();
@@ -493,7 +495,7 @@ class ChatServiceTest {
     // when
     // then
     assertThatThrownBy(
-        () -> chatService.getChatMessages(userId, chatRoomId, pageable, SenderType.USER))
+        () -> chatService.getChatMessagesAsUser(userId, chatRoomId, pageable))
         .isInstanceOf(MeongnyangerangException.class)
         .hasFieldOrPropertyWithValue("ErrorCode", ErrorCode.NOT_EXIST_CHAT_ROOM);
 
@@ -515,8 +517,8 @@ class ChatServiceTest {
 
     // when
     // then
-    assertThatThrownBy(() -> chatService.getChatMessages(
-        notAuthorizedUser.getId(), chatRoomId, pageable, SenderType.USER))
+    assertThatThrownBy(() -> chatService.getChatMessagesAsUser(
+        notAuthorizedUser.getId(), chatRoomId, pageable))
         .isInstanceOf(MeongnyangerangException.class)
         .hasFieldOrPropertyWithValue("ErrorCode", ErrorCode.CHAT_ROOM_NOT_AUTHORIZED);
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #222 

## 📝 변경 사항
### AS-IS
- 메시지 이력 조회 시, 상대방의 이름과 이미지가 반환되지 않음

### TO-BE
- 메시지 이력 조회 또는 실시간 메시지 전송 시, 상대방의 이름과 이미지 추가 반환
  - 상대방이 호스트인 경우 숙소명과 숙소 썸네일을 반환
  - 상대방이 일반회원인 경우 회원의 닉네임과 프로필 사진을 반환

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 일반회원이 조회했을 때, 상대 호스트의 숙소명과 숙소 썸네일 반환
![new_user](https://github.com/user-attachments/assets/8fdac4bc-de65-4731-9e8d-030fafb60b79)

- 호스트가 조회했을 때 상대 일반회원의 닉네임과 프로필 사진을 반환
![new_host](https://github.com/user-attachments/assets/173d0808-ee49-4607-a6c6-fc6cf5f1f452)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.