### PR TITLE
[Feature] 리프레시 토큰 기반 액세스 토큰 재발급 기능 추가

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
@@ -62,6 +62,7 @@ public class SecurityConfig {
                 "/api/v1/search/accommodations",
                 "/api/v1/accommodations/{accommodationId}",
                 "/api/v1/rooms/{roomId}",
+                "api/v1/auth/reissue",
                 "/health"
             ).permitAll()
             .requestMatchers("/api/v1/users/**").hasAuthority("ROLE_USER")

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
@@ -34,7 +34,7 @@ public class AdminController {
   // 관리자 로그인 API
   @PostMapping("/login")
   public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
-    return ResponseEntity.ok(new LoginResponse(adminService.login(request)));
+    return ResponseEntity.ok(adminService.login(request));
   }
 
   // 호스트 가입 신청 목록 조회

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AuthController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AuthController.java
@@ -2,6 +2,8 @@ package com.meongnyangerang.meongnyangerang.controller;
 
 import com.meongnyangerang.meongnyangerang.dto.EmailRequest;
 import com.meongnyangerang.meongnyangerang.dto.VerifyCodeRequest;
+import com.meongnyangerang.meongnyangerang.dto.auth.RefreshRequest;
+import com.meongnyangerang.meongnyangerang.dto.auth.RefreshResponse;
 import com.meongnyangerang.meongnyangerang.service.AuthService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
@@ -58,5 +60,12 @@ public class AuthController {
       @RequestParam("nickname") @Size(min = 2, max = 20) String nickname) {
     authService.checkNickname(nickname);
     return ResponseEntity.ok().build();
+  }
+
+  // 리프레시 토큰을 이용해 새로운 액세스 토큰을 재발급하는 API
+  @PostMapping("/auth/reissue")
+  public ResponseEntity<RefreshResponse> reissueAccessToken(
+      @RequestBody @Valid RefreshRequest request) {
+    return ResponseEntity.ok(authService.reissueAccessToken(request.refreshToken()));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/HostController.java
@@ -45,7 +45,7 @@ public class HostController {
   // 호스트 로그인 API
   @PostMapping("/login")
   public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
-    return ResponseEntity.ok(new LoginResponse(hostService.login(request)));
+    return ResponseEntity.ok(hostService.login(request));
   }
 
   // 호스트 회원 탈퇴 API

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/UserController.java
@@ -40,7 +40,7 @@ public class UserController {
   // 사용자 로그인 API
   @PostMapping("/login")
   public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
-    return ResponseEntity.ok(new LoginResponse(userService.login(request)));
+    return ResponseEntity.ok(userService.login(request));
   }
 
   // 사용자 회원 탈퇴 API

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/auth/RefreshToken.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/auth/RefreshToken.java
@@ -1,0 +1,39 @@
+package com.meongnyangerang.meongnyangerang.domain.auth;
+
+import com.meongnyangerang.meongnyangerang.domain.user.Role;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class RefreshToken {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true)
+  private String refreshToken;
+
+  @Column(nullable = false)
+  private Long userId;
+
+  @Enumerated(EnumType.STRING)
+  private Role role;
+
+  @Column(nullable = false)
+  private LocalDateTime expiryDate;
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/LoginResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/LoginResponse.java
@@ -9,4 +9,5 @@ import lombok.Getter;
 public class LoginResponse {
 
   private String accessToken;
+  private String refreshToken;
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/auth/RefreshRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/auth/RefreshRequest.java
@@ -1,0 +1,8 @@
+package com.meongnyangerang.meongnyangerang.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(
+    @NotBlank(message = "리프레시 토큰이 누락되었습니다.")
+    String refreshToken
+) {}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/auth/RefreshResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/auth/RefreshResponse.java
@@ -1,0 +1,5 @@
+package com.meongnyangerang.meongnyangerang.dto.auth;
+
+public record RefreshResponse(
+    String accessToken
+){}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -42,6 +42,8 @@ public enum ErrorCode {
 
   // 401 UNAUTHORIZED (인증 실패)
   EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "JWT 토큰이 만료되었습니다."),
+  INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),
+  EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
   INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "JWT 서명이 유효하지 않습니다."),
   JWT_VALIDATION_ERROR(HttpStatus.UNAUTHORIZED, "JWT 검증 중 오류가 발생했습니다."),
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/jwt/JwtTokenProvider.java
@@ -53,10 +53,10 @@ public class JwtTokenProvider {
     key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
   }
 
