### PR TITLE
[Feature] WebSocket/STOMP 모니터링 관련 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,10 @@ dependencies {
     // 더미 데이터 생성
     implementation 'net.datafaker:datafaker:2.0.2'
 
+    // 모니터링
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
@@ -62,7 +62,8 @@ public class SecurityConfig {
                 "/api/v1/search/accommodations",
                 "/api/v1/accommodations/{accommodationId}",
                 "/api/v1/rooms/{roomId}",
-                "/health"
+                "/health",
+                "/actuator/**"
             ).permitAll()
             .requestMatchers("/api/v1/users/**").hasAuthority("ROLE_USER")
             .requestMatchers("/api/v1/chats/users/create").hasAuthority("ROLE_USER")

--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/WebSocketMetricsConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/WebSocketMetricsConfig.java
@@ -1,0 +1,99 @@
+package com.meongnyangerang.meongnyangerang.config;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.WebSocketHandlerDecorator;
+import org.springframework.web.socket.handler.WebSocketHandlerDecoratorFactory;
+
+@Slf4j
+@Configuration
+public class WebSocketMetricsConfig {
+
+  private final MeterRegistry meterRegistry;
+  private final Counter messageErrorCounter;
+  private final Counter webSocketErrorCounter;
+  private final Set<WebSocketSession> sessions = new HashSet<>();
+
+  public WebSocketMetricsConfig(MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
+
+    this.messageErrorCounter = Counter.builder("stomp.messages.errors")
+        .description("Counter of STOMP message errors")
+        .register(meterRegistry);
+
+    this.webSocketErrorCounter = Counter.builder("websocket.errors")
+        .description("Counter of WebSocket transport errors")
+        .register(meterRegistry);
+  }
+
+  @Bean
+  public WebSocketHandlerDecoratorFactory webSocketMetricsDecorator() {
+    return handler -> new WebSocketHandlerDecorator(handler) {
+      private final Counter sessionsCounter = meterRegistry.counter("websocket.sessions.total");
+      private final Gauge activeSessionsGauge = Gauge.builder(
+          "websocket.sessions.active", sessions::size).register(meterRegistry);
+
+      @Override
+      public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        sessions.add(session);
+        sessionsCounter.increment();
+        super.afterConnectionEstablished(session);
+      }
+
+      @Override
+      public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus)
+          throws Exception {
+        sessions.remove(session);
+        super.afterConnectionClosed(session, closeStatus);
+      }
+
+      @Override
+      public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
+        // WebSocket 전송 에러 카운팅
+        webSocketErrorCounter.increment();
+        super.handleTransportError(session, exception);
+      }
+    };
+  }
+
+  @Bean
+  public ChannelInterceptor stompMetricsInterceptor() {
+    return new ChannelInterceptor() {
+      private final Counter messageSentCounter = meterRegistry.counter("stomp.messages.sent");
+      private final Timer messageProcessingTimer = meterRegistry.timer(
+          "stomp.messages.processing.time");
+
+      @Override
+      public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        if (StompHeaderAccessor.wrap(message).getCommand() == StompCommand.SEND) {
+          messageSentCounter.increment();
+          return messageProcessingTimer.record(() -> message);
+        }
+        return message;
+      }
+
+      @Override
+      public void afterSendCompletion(
+          Message<?> message, MessageChannel channel, boolean sent, Exception ex
+      ) {
+        if (StompHeaderAccessor.wrap(message).getCommand() == StompCommand.SEND && ex != null) {
+          messageErrorCounter.increment(); // 에러 발생 시 카운터 증가
+        }
+      }
+    };
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,3 +36,16 @@ spring:
 
   jwt:
     secret: ${JWT_SECRET}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      show-details: always
+  metrics:
+    export:
+      prometheus:
+        enabled: true

--- a/src/main/resources/docker-compose.yml
+++ b/src/main/resources/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    depends_on:
+      - prometheus
+
+volumes:
+  grafana-storage:

--- a/src/main/resources/prometheus.yml
+++ b/src/main/resources/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'spring-boot'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080']


### PR DESCRIPTION
## 📌 관련 이슈
- close #234 

## 📝 변경 사항
### AS-IS
- 채팅 관련 모니터링 설정 부재

### TO-BE
- 모니터링을 위한 spring-actuator, prometheus 의존성 추가
- WebSocket/STOMP 메시지 통신의 성능 징표를 수집하기 위한 설정 클래스 구현
- prometheus 설정 추가
- prometheus와 grafana를 도커로 컨테이너로 실행하기 위한 설정 추가

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.