### PR TITLE
[Feature] 채팅 읽음 처리 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ChatController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ChatController.java
@@ -16,6 +16,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -81,6 +82,16 @@ public class ChatController {
   ) {
     chatService.sendImage(
         request.chatRoomId(), imageFile, userDetails.getId(), userDetails.getRole().toSenderType());
+    return ResponseEntity.ok().build();
+  }
+
+  @PatchMapping("/{chatRoomId}/read")
+  public ResponseEntity<Void> markAsRead(
+      @PathVariable Long chatRoomId,
+      @AuthenticationPrincipal UserDetailsImpl userDetails
+  ) {
+    SenderType viewerType = userDetails.getRole().toSenderType();
+    chatService.markMessageAsRead(userDetails.getId(), chatRoomId, viewerType);
     return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ChatService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ChatService.java
@@ -150,6 +150,15 @@ public class ChatService {
     sendWebSocketMessageWithSenderInfo(chatRoomId, senderType, savedMessage, chatRoom);
   }
 
+  /**
+   * 읽음 상태 갱신
+   */
+  @Transactional
+  public void markMessageAsRead(Long viewerId, Long chatRoomId, SenderType viewerType) {
+    ChatRoom chatRoom = findAndValidateChatRoom(viewerId, chatRoomId, viewerType);
+    updateReadStatus(chatRoom, viewerId, viewerType);
+  }
+
   private void sendWebSocketMessageWithSenderInfo(
       Long chatRoomId,
       SenderType senderType,


### PR DESCRIPTION
## 📌 관련 이슈
- close #228

## 📝 변경 사항
### AS-IS
- 채팅 읽음 처리를 API 부재

### TO-BE
- 채팅 읽음 처리 API 구현
  - 채팅방의 읽음 상태의 last_read_time을 API를 호출한 시각으로 갱신
- 채팅 읽음 처리 단위 테스트 구현
  - 읽음 상태 존재할 때 성공 케이스
  - 읽음 상태 존재하지 않을 때 성공 케이스
  - 채팅방이 존재하지 않을 때 예외 발생 케이스
  - 채팅방 권한이 없을 때 예외 발생 케이스

🔄 기대 동작
## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 성공
![success](https://github.com/user-attachments/assets/8ecd4331-8902-496c-af50-8a4c945541c3)

- 채팅방 없음
![error_not_found_chatroom](https://github.com/user-attachments/assets/db23cd54-3b15-47fe-ac88-2fe7914b1fee)

- 채팅방 권한 없음
![error_not_authorization](https://github.com/user-attachments/assets/dc5cdbda-1723-441d-ab2c-9baca0a016f6)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.