### PR TITLE
[Feature] 관리자 - 신고된 리뷰 상세 보기 API 구현 및 테스트 완료

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/CommonApiMetricsConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/CommonApiMetricsConfig.java
@@ -36,7 +36,7 @@ public class CommonApiMetricsConfig implements WebMvcConfigurer {
       API_URL_PREFIX + "/accommodations/{id}",
 
       Pattern.compile(API_URL_PREFIX + "/rooms/\\d+"),
-      API_URL_PREFIX + "/rooms/{id}"
+      API_URL_PREFIX + "/rooms/{id}",
 
       // 추가 패턴은 여기에...
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
@@ -4,6 +4,7 @@ import com.meongnyangerang.meongnyangerang.dto.LoginRequest;
 import com.meongnyangerang.meongnyangerang.dto.LoginResponse;
 import com.meongnyangerang.meongnyangerang.dto.PendingHostDetailResponse;
 import com.meongnyangerang.meongnyangerang.dto.PendingHostListResponse;
+import com.meongnyangerang.meongnyangerang.dto.ReviewReportDetailResponse;
 import com.meongnyangerang.meongnyangerang.dto.ReviewReportResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
 import com.meongnyangerang.meongnyangerang.service.AdminService;
@@ -75,6 +76,13 @@ public class AdminController {
       @PageableDefault(size = 20, sort = "createdAt", direction = Direction.ASC) Pageable pageable
   ) {
     return ResponseEntity.ok(reviewReportService.getReviews(pageable));
+  }
+
+  @GetMapping("/reports/{reviewReportId}")
+  public ResponseEntity<ReviewReportDetailResponse> getReviewReportDetail(
+      @PathVariable Long reviewReportId) {
+
+    return ResponseEntity.ok(reviewReportService.getReviewReportDetail(reviewReportId));
   }
 
   @DeleteMapping("/reports/{reviewReportId}")

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/review/Review.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/review/Review.java
@@ -65,4 +65,8 @@ public class Review {
   @LastModifiedDate
   @Column(nullable = false)
   private LocalDateTime updatedAt;
+
+  public String getUserNickname() {
+    return this.user.getNickname();
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/domain/review/ReviewReport.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/domain/review/ReviewReport.java
@@ -56,6 +56,10 @@ public class ReviewReport {
   @CreatedDate
   @Column(nullable = false)
   private LocalDateTime createdAt;
+
+  public String getReviewerNickname() {
+    return this.review.getUserNickname();
+  }
 }
 
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportDetailResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportDetailResponse.java
@@ -1,5 +1,7 @@
 package com.meongnyangerang.meongnyangerang.dto;
 
+import com.meongnyangerang.meongnyangerang.domain.review.ReviewReport;
+import java.time.format.DateTimeFormatter;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,4 +16,17 @@ public class ReviewReportDetailResponse {
   private String evidenceImageUrl;
   private String reportDate;
 
+  public static ReviewReportDetailResponse from(ReviewReport reviewReport,
+      String reporterNickname) {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    return ReviewReportDetailResponse.builder()
+        .reviewId(reviewReport.getReview().getId())
+        .reviewerNickname(reviewReport.getReviewerNickname())
+        .reporterNickname(reporterNickname)
+        .reason(reviewReport.getReason())
+        .evidenceImageUrl(reviewReport.getEvidenceImageUrl())
+        .reportDate(reviewReport.getCreatedAt().format(formatter))
+        .build();
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportDetailResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportDetailResponse.java
@@ -1,0 +1,17 @@
+package com.meongnyangerang.meongnyangerang.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewReportDetailResponse {
+
+  private Long reviewId;
+  private String reviewerNickname;
+  private String reporterNickname;
+  private String reason;
+  private String evidenceImageUrl;
+  private String reportDate;
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
   REVIEW_REPORT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 신고된 리뷰입니다."),
   ROOM_COUNT_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "객실은 20개까지 생성 가능합니다."),
   SOCIAL_ACCOUNT_LOGIN_ONLY(HttpStatus.BAD_REQUEST, "소셜 계정은 일반 로그인을 지원하지 않습니다."),
+  INVALID_REPORTER_TYPE(HttpStatus.BAD_REQUEST, "신고자 유형이 올바르지 않습니다."),
 
   // 400 BAD REQUEST (JWT 관련 요청 오류)
   INVALID_JWT_FORMAT(HttpStatus.BAD_REQUEST, "JWT 형식이 올바르지 않습니다."),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
   ROOM_COUNT_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "객실은 20개까지 생성 가능합니다."),
   SOCIAL_ACCOUNT_LOGIN_ONLY(HttpStatus.BAD_REQUEST, "소셜 계정은 일반 로그인을 지원하지 않습니다."),
   INVALID_REPORTER_TYPE(HttpStatus.BAD_REQUEST, "신고자 유형이 올바르지 않습니다."),
+  ALREADY_PROCESSED_REVIEW_REPORT(HttpStatus.BAD_REQUEST, "이미 처리된 신고입니다."),
 
   // 400 BAD REQUEST (JWT 관련 요청 오류)
   INVALID_JWT_FORMAT(HttpStatus.BAD_REQUEST, "JWT 형식이 올바르지 않습니다."),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
@@ -89,14 +89,16 @@ public class ReviewReportService {
   }
 
   private String getReporterNickname(Long reporterId, ReporterType type) {
-    String nickname = "";
-
     if (type == ReporterType.USER) {
-      nickname = String.valueOf(userRepository.findById(reporterId).map(User::getNickname));
+      return userRepository.findById(reporterId)
+          .map(User::getNickname)
+          .orElseThrow(() -> new MeongnyangerangException(ErrorCode.USER_NOT_FOUND));
     } else if (type == ReporterType.HOST) {
-      nickname = String.valueOf(hostRepository.findById(reporterId).map(Host::getNickname));
+      return hostRepository.findById(reporterId)
+          .map(Host::getNickname)
+          .orElseThrow(() -> new MeongnyangerangException(ErrorCode.NOT_EXISTS_HOST));
     }
 
-    return nickname;
+    return new MeongnyangerangException(ErrorCode.INVALID_REPORTER_TYPE);
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
@@ -72,10 +72,6 @@ public class ReviewReportService {
     ReviewReport reviewReport = reviewReportRepository.findById(reviewReportId)
         .orElseThrow(() -> new MeongnyangerangException(ErrorCode.NOT_EXIST_REVIEW_REPORT));
 
-    if (reviewReport.getStatus() != ReportStatus.PENDING) {
-      throw new MeongnyangerangException(ErrorCode.ALREADY_PROCESSED_REVIEW_REPORT);
-    }
-
     String reporterNickname = getReporterNickname(reviewReport.getReporterId(),
         reviewReport.getType());
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
@@ -99,6 +99,6 @@ public class ReviewReportService {
           .orElseThrow(() -> new MeongnyangerangException(ErrorCode.NOT_EXISTS_HOST));
     }
 
-    return new MeongnyangerangException(ErrorCode.INVALID_REPORTER_TYPE);
+    throw new MeongnyangerangException(ErrorCode.INVALID_REPORTER_TYPE);
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
@@ -72,6 +72,10 @@ public class ReviewReportService {
     ReviewReport reviewReport = reviewReportRepository.findById(reviewReportId)
         .orElseThrow(() -> new MeongnyangerangException(ErrorCode.NOT_EXIST_REVIEW_REPORT));
 
+    if (reviewReport.getStatus() != ReportStatus.PENDING) {
+      throw new MeongnyangerangException(ErrorCode.ALREADY_PROCESSED_REVIEW_REPORT);
+    }
+
     String reporterNickname = getReporterNickname(reviewReport.getReporterId(),
         reviewReport.getType());
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
@@ -1,15 +1,21 @@
 package com.meongnyangerang.meongnyangerang.service;
 
+import com.meongnyangerang.meongnyangerang.domain.host.Host;
 import com.meongnyangerang.meongnyangerang.domain.review.ReportStatus;
+import com.meongnyangerang.meongnyangerang.domain.review.ReporterType;
 import com.meongnyangerang.meongnyangerang.domain.review.Review;
 import com.meongnyangerang.meongnyangerang.domain.review.ReviewReport;
+import com.meongnyangerang.meongnyangerang.domain.user.User;
+import com.meongnyangerang.meongnyangerang.dto.ReviewReportDetailResponse;
 import com.meongnyangerang.meongnyangerang.dto.ReviewReportRequest;
 import com.meongnyangerang.meongnyangerang.dto.ReviewReportResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import com.meongnyangerang.meongnyangerang.repository.HostRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReviewReportRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
+import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.image.ImageService;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +31,8 @@ public class ReviewReportService {
 
   private final ReviewReportRepository reviewReportRepository;
   private final ReviewRepository reviewRepository;
+  private final UserRepository userRepository;
+  private final HostRepository hostRepository;
   private final ReviewDeletionService reviewDeletionService;
   private final ImageService imageService;
 
@@ -60,6 +68,16 @@ public class ReviewReportService {
     return PageResponse.from(responses);
   }
 
+  public ReviewReportDetailResponse getReviewReportDetail(Long reviewReportId) {
+    ReviewReport reviewReport = reviewReportRepository.findById(reviewReportId)
+        .orElseThrow(() -> new MeongnyangerangException(ErrorCode.NOT_EXIST_REVIEW_REPORT));
+
+    String reporterNickname = getReporterNickname(reviewReport.getReporterId(),
+        reviewReport.getType());
+
+    return ReviewReportDetailResponse.from(reviewReport, reporterNickname);
+  }
+
   @Transactional
   public void deleteReviewReport(Long reviewReportId) {
     ReviewReport reviewReport = reviewReportRepository.findById(reviewReportId)
@@ -68,5 +86,17 @@ public class ReviewReportService {
     reviewReportRepository.delete(reviewReport);
 
     reviewDeletionService.deleteReviewCompletely(reviewReport.getReview());
+  }
+
+  private String getReporterNickname(Long reporterId, ReporterType type) {
+    String nickname = "";
+
+    if (type == ReporterType.USER) {
+      nickname = String.valueOf(userRepository.findById(reporterId).map(User::getNickname));
+    } else if (type == ReporterType.HOST) {
+      nickname = String.valueOf(hostRepository.findById(reporterId).map(Host::getNickname));
+    }
+
+    return nickname;
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
@@ -250,35 +250,4 @@ class ReviewReportServiceTest {
     // then
     assertEquals(ErrorCode.NOT_EXIST_REVIEW_REPORT, e.getErrorCode());
   }
-
-  @Test
-  @DisplayName("신고된 리뷰 상세 보기 - 실패: 이미 처리된 신고인 경우")
-  void getReviewReportDetail_already_processed_review_report() {
-    // given
-    User user = User.builder().id(1L).nickname("장난꾸러기").build();
-    Host host = Host.builder().id(100L).nickname("3월").build();
-    Review review = Review.builder().id(1L).user(user).content("비추천. 최악의 숙소입니다.").build();
-
-    ReviewReport reviewReport = ReviewReport.builder()
-        .id(1L)
-        .review(review)
-        .reporterId(host.getId())
-        .type(ReporterType.HOST)
-        .status(ReportStatus.COMPLETED)
-        .reason("나쁜 말만 사용합니다.")
-        .evidenceImageUrl("")
-        .createdAt(LocalDateTime.of(2025, 5, 5, 15, 30, 0))
-        .build();
-
-    when(reviewReportRepository.findById(reviewReport.getId())).thenReturn(
-        Optional.of(reviewReport));
-
-    // when
-    MeongnyangerangException e = assertThrows(MeongnyangerangException.class, () -> {
-      reviewReportService.getReviewReportDetail(reviewReport.getId());
-    });
-
-    // then
-    assertEquals(ErrorCode.ALREADY_PROCESSED_REVIEW_REPORT, e.getErrorCode());
-  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
@@ -6,20 +6,26 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.meongnyangerang.meongnyangerang.domain.host.Host;
+import com.meongnyangerang.meongnyangerang.domain.review.ReportStatus;
+import com.meongnyangerang.meongnyangerang.domain.review.ReporterType;
 import com.meongnyangerang.meongnyangerang.domain.review.Review;
 import com.meongnyangerang.meongnyangerang.domain.review.ReviewReport;
 import com.meongnyangerang.meongnyangerang.domain.user.Role;
+import com.meongnyangerang.meongnyangerang.domain.user.User;
 import com.meongnyangerang.meongnyangerang.domain.user.UserStatus;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import com.meongnyangerang.meongnyangerang.repository.HostRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReviewReportRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
+import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.ReviewDeletionService;
 import com.meongnyangerang.meongnyangerang.service.ReviewReportService;
 import com.meongnyangerang.meongnyangerang.service.image.ImageService;
+import java.time.LocalDateTime;
 import java.util.Optional;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +43,12 @@ class ReviewReportServiceTest {
 
   @Mock
   private ReviewRepository reviewRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private HostRepository hostRepository;
 
   @Mock
   private ReviewDeletionService reviewDeletionService;
@@ -186,5 +198,41 @@ class ReviewReportServiceTest {
 
     // then
     assertEquals(ErrorCode.NOT_EXIST_REVIEW_REPORT, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("신고된 리뷰 상세 보기 - 성공")
+  void getReviewReportDetail_success() {
+    // given
+    User user = User.builder().id(1L).nickname("장난꾸러기").build();
+    Host host = Host.builder().id(100L).nickname("3월").build();
+    Review review = Review.builder().id(1L).user(user).content("비추천. 최악의 숙소입니다.").build();
+
+    ReviewReport reviewReport = ReviewReport.builder()
+        .id(1L)
+        .review(review)
+        .reporterId(host.getId())
+        .type(ReporterType.HOST)
+        .status(ReportStatus.PENDING)
+        .reason("나쁜 말만 사용합니다.")
+        .evidenceImageUrl("")
+        .createdAt(LocalDateTime.of(2025, 5, 5, 15, 30, 0))
+        .build();
+
+    when(reviewReportRepository.findById(reviewReport.getId())).thenReturn(
+        Optional.of(reviewReport));
+    when(hostRepository.findById(host.getId())).thenReturn(Optional.of(host));
+
+    // when
+    ReviewReportDetailResponse response = reviewReportService.getReviewReportDetail(
+        reviewReport.getId());
+
+    // then
+    assertEquals(review.getId(), response.getReviewId());
+    assertEquals(user.getNickname(), response.getReviewerNickname());
+    assertEquals(host.getNickname(), response.getReporterNickname());
+    assertEquals("", response.getEvidenceImageUrl());
+    assertEquals("나쁜 말만 사용합니다.", response.getReason());
+    assertEquals("2025-05-05", response.getReportDate());
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
@@ -250,4 +250,35 @@ class ReviewReportServiceTest {
     // then
     assertEquals(ErrorCode.NOT_EXIST_REVIEW_REPORT, e.getErrorCode());
   }
+
+  @Test
+  @DisplayName("신고된 리뷰 상세 보기 - 실패: 이미 처리된 신고인 경우")
+  void getReviewReportDetail_already_processed_review_report() {
+    // given
+    User user = User.builder().id(1L).nickname("장난꾸러기").build();
+    Host host = Host.builder().id(100L).nickname("3월").build();
+    Review review = Review.builder().id(1L).user(user).content("비추천. 최악의 숙소입니다.").build();
+
+    ReviewReport reviewReport = ReviewReport.builder()
+        .id(1L)
+        .review(review)
+        .reporterId(host.getId())
+        .type(ReporterType.HOST)
+        .status(ReportStatus.COMPLETED)
+        .reason("나쁜 말만 사용합니다.")
+        .evidenceImageUrl("")
+        .createdAt(LocalDateTime.of(2025, 5, 5, 15, 30, 0))
+        .build();
+
+    when(reviewReportRepository.findById(reviewReport.getId())).thenReturn(
+        Optional.of(reviewReport));
+
+    // when
+    MeongnyangerangException e = assertThrows(MeongnyangerangException.class, () -> {
+      reviewReportService.getReviewReportDetail(reviewReport.getId());
+    });
+
+    // then
+    assertEquals(ErrorCode.ALREADY_PROCESSED_REVIEW_REPORT, e.getErrorCode());
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
@@ -235,4 +235,19 @@ class ReviewReportServiceTest {
     assertEquals("나쁜 말만 사용합니다.", response.getReason());
     assertEquals("2025-05-05", response.getReportDate());
   }
+
+  @Test
+  @DisplayName("신고된 리뷰 상세 보기 - 실패: 신고 리뷰가 없는 경우")
+  void getReviewReportDetail_not_exists_review_report() {
+    // given
+    when(reviewReportRepository.findById(2L)).thenReturn(Optional.empty());
+
+    // when
+    MeongnyangerangException e = assertThrows(MeongnyangerangException.class, () -> {
+      reviewReportService.getReviewReportDetail(2L);
+    });
+
+    // then
+    assertEquals(ErrorCode.NOT_EXIST_REVIEW_REPORT, e.getErrorCode());
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #255 

## 📝 변경 사항
### AS-IS
- 기존에 관리자가 신고된 리뷰의 상세 정보를 확인하는 API가 없었음.

### TO-BE
- 관리자가 신고된 리뷰의 상세 정보를 확인할 수 있는 API 구현
- 리뷰 ID, 리뷰 작성자 닉네임, 신고자 닉네임, 신고 사유, 증거 이미지, 신고 날짜 포함
- 날짜 포맷을 yyyy-MM-dd 형식으로 응답
- 관련 테스트 코드 작성 및 검증 완료

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 신고된 리뷰 상세 보기 성공
![관리자 - 신고된 리뷰 상세 보기 성공](https://github.com/user-attachments/assets/7146ce1b-90bd-4dac-8c96-1c77269146b9)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
