### PR TITLE
[Feature] 로그아웃 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
                 "/api/v1/search/accommodations",
                 "/api/v1/accommodations/{accommodationId}",
                 "/api/v1/rooms/{roomId}",
-                "api/v1/auth/reissue",
+                "/api/v1/auth/reissue",
                 "/health"
             ).permitAll()
             .requestMatchers("/api/v1/users/**").hasAuthority("ROLE_USER")

--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
             .requestMatchers("/api/v1/admin/**", "/api/v1/dummy-data/**").hasAuthority("ROLE_ADMIN")
             .requestMatchers("/api/v1/account/**").hasAnyAuthority("ROLE_USER", "ROLE_HOST")
             .requestMatchers("/api/v1/reviews/**").hasAnyAuthority("ROLE_USER", "ROLE_HOST")
+            .requestMatchers("/api/v1/auth/logout").authenticated()
             .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
         )
         .addFilterBefore(jwtAuthenticationFilter,

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AuthController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AuthController.java
@@ -4,12 +4,14 @@ import com.meongnyangerang.meongnyangerang.dto.EmailRequest;
 import com.meongnyangerang.meongnyangerang.dto.VerifyCodeRequest;
 import com.meongnyangerang.meongnyangerang.dto.auth.RefreshRequest;
 import com.meongnyangerang.meongnyangerang.dto.auth.RefreshResponse;
+import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.AuthService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -67,5 +69,12 @@ public class AuthController {
   public ResponseEntity<RefreshResponse> reissueAccessToken(
       @RequestBody @Valid RefreshRequest request) {
     return ResponseEntity.ok(authService.reissueAccessToken(request.refreshToken()));
+  }
+
+  // 로그아웃(사용자, 호스트, 관리자 모두 공통)
+  @PostMapping("/auth/logout")
+  public ResponseEntity<Void> logout(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    authService.logout(userDetails.getId(), userDetails.getRole());
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AuthService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AuthService.java
@@ -135,6 +135,7 @@ public class AuthService {
   }
 
   // 로그아웃
+  @Transactional
   public void logout(Long userId, Role role) {
     // 해당 사용자의 RefreshToken 삭제(id, role 모두 검증)
     refreshTokenRepository.deleteByUserIdAndRole(userId, role);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AuthService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AuthService.java
@@ -134,6 +134,12 @@ public class AuthService {
     });
   }
 
+  // 로그아웃
+  public void logout(Long userId, Role role) {
+    // 해당 사용자의 RefreshToken 삭제(id, role 모두 검증)
+    refreshTokenRepository.deleteByUserIdAndRole(userId, role);
+  }
+
   private String reissueForUser(Long userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_ACCOUNT));

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AuthServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AuthServiceTest.java
@@ -288,4 +288,18 @@ class AuthServiceTest {
         .isInstanceOf(JwtCustomException.class)
         .hasMessage(ErrorCode.INVALID_JWT_FORMAT.getDescription());
   }
+
+  @Test
+  @DisplayName("로그아웃 시 해당 사용자의 리프레시 토큰 삭제")
+  void should_delete_refresh_token_on_logout() {
+    // given
+    Long userId = 1L;
+    Role role = Role.ROLE_USER;
+
+    // when
+    authService.logout(userId, role);
+
+    // then
+    verify(refreshTokenRepository, times(1)).deleteByUserIdAndRole(userId, role);
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #232 

## 📝 변경 사항
### AS-IS
- 로그아웃 기능 미구현 상태

### TO-BE
- 인증된 사용자(유저/호스트/관리자) 로그아웃 시 RefreshToken 삭제 처리
- SecurityConfig에 `/api/v1/auth/logout` 경로 인증 필요 설정 추가

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 정상적 로그인(반환: AccessToken, RefreshToken)
![image](https://github.com/user-attachments/assets/762b4eba-e042-4150-98ca-44ce72afe386)

- 로그아웃 호출 후, DB에서 해당 사용자의 RefreshToken 삭제 확인(확인 O)
![image](https://github.com/user-attachments/assets/9c7a9102-fb79-482c-9775-90677392fe61)

- 처음 로그인 시 발급된 RefreshToken으로 AccessToken 재발급 시도 → 실패 확인
![image](https://github.com/user-attachments/assets/b3d1c700-1e83-471a-b457-e2dfc72f805b)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 현재는 RefreshToken 삭제 방식만 사용했으며, 추후 Redis를 활용한 블랙리스트 기능도 추가하여 보완 예정입니다.
