### PR TITLE
[Feature] 공지사항 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
                 "/api/v1/auth/reissue",
                 "/api/v1/oauth/kakao/callback",
                 "/health",
+                "/api/v1/notices",
                 "/actuator/**"
             ).permitAll()
             .requestMatchers("/api/v1/users/**").hasAuthority("ROLE_USER")

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/PublicNoticeController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/PublicNoticeController.java
@@ -1,5 +1,6 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
+import com.meongnyangerang.meongnyangerang.dto.NoticeSimpleResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
 import com.meongnyangerang.meongnyangerang.service.NoticeService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/PublicNoticeController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/PublicNoticeController.java
@@ -1,0 +1,29 @@
+package com.meongnyangerang.meongnyangerang.controller;
+
+import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
+import com.meongnyangerang.meongnyangerang.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notices")
+public class PublicNoticeController {
+
+  private final NoticeService noticeService;
+
+  // 공지사항 목록 조회 API
+  @GetMapping
+  public ResponseEntity<PageResponse<NoticeSimpleResponse>> getNoticeList(
+      @PageableDefault(size = 20, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+
+    return ResponseEntity.ok(noticeService.getNoticeList(pageable));
+  }
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/NoticeSimpleResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/NoticeSimpleResponse.java
@@ -1,0 +1,9 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import java.time.LocalDateTime;
+
+public record NoticeSimpleResponse (
+    Long noticeId,
+    String title,
+    LocalDateTime createdAt
+) {}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/NoticeSimpleResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/NoticeSimpleResponse.java
@@ -1,9 +1,19 @@
 package com.meongnyangerang.meongnyangerang.dto;
 
+import com.meongnyangerang.meongnyangerang.domain.admin.Notice;
 import java.time.LocalDateTime;
 
 public record NoticeSimpleResponse (
     Long noticeId,
     String title,
     LocalDateTime createdAt
-) {}
+) {
+
+  public static NoticeSimpleResponse from(Notice notice) {
+    return new NoticeSimpleResponse(
+        notice.getId(),
+        notice.getTitle(),
+        notice.getCreatedAt()
+    );
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/NoticeService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/NoticeService.java
@@ -6,11 +6,15 @@ import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_
 import com.meongnyangerang.meongnyangerang.domain.admin.Admin;
 import com.meongnyangerang.meongnyangerang.domain.admin.Notice;
 import com.meongnyangerang.meongnyangerang.dto.NoticeRequest;
+import com.meongnyangerang.meongnyangerang.dto.NoticeSimpleResponse;
+import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.AdminRepository;
 import com.meongnyangerang.meongnyangerang.repository.NoticeRepository;
 import com.meongnyangerang.meongnyangerang.service.image.ImageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -82,5 +86,12 @@ public class NoticeService {
     }
 
     noticeRepository.delete(notice);
+  }
+
+  // 공지사항 목록 조회
+  public PageResponse<NoticeSimpleResponse> getNoticeList(Pageable pageable) {
+    Page<Notice> notices = noticeRepository.findAll(pageable);
+
+    return PageResponse.from(notices.map(NoticeSimpleResponse::from));
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #243 

## 📝 변경 사항
### AS-IS
- 공지사항 목록 조회 기능 미구현

### TO-BE
- 공지사항 목록 페이징 조회 API 구현
- 최신순 정렬된 `NoticeSimpleResponse` 리스트 반환

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 공지사항 목록 조회 성공
![image](https://github.com/user-attachments/assets/f59a712e-0f53-4b17-b7bf-2e12bd8445f5)
![image](https://github.com/user-attachments/assets/bc870022-88c9-45df-8f63-4ca7edf7ec1e)


## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
