### PR TITLE
[Feature] 신고 리뷰 삭제 API 구현 및 테스트 완료

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
@@ -76,4 +76,9 @@ public class AdminController {
   ) {
     return ResponseEntity.ok(reviewReportService.getReviews(pageable));
   }
+
+  @DeleteMapping("/reports/{reviewReportId}")
+  public ResponseEntity<Void> deleteReportReview(@PathVariable Long reviewReportId) {
+    return ResponseEntity.ok(reviewReportService.deleteReportReview(reviewReportId)).build();
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
@@ -78,9 +78,9 @@ public class AdminController {
   }
 
   @DeleteMapping("/reports/{reviewReportId}")
-  public ResponseEntity<Void> deleteReportReview(@PathVariable Long reviewReportId) {
+  public ResponseEntity<Void> deleteReviewReport(@PathVariable Long reviewReportId) {
 
-    reviewReportService.deleteReportReview(reviewReportId);
+    reviewReportService.deleteReviewReport(reviewReportId);
 
     return ResponseEntity.ok().build();
   }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
@@ -79,6 +79,9 @@ public class AdminController {
 
   @DeleteMapping("/reports/{reviewReportId}")
   public ResponseEntity<Void> deleteReportReview(@PathVariable Long reviewReportId) {
-    return ResponseEntity.ok(reviewReportService.deleteReportReview(reviewReportId)).build();
+
+    reviewReportService.deleteReportReview(reviewReportId);
+
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -68,6 +68,7 @@ public enum ErrorCode {
   ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "객실이 존재하지 않습니다."),
   RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약이 존재하지 않습니다."),
   REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰가 존재하지 않습니다."),
+  NOT_EXIST_REVIEW_REPORT(HttpStatus.NOT_FOUND, "존재하지 않는 리뷰 신고입니다."),
   NOT_EXIST_PET(HttpStatus.NOT_FOUND, "존재하지 않는 반려동물입니다."),
   NOT_EXIST_WISHLIST(HttpStatus.NOT_FOUND, "존재하지 않는 찜 목록입니다."),
   NOT_EXIST_NOTICE(HttpStatus.NOT_FOUND, "존재하지 않는 공지사항입니다."),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewDeletionService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewDeletionService.java
@@ -1,0 +1,74 @@
+package com.meongnyangerang.meongnyangerang.service;
+
+import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
+import com.meongnyangerang.meongnyangerang.domain.review.Review;
+import com.meongnyangerang.meongnyangerang.domain.review.ReviewImage;
+import com.meongnyangerang.meongnyangerang.repository.ReviewImageRepository;
+import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
+import com.meongnyangerang.meongnyangerang.repository.room.RoomRepository;
+import com.meongnyangerang.meongnyangerang.service.image.ImageService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewDeletionService {
+
+  private final ReviewRepository reviewRepository;
+  private final ReviewImageRepository reviewImageRepository;
+  private final AccommodationRoomSearchService accommodationRoomSearchService;
+  private final ImageService imageService;
+  private final RoomRepository roomRepository;
+
+  public void deleteReviewCompletely(Review review) {
+    deleteAllReviewImages(review.getId());
+
+    Accommodation accommodation = review.getAccommodation();
+    double userRating = review.getUserRating();
+    double petFriendlyRating = review.getPetFriendlyRating();
+
+    reviewRepository.delete(review);
+    updateAccommodationRatingOnDelete(accommodation, userRating, petFriendlyRating);
+    updateElasticsearchDocument(accommodation);
+  }
+
+  private void deleteAllReviewImages(Long reviewId) {
+    List<ReviewImage> images = reviewImageRepository.findAllByReviewId(reviewId);
+    List<String> imageUrls = images.stream().map(ReviewImage::getImageUrl).toList();
+
+    imageService.deleteImagesAsync(imageUrls);
+
+    reviewImageRepository.deleteAll(images);
+  }
+
+  private void updateAccommodationRatingOnDelete(Accommodation accommodation, double userRating,
+      double petFriendlyRating) {
+    int reviewCount = reviewRepository.countByAccommodationId(accommodation.getId());
+
+    if (reviewCount == 0) {
+      accommodation.setTotalRating(0.0);
+      return;
+    }
+
+    double existingTotalRating = accommodation.getTotalRating();
+    double removedReviewRating = calculateReviewRating(userRating, petFriendlyRating);
+
+    double newTotalRating = Math.round(
+        ((existingTotalRating * (reviewCount + 1) - removedReviewRating) / reviewCount) * 10)
+        / 10.0;
+
+    accommodation.setTotalRating(newTotalRating);
+  }
+
+  private double calculateReviewRating(double userRating, double petFriendlyRating) {
+    return Math.round(((userRating + petFriendlyRating) / 2) * 10) / 10.0;
+  }
+
+  private void updateElasticsearchDocument(Accommodation accommodation) {
+    accommodationRoomSearchService.updateAllRooms(accommodation,
+        roomRepository.findAllByAccommodationId(accommodation.getId()));
+    accommodationRoomSearchService.updateAccommodationTotalRating(accommodation,
+        accommodation.getTotalRating());
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
@@ -65,8 +65,8 @@ public class ReviewReportService {
     ReviewReport reviewReport = reviewReportRepository.findById(reviewReportId)
         .orElseThrow(() -> new MeongnyangerangException(ErrorCode.NOT_EXIST_REVIEW_REPORT));
 
-    reviewDeletionService.deleteReviewCompletely(reviewReport.getReview());
-
     reviewReportRepository.delete(reviewReport);
+
+    reviewDeletionService.deleteReviewCompletely(reviewReport.getReview());
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
@@ -25,6 +25,7 @@ public class ReviewReportService {
 
   private final ReviewReportRepository reviewReportRepository;
   private final ReviewRepository reviewRepository;
+  private final ReviewDeletionService reviewDeletionService;
   private final ImageService imageService;
 
   // 리뷰 신고 생성
@@ -57,5 +58,15 @@ public class ReviewReportService {
         pageable, ReportStatus.PENDING);
     Page<ReviewReportResponse> responses = reviewReportResponse.map(ReviewReportResponse::from);
     return PageResponse.from(responses);
+  }
+
+  @Transactional
+  public void deleteReviewReport(Long reviewReportId) {
+    ReviewReport reviewReport = reviewReportRepository.findById(reviewReportId)
+        .orElseThrow(() -> new MeongnyangerangException(ErrorCode.NOT_EXIST_REVIEW_REPORT));
+
+    reviewDeletionService.deleteReviewCompletely(reviewReport.getReview());
+
+    reviewReportRepository.delete(reviewReport);
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
@@ -15,9 +15,11 @@ import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.ReviewReportRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
+import com.meongnyangerang.meongnyangerang.service.ReviewDeletionService;
 import com.meongnyangerang.meongnyangerang.service.ReviewReportService;
 import com.meongnyangerang.meongnyangerang.service.image.ImageService;
 import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,6 +37,9 @@ class ReviewReportServiceTest {
 
   @Mock
   private ReviewRepository reviewRepository;
+
+  @Mock
+  private ReviewDeletionService reviewDeletionService;
 
   @Mock
   private ImageService imageService;
@@ -149,5 +154,22 @@ class ReviewReportServiceTest {
 
     // then
     assertEquals(ErrorCode.REVIEW_REPORT_ALREADY_EXISTS, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("신고 리뷰 삭제 - 성공")
+  void deleteReviewReport_success() {
+    // given
+    Review review = Review.builder().id(1L).build();
+    ReviewReport reviewReport = ReviewReport.builder().id(1L).review(review).build();
+
+    when(reviewReportRepository.findById(1L)).thenReturn(Optional.ofNullable(reviewReport));
+
+    // when
+    reviewReportService.deleteReviewReport(1L);
+
+    // then
+    verify(reviewDeletionService, times(1)).deleteReviewCompletely(review);
+    verify(reviewReportRepository, times(1)).delete(reviewReport);
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
@@ -172,4 +172,19 @@ class ReviewReportServiceTest {
     verify(reviewDeletionService, times(1)).deleteReviewCompletely(review);
     verify(reviewReportRepository, times(1)).delete(reviewReport);
   }
+
+  @Test
+  @DisplayName("신고 리뷰 삭제 - 실패: 신고 리뷰가 없는 경우")
+  void deleteReviewReport_not_exists_review_report() {
+    // given
+    when(reviewReportRepository.findById(999L)).thenReturn(Optional.empty());
+
+    // when
+    MeongnyangerangException e = assertThrows(MeongnyangerangException.class, () -> {
+      reviewReportService.deleteReviewReport(999L);
+    });
+
+    // then
+    assertEquals(ErrorCode.NOT_EXIST_REVIEW_REPORT, e.getErrorCode());
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReviewServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReviewServiceTest.java
@@ -77,6 +77,9 @@ class ReviewServiceTest {
   private ImageService imageService;
 
   @Mock
+  private ReviewDeletionService reviewDeletionService;
+
+  @Mock
   private NotificationService notificationService;
 
   @InjectMocks
@@ -588,31 +591,16 @@ class ReviewServiceTest {
     // when
     User user = User.builder().id(1L).build();
     Accommodation accommodation = Accommodation.builder().id(1L).totalRating(4.0).build();
-
     Review review = Review.builder().id(1L).user(user).userRating(3.0).petFriendlyRating(4.0)
         .accommodation(accommodation).build();
-    ReviewImage image = ReviewImage.builder().id(1L).review(review).build();
 
     when(reviewRepository.findById(review.getId())).thenReturn(Optional.of(review));
-    when(reviewImageRepository.findAllByReviewId(review.getId())).thenReturn(List.of(image));
-
-    double previousTotalRating = accommodation.getTotalRating();
 
     // when
     reviewService.deleteReview(review.getId(), user.getId());
 
     // then
-    ArgumentCaptor<Review> reviewCaptor = ArgumentCaptor.forClass(Review.class);
-    verify(reviewRepository, times(1)).delete(reviewCaptor.capture());
-    assertEquals(review.getId(), reviewCaptor.getValue().getId());
-
-    ArgumentCaptor<List<ReviewImage>> reviewImagesCaptor = ArgumentCaptor.forClass(List.class);
-    verify(reviewImageRepository, times(1)).deleteAll(reviewImagesCaptor.capture());
-    assertEquals(1, reviewImagesCaptor.getValue().size());
-    assertEquals(image.getId(), reviewImagesCaptor.getValue().get(0).getId());
-
-    assertNotEquals(previousTotalRating, accommodation.getTotalRating());
-    assertEquals(0, accommodation.getTotalRating());
+    verify(reviewDeletionService, times(1)).deleteReviewCompletely(review);
   }
 
   @Test


### PR DESCRIPTION
## 📌 관련 이슈
- close #241 

## 📝 변경 사항
### AS-IS
- 기존에 관리자가 신고된 리뷰를 삭제하는 기능이 없었음
- 신고된 리뷰 삭제 시 ReviewService의 deleteReview와 로직이 중복됨

### TO-BE
- 리뷰 삭제에 필요한 공통 로직을 ReviewDeletionService로 분리하여 재사용 가능하도록 리팩토링
- 관리자 신고 리뷰 삭제 기능 (ReviewReportService)에서도 동일한 삭제 로직을 호출하여 일관성 확보

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 성공
![신고 리뷰 삭제 - 200](https://github.com/user-attachments/assets/43f43d87-efda-409f-96d8-370a4d9c99c5)

- 401 실패
![신고 리뷰 삭제 - 401](https://github.com/user-attachments/assets/2c35636e-2807-4d9d-9f49-7a195fd28dfa)

- 403 실패
![신고 리뷰 삭제 - 403](https://github.com/user-attachments/assets/349f5b62-50ed-4e16-bf21-aeddf0e55421)

- 404 실패
![신고 리뷰 삭제 - 404](https://github.com/user-attachments/assets/9f3b9ec2-87df-4908-84c6-d49f7f172140)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
