### PR TITLE
[Fix] 비로그인 & 로그인 추천 더보기 API 호출 시, 기존 데이터가 중복되는 버그 수정

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
@@ -68,7 +68,7 @@ public class AccommodationRecommendationService {
   public PageResponse<RecommendationResponse> getDefaultLoadMoreRecommendations(PetType type,
       Pageable pageable) {
     int size = calculateActualSize(pageable);
-    int from = (int) pageable.getOffset();
+    int from = calculateFromOffset(pageable);
 
     Query query = buildPetTypeQuery(type.name());
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
@@ -148,7 +148,7 @@ public class AccommodationRecommendationService {
           roomScoreMap, wishlistedIds);
 
       long totalElements = response.hits().total().value();
-      int totalPages = (int) Math.ceil((double) totalElements / pageable.getPageSize());
+      int totalPages = (int) Math.ceil((double) totalElements / size);
 
       boolean isFirst = pageable.getPageNumber() == 0;
       boolean isLast = from + size >= MAX_RESULTS || totalElements <= (from + size);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
@@ -317,7 +317,7 @@ public class AccommodationRecommendationService {
   }
 
   private int calculateFromOffset(Pageable pageable) {
-    return pageable.getPageNumber() == 0 ? 6 : (int) pageable.getOffset();
+    return pageable.getPageNumber() == 0 ? SIZE : (int) pageable.getOffset();
   }
 
   // 점수 계산 및 정렬 처리

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
@@ -126,7 +126,7 @@ public class AccommodationRecommendationService {
     UserPet pet = validateAndGetUserPet(userId, petId);
 
     int size = calculateActualSize(pageable);
-    int from = (int) pageable.getOffset();
+    int from = calculateFromOffset(pageable);
 
     Map<AccommodationPetFacilityType, Integer> accScoreMap = getAccommodationScoreMap(pet);
     Map<RoomPetFacilityType, Integer> roomScoreMap = getRoomScoreMap(pet);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
@@ -308,7 +308,7 @@ public class AccommodationRecommendationService {
 
   private int calculateActualSize(Pageable pageable) {
     int size = pageable.getPageSize();
-    int from = (int) pageable.getOffset();
+    int from = calculateFromOffset(pageable);
 
     if (from + size > MAX_RESULTS) {
       return Math.max(0, MAX_RESULTS - from);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationService.java
@@ -316,6 +316,10 @@ public class AccommodationRecommendationService {
     return size;
   }
 
+  private int calculateFromOffset(Pageable pageable) {
+    return pageable.getPageNumber() == 0 ? 6 : (int) pageable.getOffset();
+  }
+
   // 점수 계산 및 정렬 처리
   private List<RecommendationResponse> calculateScoreAndSort(
       SearchResponse<AccommodationDocument> response,


### PR DESCRIPTION
## 📌 관련 이슈
- close #236 

## 📝 변경 사항
### AS-IS
- 더보기 API에서 from(offset) 값을 항상 0부터 계산하여 전달
- 먼저 출력된 추천 숙소 6개가, 더보기 첫 페이지 결과에 중복 포함됨

### TO-BE
- calculateFromOffset(Pageable pageable) 메서드 도입
→ 더보기 첫 페이지 요청 시 offset을 SIZE로 수정
- calculateActualSize()에서도 동일한 offset 기준을 사용하도록 변경
- 비로그인/로그인 추천 더보기 API 모두 중복 없이 다음 숙소 목록부터 조회

## 🔍 테스트
- [ ] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
// UI 변경사항이 있는 경우

## ✅ 체크리스트
- [ ] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
