### PR TITLE
[Feature] 공지사항 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
                 "/api/v1/auth/reissue",
                 "/api/v1/oauth/kakao/callback",
                 "/health",
-                "/api/v1/notices",
+                "/api/v1/notices/**",
                 "/actuator/**"
             ).permitAll()
             .requestMatchers("/api/v1/users/**").hasAuthority("ROLE_USER")

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/PublicNoticeController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/PublicNoticeController.java
@@ -1,5 +1,6 @@
 package com.meongnyangerang.meongnyangerang.controller;
 
+import com.meongnyangerang.meongnyangerang.dto.NoticeDetailResponse;
 import com.meongnyangerang.meongnyangerang.dto.NoticeSimpleResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
 import com.meongnyangerang.meongnyangerang.service.NoticeService;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/PublicNoticeController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/PublicNoticeController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,4 +28,9 @@ public class PublicNoticeController {
     return ResponseEntity.ok(noticeService.getNoticeList(pageable));
   }
 
+  // 공지사항 상세 조회 API
+  @GetMapping("/{noticeId}")
+  public ResponseEntity<NoticeDetailResponse> getNoticeDetail(@PathVariable Long noticeId) {
+    return ResponseEntity.ok(noticeService.getNoticeDetail);
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/PublicNoticeController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/PublicNoticeController.java
@@ -32,6 +32,6 @@ public class PublicNoticeController {
   // 공지사항 상세 조회 API
   @GetMapping("/{noticeId}")
   public ResponseEntity<NoticeDetailResponse> getNoticeDetail(@PathVariable Long noticeId) {
-    return ResponseEntity.ok(noticeService.getNoticeDetail);
+    return ResponseEntity.ok(noticeService.getNoticeDetail(noticeId));
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dev/DummyDataCreateService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dev/DummyDataCreateService.java
@@ -41,6 +41,7 @@ import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomFacility;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomFacilityType;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomPetFacility;
 import com.meongnyangerang.meongnyangerang.domain.room.facility.RoomPetFacilityType;
+import com.meongnyangerang.meongnyangerang.domain.user.AuthProvider;
 import com.meongnyangerang.meongnyangerang.domain.user.Role;
 import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
@@ -301,6 +302,7 @@ public class DummyDataCreateService {
               random.nextBoolean() ? imageUrls.get(random.nextInt(imageUrls.size())) : null)
           .status(UserStatus.ACTIVE)
           .role(Role.ROLE_USER)
+          .provider(AuthProvider.LOCAL)
           .createdAt(LocalDateTime.now())
           .updatedAt(LocalDateTime.now())
           .build();

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/NoticeDetailResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/NoticeDetailResponse.java
@@ -1,0 +1,11 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import java.time.LocalDateTime;
+
+public record NoticeDetailResponse (
+    Long noticeId,
+    String title,
+    String content,
+    String noticeImageUrl,
+    LocalDateTime createdAt
+) {}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/NoticeDetailResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/NoticeDetailResponse.java
@@ -1,5 +1,6 @@
 package com.meongnyangerang.meongnyangerang.dto;
 
+import com.meongnyangerang.meongnyangerang.domain.admin.Notice;
 import java.time.LocalDateTime;
 
 public record NoticeDetailResponse (
@@ -8,4 +9,15 @@ public record NoticeDetailResponse (
     String content,
     String noticeImageUrl,
     LocalDateTime createdAt
-) {}
+) {
+
+  public static NoticeDetailResponse from(Notice notice) {
+    return new NoticeDetailResponse(
+        notice.getId(),
+        notice.getTitle(),
+        notice.getContent(),
+        notice.getImageUrl(),
+        notice.getCreatedAt()
+    );
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AdminService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AdminService.java
@@ -41,6 +41,7 @@ public class AdminService {
   private final RefreshTokenRepository refreshTokenRepository;
 
   // 관리자 로그인
+  @Transactional
   public LoginResponse login(@Valid LoginRequest request) {
 
     // 관리자 조회

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/NoticeService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/NoticeService.java
@@ -5,9 +5,11 @@ import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.NOT_EXIST_
 
 import com.meongnyangerang.meongnyangerang.domain.admin.Admin;
 import com.meongnyangerang.meongnyangerang.domain.admin.Notice;
+import com.meongnyangerang.meongnyangerang.dto.NoticeDetailResponse;
 import com.meongnyangerang.meongnyangerang.dto.NoticeRequest;
 import com.meongnyangerang.meongnyangerang.dto.NoticeSimpleResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.AdminRepository;
 import com.meongnyangerang.meongnyangerang.repository.NoticeRepository;
@@ -93,5 +95,12 @@ public class NoticeService {
     Page<Notice> notices = noticeRepository.findAll(pageable);
 
     return PageResponse.from(notices.map(NoticeSimpleResponse::from));
+  }
+
+  // 공지사항 상세 조회
+  public NoticeDetailResponse getNoticeDetail(Long noticeId) {
+    Notice notice = noticeRepository.findById(noticeId)
+        .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_NOTICE));
+    return NoticeDetailResponse.from(notice);
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
@@ -355,4 +355,18 @@ public class NoticeServiceTest {
     assertEquals(LocalDateTime.of(2025, 5, 8, 10, 31, 45), response.createdAt());
   }
 
+
+  @Test
+  @DisplayName("공지사항 상세 조회 실패 - 존재하지 않는 공지사항")
+  void getNoticeDetailFail_notExist() {
+    // given
+    Long noticeId = 999L;
+    given(noticeRepository.findById(noticeId)).willReturn(Optional.empty());
+
+    // when & then
+    MeongnyangerangException exception = assertThrows(MeongnyangerangException.class,
+        () -> noticeService.getNoticeDetail(noticeId));
+
+    assertEquals(ErrorCode.NOT_EXIST_NOTICE, exception.getErrorCode());
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/NoticeServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import com.meongnyangerang.meongnyangerang.domain.admin.Admin;
 import com.meongnyangerang.meongnyangerang.domain.admin.Notice;
+import com.meongnyangerang.meongnyangerang.dto.NoticeDetailResponse;
 import com.meongnyangerang.meongnyangerang.dto.NoticeRequest;
 import com.meongnyangerang.meongnyangerang.dto.NoticeSimpleResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
@@ -326,6 +327,32 @@ public class NoticeServiceTest {
     assertEquals(0, result.page());
     assertEquals(2, result.totalElements());
     verify(noticeRepository).findAll(pageable);
+  }
+
+  @Test
+  @DisplayName("공지사항 상세 조회 성공")
+  void getNoticeDetailSuccess() {
+    // given
+    Long noticeId = 1L;
+    Notice notice = Notice.builder()
+        .id(noticeId)
+        .title("공지사항 제목입니다")
+        .content("공지사항 내용입니다")
+        .imageUrl("https://s3.bucket/notice.jpg")
+        .createdAt(LocalDateTime.of(2025, 5, 8, 10, 31, 45))
+        .build();
+
+    given(noticeRepository.findById(noticeId)).willReturn(Optional.of(notice));
+
+    // when
+    NoticeDetailResponse response = noticeService.getNoticeDetail(noticeId);
+
+    // then
+    assertEquals(noticeId, response.noticeId());
+    assertEquals("공지사항 제목입니다", response.title());
+    assertEquals("공지사항 내용입니다", response.content());
+    assertEquals("https://s3.bucket/notice.jpg", response.noticeImageUrl());
+    assertEquals(LocalDateTime.of(2025, 5, 8, 10, 31, 45), response.createdAt());
   }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #247 

## 📝 변경 사항
### AS-IS
- 공지사항 상세 정보를 조회하는 API가 존재하지 않았음

### TO-BE
- GET `/api/v1/notices/{noticeId}` 엔드포인트 추가
- `NoticeService.getNoticeDetail()` 메서드 구현
- `NoticeDetailResponse` DTO 구현 및 매핑
- 공지사항이 존재하지 않을 경우 예외 처리

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 공지사항 상세 조회 성공
![image](https://github.com/user-attachments/assets/bdea3426-26a6-49cc-a64a-37b529144cc5)

- 공지사항 상세 조회 실패(존재하지 않는 공지사항 id)
![image](https://github.com/user-attachments/assets/e9b2cef8-0c96-4a8d-91d5-63351cd00f95)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
