### PR TITLE
[Feature] 이미지 압축 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
     // JSON 파싱용 (카카오 응답 파싱 시 필요)
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
+    // 이미지 압축
+    implementation 'org.imgscalr:imgscalr-lib:4.2'
+
     // Port One (이니시스 결제 연동)
 //	implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/CommonApiMetricsConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/CommonApiMetricsConfig.java
@@ -36,7 +36,7 @@ public class CommonApiMetricsConfig implements WebMvcConfigurer {
       API_URL_PREFIX + "/accommodations/{id}",
 
       Pattern.compile(API_URL_PREFIX + "/rooms/\\d+"),
-      API_URL_PREFIX + "/rooms/{id}"
+      API_URL_PREFIX + "/rooms/{id}",
 
       // 추가 패턴은 여기에...
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/image/CompressedImageData.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/image/CompressedImageData.java
@@ -1,0 +1,9 @@
+package com.meongnyangerang.meongnyangerang.dto.image;
+
+public record CompressedImageData(
+    byte[] imageData,
+    String filename,
+    String contentType
+) {
+
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/adptor/ImageStorage.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/adptor/ImageStorage.java
@@ -7,6 +7,8 @@ public interface ImageStorage {
 
   String uploadFile(MultipartFile file);
 
+  String uploadFile(byte[] fileData, String originalFilename, String contentType);
+
   void deleteFile(String fileUrl);
 
   void deleteFiles(List<String> fileUrls);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/image/ImageCompressionUtil.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/image/ImageCompressionUtil.java
@@ -131,14 +131,16 @@ public class ImageCompressionUtil {
     // JPG/JPEG 둘 다 "jpeg" Writer 사용 (동일한 형식이므로)
     if ("jpg".equals(lowerFormat) || "jpeg".equals(lowerFormat)) {
       compressJpegImage(image, outputStream);
-    } else if ("png".equals(lowerFormat)) {
-      ImageIO.write(image, "png", outputStream);
-    } else {
-      log.error("압축을 지원하지 않는 파일 형식입니다. {}", format);
-      throw new MeongnyangerangException(ErrorCode.NOT_SUPPORTED_TYPE);
+      return outputStream.toByteArray();
     }
 
-    return outputStream.toByteArray();
+    if ("png".equals(lowerFormat)) {
+      ImageIO.write(image, "png", outputStream);
+      return outputStream.toByteArray();
+    }
+
+    log.error("압축을 지원하지 않는 파일 형식입니다. {}", format);
+    throw new MeongnyangerangException(ErrorCode.NOT_SUPPORTED_TYPE);
   }
 
   private void compressJpegImage(BufferedImage image, ByteArrayOutputStream outputStream)

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/image/ImageCompressionUtil.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/image/ImageCompressionUtil.java
@@ -1,0 +1,172 @@
+package com.meongnyangerang.meongnyangerang.service.image;
+
+import com.meongnyangerang.meongnyangerang.dto.image.CompressedImageData;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
+import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Optional;
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.imgscalr.Scalr;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Component
+public class ImageCompressionUtil {
+
+  @Value("${image.compression.capacity-threshold}")
+  private long capacityThreshold;
+
+  @Value("${image.compression.size-threshold}")
+  private long sizeThreshold;
+
+  @Value("${image.compression.quality}")
+  private float quality;
+
+  @Value("${image.compression.max-width}")
+  private int maxWidth;
+
+  @Value("${image.compression.max-height}")
+  private int maxHeight;
+
+  /**
+   * 이미지 압축 필요 여부 확인 (해상도 + 용량 기준)
+   */
+  public boolean shouldCompress(MultipartFile file) {
+    boolean capacityExceeded = file.getSize() > capacityThreshold; // 용량 체크
+    boolean sizeExceeded = isSizeExceeded(file); // 해상도 체크
+    return capacityExceeded || sizeExceeded;
+  }
+
+  /**
+   * 이미지 압축 및 변환 처리
+   */
+  public CompressedImageData compressImage(MultipartFile file) {
+    try {
+      byte[] originalData = file.getBytes();
+      long originalSize = originalData.length;
+
+      BufferedImage originalImage = Optional.ofNullable(
+              ImageIO.read(new ByteArrayInputStream(originalData)))
+          .orElseThrow(() -> new MeongnyangerangException(ErrorCode.MISSING_IMAGE_FILE));
+
+      // 이미지 처리
+      BufferedImage processedImage = processImageSize(originalImage);
+      String targetFormat = getFileExtension(file.getOriginalFilename());
+      byte[] compressedData = compressImageByFormat(processedImage, targetFormat);
+
+      // 압축 결과 로깅
+      log.debug("이미지 압축 완료 - {}KB → {}KB ({}% 감소)",
+          originalSize / 1024,
+          compressedData.length / 1024,
+          String.format("%.1f", (1.0 - (double) compressedData.length / originalSize) * 100));
+
+      // 압축된 데이터 반환
+      return new CompressedImageData(
+          compressedData,
+          file.getOriginalFilename(),
+          file.getContentType()
+      );
+    } catch (IOException e) {
+      throw new MeongnyangerangException(ErrorCode.INVALID_IO_ERROR);
+    }
+  }
+
+  private boolean isSizeExceeded(MultipartFile file) {
+    try {
+      BufferedImage image = Optional.ofNullable(ImageIO.read(file.getInputStream()))
+          .orElseThrow(() -> new MeongnyangerangException(ErrorCode.MISSING_IMAGE_FILE));
+      int maxDimension = Math.max(image.getWidth(), image.getHeight());
+
+      return maxDimension > sizeThreshold;
+    } catch (IOException e) {
+      log.error("이미지 해상도 가져오던 중 에러 발생: {}", e.getMessage());
+      throw new MeongnyangerangException(ErrorCode.INVALID_IO_ERROR);
+    }
+  }
+
+  /**
+   * 이미지 크기 처리 (리사이즈)
+   */
+  private BufferedImage processImageSize(BufferedImage originalImage) {
+    int originalWidth = originalImage.getWidth();
+    int originalHeight = originalImage.getHeight();
+
+    // 리사이즈가 필요한지 확인
+    if (originalWidth <= maxWidth && originalHeight <= maxHeight) {
+      return originalImage;
+    }
+
+    // 비율 유지하여 리사이즈
+    double widthRatio = (double) maxWidth / originalWidth;
+    double heightRatio = (double) maxHeight / originalHeight;
+    double resizeRatio = Math.min(widthRatio, heightRatio);
+
+    int targetWidth = (int) (originalWidth * resizeRatio);
+    int targetHeight = (int) (originalHeight * resizeRatio);
+
+    log.debug("이미지 리사이즈: {}x{} → {}x{}",
+        originalWidth, originalHeight, targetWidth, targetHeight);
+
+    return Scalr.resize(originalImage, Scalr.Method.QUALITY, targetWidth, targetHeight);
+  }
+
+  /**
+   * 형식별 압축 처리
+   */
+  private byte[] compressImageByFormat(BufferedImage image, String format) throws IOException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    String lowerFormat = format.toLowerCase();
+
+    // JPG/JPEG 둘 다 "jpeg" Writer 사용 (동일한 형식이므로)
+    if ("jpg".equals(lowerFormat) || "jpeg".equals(lowerFormat)) {
+      compressJpegImage(image, outputStream);
+    } else if ("png".equals(lowerFormat)) {
+      ImageIO.write(image, "png", outputStream);
+    } else {
+      log.error("압축을 지원하지 않는 파일 형식입니다. {}", format);
+      throw new MeongnyangerangException(ErrorCode.NOT_SUPPORTED_TYPE);
+    }
+
+    return outputStream.toByteArray();
+  }
+
+  private void compressJpegImage(BufferedImage image, ByteArrayOutputStream outputStream)
+      throws IOException {
+    Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName("jpeg");
+    if (!writers.hasNext()) {
+      throw new IllegalStateException("JPEG Writer를 찾을 수 없습니다.");
+    }
+
+    ImageWriter writer = writers.next();
+    try (ImageOutputStream ios = ImageIO.createImageOutputStream(outputStream)) {
+      writer.setOutput(ios);
+      ImageWriteParam param = writer.getDefaultWriteParam();
+
+      if (param.canWriteCompressed()) {
+        param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+        param.setCompressionQuality(quality);
+      }
+      writer.write(null, new IIOImage(image, null, null), param);
+    } finally {
+      writer.dispose();
+    }
+  }
+
+  private String getFileExtension(String fileName) {
+    if (fileName == null || !fileName.contains(".")) {
+      throw new IllegalArgumentException("유효하지 않은 파일명입니다: " + fileName);
+    }
+    return fileName.substring(fileName.lastIndexOf(".") + 1).toLowerCase();
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/image/ImageService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/image/ImageService.java
@@ -1,5 +1,6 @@
 package com.meongnyangerang.meongnyangerang.service.image;
 
+import com.meongnyangerang.meongnyangerang.dto.image.CompressedImageData;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.service.adptor.ImageStorage;
@@ -18,12 +19,18 @@ import org.springframework.web.multipart.MultipartFile;
 public class ImageService {
 
   private final ImageStorage imageStorage;
+  private final ImageCompressionUtil imageCompressionUtil;
 
   /**
    * 이미지 업로드
    */
   public String storeImage(MultipartFile image) {
     validateImage(image);
+    if (imageCompressionUtil.shouldCompress(image)){
+      CompressedImageData compressedImage = imageCompressionUtil.compressImage(image);
+      return imageStorage.uploadFile(
+          compressedImage.imageData(), compressedImage.filename(), compressedImage.contentType());
+    }
     return imageStorage.uploadFile(image);
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,15 @@ spring:
   jwt:
     secret: ${JWT_SECRET}
 
+# 이미지 압축 설정
+image:
+  compression:
+    capacity-threshold: 512000 # 용량 500KB 이상 시 압축
+    size-threshold: 1080       # 크기 1080 이상 시 압축
+    quality: 0.7               # 70% 품질로 압축
+    max-width: 1080 # 최대 너비
+    max-height: 1080 # 쵀디 높이
+
 management:
   endpoints:
     web:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,7 @@ image:
     size-threshold: 1080       # 크기 1080 이상 시 압축
     quality: 0.7               # 70% 품질로 압축
     max-width: 1080 # 최대 너비
-    max-height: 1080 # 쵀디 높이
+    max-height: 1080 # 최대 높이
 
 management:
   endpoints:

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/image/ImageCompressionUtilTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/image/ImageCompressionUtilTest.java
@@ -1,0 +1,118 @@
+package com.meongnyangerang.meongnyangerang.service.image;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.meongnyangerang.meongnyangerang.dto.image.CompressedImageData;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class ImageCompressionUtilTest {
+
+  @InjectMocks
+  private ImageCompressionUtil compressionUtil;
+
+  @Test
+  @DisplayName("이미지 압축 성공")
+  void compressImage_Success() throws IOException {
+    // given
+    final long capacityThreshold = 512000;
+    final int maxWidth = 1080;
+    final int maxHeight = 1080;
+
+    MultipartFile largeJpegFile = createTestImageFile(
+        "large.jpeg", "image/jpeg", 3000, 2000);
+    long originalSize = largeJpegFile.getSize();
+
+    // when
+    CompressedImageData result = compressionUtil.compressImage(largeJpegFile);
+    byte[] imageData = result.imageData();
+    long compressedSize = imageData.length;
+
+    // then
+    assertNotNull(imageData);
+    assertEquals("large.jpeg", result.filename());
+    assertEquals("image/jpeg", result.contentType());
+
+    // 압축된 이미지가 원본보다 작은지 확인
+    assertTrue(compressedSize < largeJpegFile.getSize());
+
+    // 압축된 이미지가 유효한 이미지인지 확인
+    BufferedImage compressedImage = ImageIO.read(new ByteArrayInputStream(imageData));
+    assertNotNull(compressedImage);
+
+    System.out.println("compressedSize : " + compressedSize);
+    System.out.println("compressedImage.getWidth() : " + compressedImage.getWidth());
+    System.out.println("compressedImage.getHeight() : " + compressedImage.getHeight());
+    System.out.println("maxWidth : " + maxWidth);
+    System.out.println("maxHeight : " + maxHeight);
+
+    // 용량이 임계값(500KB) 이하로 압축되었는지 확인
+    assertTrue(compressedSize <= capacityThreshold);
+
+    // 리사이즈가 적용되었는지 확인 (1920x1080 이하)
+    assertTrue(compressedImage.getWidth() <= maxWidth);
+    assertTrue(compressedImage.getHeight() <= maxHeight);
+  }
+
+  @Test
+  @DisplayName("PNG 이미지 압축 성공 - 리사이즈만 적용")
+  void compressImage_Png_Success() throws IOException {
+    // given
+    MultipartFile largePngFile = createTestImageFile(
+        "large.png", "image/png", 2500, 1800);
+
+    // when
+    CompressedImageData result = compressionUtil.compressImage(largePngFile);
+    byte[] imageData = result.imageData();
+
+    // then
+    assertNotNull(imageData);
+    assertEquals("large.png", result.filename());
+    assertEquals("image/png", result.contentType());
+
+    // 압축된 이미지가 원본보다 작은지 확인 (리사이즈로 인해)
+    assertTrue(imageData.length < largePngFile.getSize());
+
+    // 압축된 이미지의 해상도 확인
+    BufferedImage compressedImage = ImageIO.read(new ByteArrayInputStream(imageData));
+    assertNotNull(compressedImage);
+    assertTrue(compressedImage.getWidth() <= 1920);
+    assertTrue(compressedImage.getHeight() <= 1080);
+  }
+
+  private MockMultipartFile createTestImageFile(
+      String filename, String contentType, int width, int height
+  ) throws IOException {
+    BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+    Graphics2D g2d = image.createGraphics();
+
+    // 간단한 패턴 그리기 (테스트용)
+    g2d.setColor(Color.BLUE);
+    g2d.fillRect(0, 0, width, height);
+    g2d.setColor(Color.WHITE);
+    g2d.fillOval(width / 4, height / 4, width / 2, height / 2);
+    g2d.dispose();
+
+    // byte[]로 변환
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    String format = contentType.equals("image/jpeg") ? "jpeg" : "png";
+    ImageIO.write(image, format, baos);
+
+    return new MockMultipartFile("file", filename, contentType, baos.toByteArray());
+  }
+}

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/image/ImageCompressionUtilTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/image/ImageCompressionUtilTest.java
@@ -55,12 +55,6 @@ class ImageCompressionUtilTest {
     BufferedImage compressedImage = ImageIO.read(new ByteArrayInputStream(imageData));
     assertNotNull(compressedImage);
 
-    System.out.println("compressedSize : " + compressedSize);
-    System.out.println("compressedImage.getWidth() : " + compressedImage.getWidth());
-    System.out.println("compressedImage.getHeight() : " + compressedImage.getHeight());
-    System.out.println("maxWidth : " + maxWidth);
-    System.out.println("maxHeight : " + maxHeight);
-
     // 용량이 임계값(500KB) 이하로 압축되었는지 확인
     assertTrue(compressedSize <= capacityThreshold);
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #257 

## 📝 변경 사항
### AS-IS
- 이미지 압축하지 않고 업로드

### TO-BE
- 이미지의 가로 또는 세로의 크기가 1080을 초과하거나 용량이 500KB를 초과할 경우 압축하여 업로드
- JPG, JPEG는 손실 압축 진행 (이미지 크기와 용량을 모두 압축)
- PNG는 손실 압축이 불가하여 무손실 압축 진행 (크기만 리사이즈)

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.