### PR TITLE
[Feature] 숙소 목록 조회 응답에 위도, 경도 추가(지도 검색 활용) 및 메트릭 수집 경로 패턴 추가

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/CommonApiMetricsConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/CommonApiMetricsConfig.java
@@ -33,8 +33,11 @@ public class CommonApiMetricsConfig implements WebMvcConfigurer {
       API_URL_PREFIX + "/users/reservations/{id}",
 
       Pattern.compile(API_URL_PREFIX + "/accommodations/\\d+"),
-      API_URL_PREFIX + "/accommodations/{id}"
+      API_URL_PREFIX + "/accommodations/{id}",
       // 추가 패턴은 여기에...
+
+      Pattern.compile(API_URL_PREFIX + "/search/accommodations"),
+      API_URL_PREFIX + "/search/accommodations"
   );
 
   // 메트릭 캐싱을 위한 맵

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationSearchController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AccommodationSearchController.java
@@ -25,6 +25,7 @@ public class AccommodationSearchController {
 
   private final AccommodationSearchService searchService;
 
+  // 숙소 목록 조회(필터 검색) API
   @PostMapping
   public ResponseEntity<PageResponse<AccommodationSearchResponse>> searchAccommodation(
       @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchResponse.java
@@ -21,6 +21,8 @@ public class AccommodationSearchResponse {
   private Integer standardPeopleCount;
   private Integer standardPetCount;
   private AccommodationType accommodationType;
+  private Double latitude;
+  private Double longitude;
 
   public static AccommodationSearchResponse fromDocument(AccommodationRoomDocument doc,
       boolean isWishlisted) {

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/accommodation/AccommodationSearchResponse.java
@@ -25,7 +25,7 @@ public class AccommodationSearchResponse {
   private Double longitude;
 
   public static AccommodationSearchResponse fromDocument(AccommodationRoomDocument doc,
-      boolean isWishlisted) {
+      boolean isWishlisted, Double latitude, Double longitude) {
 
     return AccommodationSearchResponse.builder()
         .accommodationId(doc.getAccommodationId())
@@ -38,6 +38,8 @@ public class AccommodationSearchResponse {
         .standardPeopleCount(doc.getStandardPeopleCount())
         .standardPetCount(doc.getStandardPetCount())
         .accommodationType(doc.getAccommodationType())
+        .latitude(latitude)
+        .longitude(longitude)
         .build();
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchServiceTest.java
@@ -12,6 +12,7 @@ import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
 import com.meongnyangerang.meongnyangerang.domain.AccommodationRoomDocument;
+import com.meongnyangerang.meongnyangerang.domain.accommodation.Accommodation;
 import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationType;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchRequest;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchResponse;
@@ -19,9 +20,11 @@ import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.ReservationSlotRepository;
 import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
+import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,6 +45,9 @@ class AccommodationSearchServiceTest {
 
   @Mock
   private WishlistRepository wishlistRepository;
+
+  @Mock
+  private AccommodationRepository accommodationRepository;
 
   @InjectMocks
   private AccommodationSearchService searchService;
@@ -132,6 +138,14 @@ class AccommodationSearchServiceTest {
     given(wishlistRepository.findAccommodationIdsByUserId(userId))
         .willReturn(List.of(1L));
 
+    given(accommodationRepository.findById(1L))
+        .willReturn(
+            Optional.of(Accommodation.builder().id(1L).latitude(37.5665).longitude(126.9780).build()));
+
+    given(accommodationRepository.findById(2L))
+        .willReturn(
+            Optional.of(Accommodation.builder().id(2L).latitude(37.5796).longitude(126.9770).build()));
+
     given(elasticsearchClient.search(any(Function.class), eq(AccommodationRoomDocument.class)))
         .willReturn(mockResponse);
 
@@ -145,6 +159,10 @@ class AccommodationSearchServiceTest {
         .containsExactlyInAnyOrder(1L, 2L);
     assertThat(response.content()).extracting("isWishlisted")
         .containsExactlyInAnyOrder(true, false);
+    assertThat(response.content()).extracting("latitude")
+        .containsExactlyInAnyOrder(37.5665, 37.5796);
+    assertThat(response.content()).extracting("longitude")
+        .containsExactlyInAnyOrder(126.9780, 126.9770);
   }
 
   @Test


### PR DESCRIPTION
## 📌 관련 이슈
- close #251 

## 📝 변경 사항
### AS-IS
- 숙소 목록 조회 시 latitude, longitude 값이 미포함
- /api/v1/search/accommodations API 호출 시 CommonApiMetricsConfig에서 메트릭 수집이 불가능

### TO-BE
- AccommodationSearchResponse DTO에 latitude, longitude 필드 추가
- AccommodationSearchService에서 AccommodationRepository로 숙소 ID 기반 JPA 조회 후 위도, 경도 값 반환
- CommonApiMetricsConfig에 Pattern.compile(API_URL_PREFIX + "/search/accommodations") 경로 추가로 메트릭 수집 가능

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 숙소 목록 조회 시 위도, 경도 반환 확인(성공)
![image](https://github.com/user-attachments/assets/01a9d624-801c-4867-8550-aaba01792b10)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