-  // 토큰 생성
-  public String createToken(Long id, String email, String role, Enum<?> status) {
+  // Access Token 발급
+  public String createAccessToken(Long id, String email, String role, Enum<?> status) {
     Date now = new Date();
-    Date expiryDate = new Date(now.getTime() + tokenTime);
+    Date expiryDate = new Date(now.getTime() + accessTokenValidity);
 
     return Jwts.builder()
         .setSubject(email) // JWT payload의 subject(email)

--- a/src/main/java/com/meongnyangerang/meongnyangerang/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/jwt/JwtTokenProvider.java
@@ -69,6 +69,18 @@ public class JwtTokenProvider {
         .compact();
   }
 
+  // Refresh Token 발급
+  public String createRefreshToken() {
+    Date now = new Date();
+    Date expiryDate = new Date(now.getTime() + refreshTokenValidity);
+
+    return Jwts.builder()
+        .setIssuedAt(now)
+        .setExpiration(expiryDate)
+        .signWith(key, signatureAlgorithm)
+        .compact();
+  }
+
   // JWT 토큰 유효성 검사
   public boolean validateToken(String token) {
     try {

--- a/src/main/java/com/meongnyangerang/meongnyangerang/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/jwt/JwtTokenProvider.java
@@ -44,7 +44,8 @@ public class JwtTokenProvider {
   // 암호화 알고리즘
   private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
 
-  private final long tokenTime = 1000L * 60 * 60; // 1시간
+  private final long accessTokenValidity = 1000L * 60 * 15; // 15분
+  private final long refreshTokenValidity = 1000L * 60 * 60 * 24 * 7; // 7일
 
   // Bean 생성 후 자동 실행 (secretKey를 Key 객체로 변환하여 저장)
   @PostConstruct

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/auth/RefreshTokenRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/auth/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.meongnyangerang.meongnyangerang.repository.auth;
+
+import com.meongnyangerang.meongnyangerang.domain.auth.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/auth/RefreshTokenRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/auth/RefreshTokenRepository.java
@@ -1,10 +1,12 @@
 package com.meongnyangerang.meongnyangerang.repository.auth;
 
 import com.meongnyangerang.meongnyangerang.domain.auth.RefreshToken;
+import com.meongnyangerang.meongnyangerang.domain.user.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
+  void deleteByUserIdAndRole(Long userId, Role role);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/auth/RefreshTokenRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/auth/RefreshTokenRepository.java
@@ -2,6 +2,7 @@ package com.meongnyangerang.meongnyangerang.repository.auth;
 
 import com.meongnyangerang.meongnyangerang.domain.auth.RefreshToken;
 import com.meongnyangerang.meongnyangerang.domain.user.Role;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
   void deleteByUserIdAndRole(Long userId, Role role);
+
+  Optional<RefreshToken> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AdminService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AdminService.java
@@ -49,7 +49,7 @@ public class AdminService {
 
     // 상태 검증은 JwtTokenProvider 내부에서 수행됨
 
-    return jwtTokenProvider.createToken(admin.getId(), admin.getEmail(), admin.getRole().name(),
+    return jwtTokenProvider.createAccessToken(admin.getId(), admin.getEmail(), admin.getRole().name(),
         admin.getStatus());
   }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AdminService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AdminService.java
@@ -5,9 +5,11 @@ import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_
 
 import com.meongnyangerang.meongnyangerang.component.MailComponent;
 import com.meongnyangerang.meongnyangerang.domain.admin.Admin;
+import com.meongnyangerang.meongnyangerang.domain.auth.RefreshToken;
 import com.meongnyangerang.meongnyangerang.domain.host.Host;
 import com.meongnyangerang.meongnyangerang.domain.host.HostStatus;
 import com.meongnyangerang.meongnyangerang.dto.LoginRequest;
+import com.meongnyangerang.meongnyangerang.dto.LoginResponse;
 import com.meongnyangerang.meongnyangerang.dto.PendingHostDetailResponse;
 import com.meongnyangerang.meongnyangerang.dto.PendingHostListResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
@@ -16,7 +18,9 @@ import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.jwt.JwtTokenProvider;
 import com.meongnyangerang.meongnyangerang.repository.AdminRepository;
 import com.meongnyangerang.meongnyangerang.repository.HostRepository;
+import com.meongnyangerang.meongnyangerang.repository.auth.RefreshTokenRepository;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -34,9 +38,10 @@ public class AdminService {
   private final PasswordEncoder passwordEncoder;
   private final JwtTokenProvider jwtTokenProvider;
   private final MailComponent mailComponent;
+  private final RefreshTokenRepository refreshTokenRepository;
 
   // 관리자 로그인
-  public String login(@Valid LoginRequest request) {
+  public LoginResponse login(@Valid LoginRequest request) {
 
     // 관리자 조회
     Admin admin = adminRepository.findByEmail(request.getEmail())
@@ -47,10 +52,25 @@ public class AdminService {
       throw new MeongnyangerangException(INVALID_PASSWORD);
     }
 
-    // 상태 검증은 JwtTokenProvider 내부에서 수행됨
+    // Access Token 발급
+    String accessToken = jwtTokenProvider.createAccessToken(
+        admin.getId(), admin.getEmail(), admin.getRole().name(), admin.getStatus()
+    );
 
-    return jwtTokenProvider.createAccessToken(admin.getId(), admin.getEmail(), admin.getRole().name(),
-        admin.getStatus());
+    // Refresh Token 발급
+    String refreshToken = jwtTokenProvider.createRefreshToken();
+
+    // 기존 Refresh Token 삭제 후 저장
+    refreshTokenRepository.deleteByUserIdAndRole(admin.getId(), admin.getRole());
+    refreshTokenRepository.save(RefreshToken.builder()
+        .refreshToken(refreshToken)
+        .userId(admin.getId())
+        .role(admin.getRole())
+        .expiryDate(LocalDateTime.now().plusDays(7))
+        .build());
+
+    // 6. Access Token + Refresh Token 응답
+    return new LoginResponse(accessToken, refreshToken);
   }
 
   // 가입 신청 목록 조회

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AuthService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AuthService.java
@@ -115,7 +115,7 @@ public class AuthService {
 
     // DB 조회
     RefreshToken tokenEntity = refreshTokenRepository.findByRefreshToken(refreshToken)
-        .orElseThrow(() -> new MeongnyangerangException(ErrorCode.INVALID_REFRESH_TOKEN));
+        .orElseThrow(() -> new MeongnyangerangException(INVALID_REFRESH_TOKEN));
 
     // 만료 시간 체크
     if (tokenEntity.getExpiryDate().isBefore(LocalDateTime.now())) {

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -103,7 +103,7 @@ public class HostService {
       throw new MeongnyangerangException(ACCOUNT_PENDING);
     }
 
-    return jwtTokenProvider.createToken(host.getId(), host.getEmail(), host.getRole().name(),
+    return jwtTokenProvider.createAccessToken(host.getId(), host.getEmail(), host.getRole().name(),
         host.getStatus());
   }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/HostService.java
@@ -15,17 +15,20 @@ import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.INVALID_PA
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_ACCOUNT;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.RESERVED_RESERVATION_EXISTS;
 
+import com.meongnyangerang.meongnyangerang.domain.auth.RefreshToken;
 import com.meongnyangerang.meongnyangerang.domain.host.Host;
 import com.meongnyangerang.meongnyangerang.domain.host.HostStatus;
 import com.meongnyangerang.meongnyangerang.dto.HostProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.HostSignupRequest;
 import com.meongnyangerang.meongnyangerang.dto.LoginRequest;
+import com.meongnyangerang.meongnyangerang.dto.LoginResponse;
 import com.meongnyangerang.meongnyangerang.dto.PasswordUpdateRequest;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.jwt.JwtTokenProvider;
 import com.meongnyangerang.meongnyangerang.repository.HostRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
+import com.meongnyangerang.meongnyangerang.repository.auth.RefreshTokenRepository;
 import com.meongnyangerang.meongnyangerang.service.image.ImageService;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
@@ -44,8 +47,9 @@ public class HostService {
   private final PasswordEncoder passwordEncoder;
   private final JwtTokenProvider jwtTokenProvider;
   private final ImageService imageService;
-  private final ReservationRepository reservationRepository;
   private final AuthService authService;
+  private final ReservationRepository reservationRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
 
   // 호스트 회원가입
   public void registerHost(HostSignupRequest request,
@@ -82,7 +86,7 @@ public class HostService {
   }
 
   // 호스트 로그인
-  public String login(@Valid LoginRequest request) {
+  public LoginResponse login(@Valid LoginRequest request) {
 
     // 호스트 조회
     Host host = hostRepository.findByEmail(request.getEmail())
@@ -103,8 +107,24 @@ public class HostService {
       throw new MeongnyangerangException(ACCOUNT_PENDING);
     }
 
-    return jwtTokenProvider.createAccessToken(host.getId(), host.getEmail(), host.getRole().name(),
-        host.getStatus());
+    // Access Token 발급
+    String accessToken = jwtTokenProvider.createAccessToken(host.getId(), host.getEmail(),
+        host.getRole().name(), host.getStatus());
+
+    // Refresh Token 발급
+    String refreshToken = jwtTokenProvider.createRefreshToken();
+
+    // Refresh Token 저장
+    refreshTokenRepository.deleteByUserIdAndRole(host.getId(), host.getRole()); // 중복 방지
+    refreshTokenRepository.save(RefreshToken.builder()
+        .refreshToken(refreshToken)
+        .userId(host.getId())
+        .role(host.getRole())
+        .expiryDate(LocalDateTime.now().plusDays(7))
+        .build());
+
+    // Access Token + Refresh Token 함께 응답
+    return new LoginResponse(accessToken, refreshToken);
   }
 
   // 호스트 회원 탈퇴

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -10,9 +10,11 @@ import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.INVALID_PA
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_ACCOUNT;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.RESERVED_RESERVATION_EXISTS;
 
+import com.meongnyangerang.meongnyangerang.domain.auth.RefreshToken;
 import com.meongnyangerang.meongnyangerang.domain.reservation.ReservationStatus;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.dto.LoginRequest;
+import com.meongnyangerang.meongnyangerang.dto.LoginResponse;
 import com.meongnyangerang.meongnyangerang.dto.PasswordUpdateRequest;
 import com.meongnyangerang.meongnyangerang.dto.UserProfileResponse;
 import com.meongnyangerang.meongnyangerang.dto.UserSignupRequest;
@@ -20,6 +22,7 @@ import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.jwt.JwtTokenProvider;
 import com.meongnyangerang.meongnyangerang.repository.ReservationRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
+import com.meongnyangerang.meongnyangerang.repository.auth.RefreshTokenRepository;
 import com.meongnyangerang.meongnyangerang.service.image.ImageService;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
@@ -37,8 +40,9 @@ public class UserService {
   private final PasswordEncoder passwordEncoder;
   private final JwtTokenProvider jwtTokenProvider;
   private final ImageService imageService;
-  private final ReservationRepository reservationRepository;
   private final AuthService authService;
+  private final ReservationRepository reservationRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
 
   // 사용자 회원가입
   public void registerUser(UserSignupRequest request, MultipartFile profileImage) {
@@ -66,7 +70,8 @@ public class UserService {
   }
 
   // 사용자 로그인
-  public String login(@Valid LoginRequest request) {
+  @Transactional
+  public LoginResponse login(@Valid LoginRequest request) {
 
     // 사용자 조회
     User user = userRepository.findByEmail(request.getEmail())
@@ -82,8 +87,24 @@ public class UserService {
       throw new MeongnyangerangException(ACCOUNT_DELETED);
     }
 
-    return jwtTokenProvider.createAccessToken(user.getId(), user.getEmail(), user.getRole().name(),
-        user.getStatus());
+    // Access Token 발급
+    String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getEmail(),
+        user.getRole().name(), user.getStatus());
+
+    // Refresh Token 발급
+    String refreshToken = jwtTokenProvider.createRefreshToken();
+
+    // Refresh Token 저장
+    refreshTokenRepository.deleteByUserId(user.getId()); // 중복 방지
+    refreshTokenRepository.save(RefreshToken.builder()
+        .refreshToken(refreshToken)
+        .userId(user.getId())
+        .role(user.getRole())
+        .expiryDate(LocalDateTime.now().plusDays(7))
+        .build());
+
+    // Access Token + Refresh Token 함께 응답
+    return new LoginResponse(accessToken, refreshToken);
   }
 
   // 사용자 회원 탈퇴

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -82,7 +82,7 @@ public class UserService {
       throw new MeongnyangerangException(ACCOUNT_DELETED);
     }
 
-    return jwtTokenProvider.createToken(user.getId(), user.getEmail(), user.getRole().name(),
+    return jwtTokenProvider.createAccessToken(user.getId(), user.getEmail(), user.getRole().name(),
         user.getStatus());
   }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/UserService.java
@@ -95,7 +95,7 @@ public class UserService {
     String refreshToken = jwtTokenProvider.createRefreshToken();
 
     // Refresh Token 저장
-    refreshTokenRepository.deleteByUserId(user.getId()); // 중복 방지
+    refreshTokenRepository.deleteByUserIdAndRole(user.getId(), user.getRole()); // 중복 방지
     refreshTokenRepository.save(RefreshToken.builder()
         .refreshToken(refreshToken)
         .userId(user.getId())

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AuthServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AuthServiceTest.java
@@ -24,6 +24,7 @@ import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
 import com.meongnyangerang.meongnyangerang.dto.auth.RefreshResponse;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
+import com.meongnyangerang.meongnyangerang.exception.JwtCustomException;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.jwt.JwtTokenProvider;
 import com.meongnyangerang.meongnyangerang.repository.AdminRepository;
@@ -270,5 +271,21 @@ class AuthServiceTest {
     assertThatThrownBy(() -> authService.reissueAccessToken(refreshToken))
         .isInstanceOf(MeongnyangerangException.class)
         .hasMessage(ErrorCode.EXPIRED_REFRESH_TOKEN.getDescription());
+  }
+
+  @Test
+  @DisplayName("리프레시 토큰 자체가 유효성 검증 실패하면 예외 발생")
+  void should_throw_exception_when_refresh_token_validation_fails() {
+    // given
+    String invalidRefreshToken = "invalid-refresh-token";
+
+    // when
+    Mockito.when(jwtTokenProvider.validateToken(invalidRefreshToken))
+        .thenThrow(new JwtCustomException(ErrorCode.INVALID_JWT_FORMAT));
+
+    // then
+    assertThatThrownBy(() -> authService.reissueAccessToken(invalidRefreshToken))
+        .isInstanceOf(JwtCustomException.class)
+        .hasMessage(ErrorCode.INVALID_JWT_FORMAT.getDescription());
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AuthServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AuthServiceTest.java
@@ -6,6 +6,7 @@ import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.EXPIRED_AUTH_CODE;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.INVALID_AUTH_CODE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -22,6 +23,7 @@ import com.meongnyangerang.meongnyangerang.domain.user.Role;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
 import com.meongnyangerang.meongnyangerang.dto.auth.RefreshResponse;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.jwt.JwtTokenProvider;
 import com.meongnyangerang.meongnyangerang.repository.AdminRepository;
@@ -230,5 +232,21 @@ class AuthServiceTest {
     // then
     RefreshResponse response = authService.reissueAccessToken(refreshToken);
     assertThat(response.accessToken()).isEqualTo(newAccessToken);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 리프레시 토큰으로 요청 시 예외 발생")
+  void should_throw_exception_when_refresh_token_not_found_in_db() {
+    // given
+    String refreshToken = "nonexistent-token";
+
+    // when
+    Mockito.when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+    Mockito.when(refreshTokenRepository.findByRefreshToken(refreshToken)).thenReturn(Optional.empty());
+
+    // then
+    assertThatThrownBy(() -> authService.reissueAccessToken(refreshToken))
+        .isInstanceOf(MeongnyangerangException.class)
+        .hasMessage(ErrorCode.INVALID_REFRESH_TOKEN.getDescription());
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AuthServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AuthServiceTest.java
@@ -5,6 +5,7 @@ import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.DUPLICATE_NICKNAME;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.EXPIRED_AUTH_CODE;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.INVALID_AUTH_CODE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -16,10 +17,18 @@ import static org.mockito.Mockito.when;
 
 import com.meongnyangerang.meongnyangerang.component.MailComponent;
 import com.meongnyangerang.meongnyangerang.domain.auth.AuthenticationCode;
+import com.meongnyangerang.meongnyangerang.domain.auth.RefreshToken;
+import com.meongnyangerang.meongnyangerang.domain.user.Role;
+import com.meongnyangerang.meongnyangerang.domain.user.User;
+import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
+import com.meongnyangerang.meongnyangerang.dto.auth.RefreshResponse;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import com.meongnyangerang.meongnyangerang.jwt.JwtTokenProvider;
+import com.meongnyangerang.meongnyangerang.repository.AdminRepository;
 import com.meongnyangerang.meongnyangerang.repository.AuthenticationCodeRepository;
 import com.meongnyangerang.meongnyangerang.repository.HostRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
+import com.meongnyangerang.meongnyangerang.repository.auth.RefreshTokenRepository;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,6 +50,15 @@ class AuthServiceTest {
 
   @Mock
   private HostRepository hostRepository;
+
+  @Mock
+  private AdminRepository adminRepository;
+
+  @Mock
+  private JwtTokenProvider jwtTokenProvider;
+
+  @Mock
+  private RefreshTokenRepository refreshTokenRepository;
 
   @Mock
   private AuthenticationCodeRepository authenticationCodeRepository;
@@ -175,5 +194,41 @@ class AuthServiceTest {
     MeongnyangerangException ex = assertThrows(MeongnyangerangException.class,
         () -> authService.checkNickname(nickname));
     assertEquals(DUPLICATE_NICKNAME, ex.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("정상적인 유저의 리프레시 토큰으로 액세스 토큰 재발급 성공")
+  void should_reissue_access_token_when_valid_refresh_token_for_user() {
+    // given
+    String refreshToken = "valid-refresh-token";
+    Long userId = 1L;
+    Role role = Role.ROLE_USER;
+    UserStatus status = UserStatus.ACTIVE;
+
+    RefreshToken token = RefreshToken.builder()
+        .refreshToken(refreshToken)
+        .userId(userId)
+        .role(role)
+        .expiryDate(LocalDateTime.now().plusDays(1))
+        .build();
+
+    User user = User.builder()
+        .id(userId)
+        .email("test@example.com")
+        .status(status)
+        .role(role)
+        .build();
+
+    String newAccessToken = "new-access-token";
+
+    // when
+    Mockito.when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+    Mockito.when(refreshTokenRepository.findByRefreshToken(refreshToken)).thenReturn(Optional.of(token));
+    Mockito.when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    Mockito.when(jwtTokenProvider.createAccessToken(userId, user.getEmail(), role.name(), status)).thenReturn(newAccessToken);
+
+    // then
+    RefreshResponse response = authService.reissueAccessToken(refreshToken);
+    assertThat(response.accessToken()).isEqualTo(newAccessToken);
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #230 

## 📝 변경 사항
### AS-IS
- JWT 기반 인증은 AccessToken 단독 사용
- AccessToken 만료 시 재로그인 필요

### TO-BE
- 로그인 시 AccessToken + RefreshToken 함께 발급
- RefreshToken은 DB에 저장 및 재사용
- AccessToken 만료 시 RefreshToken으로 `/api/v1/auth/reissue` API 통해 AccessToken 재발급 가능

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 처음 로그인 시 AccessToken, RefreshToken 모두 반환
![image](https://github.com/user-attachments/assets/5d48a828-2d21-4d3c-a608-9473f0f5de6a)

- 처음 발급된 AccessToken으로 예시 API 호출(사용자 권한이 있어야 하는 API) - 성공적으로 호출
![image](https://github.com/user-attachments/assets/68c7d07e-7194-4d26-8512-4639d6b0e374)

- 처음 발급된 AccessTokne의 토큰 만료 - 실패
![image](https://github.com/user-attachments/assets/a019ac39-6935-48c5-8b1c-d5a0252bb891)
![image](https://github.com/user-attachments/assets/ff7315d5-abd0-4721-98a9-88f672d156ec)

- 로그인시 발급된 RefreshToken으로 `/api/v1/auth/reissue` API 호출하여 새로운 AccessTokne 발급
![image](https://github.com/user-attachments/assets/eb852749-4bd8-4517-b52b-9e68a99031ee)

- 새로 발급받은 AccessToken으로 예시 API 호출(사용자 권한이 있어야 하는 API) - 성공적으로 호출
![image](https://github.com/user-attachments/assets/e6cca303-5675-4ba1-ac06-cffed6159e2a)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- Admin 계정 포함 전체 유저 유형(Role)별 재발급 동작 확인 부탁드립니다.
- 이후 로그아웃 기능(RefreshToken 삭제)도 이어서 추가 예정입니다.
