### PR TITLE
[Feature] 결제 기반 예약 생성 기능 구현 및 예약 구조 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     // Port One (이니시스 결제 연동)
-//	implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
+	implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
 
     // env
     implementation 'me.paulschwarz:spring-dotenv:3.0.0'

--- a/src/main/java/com/meongnyangerang/meongnyangerang/component/PortOneClient.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/component/PortOneClient.java
@@ -3,6 +3,7 @@ package com.meongnyangerang.meongnyangerang.component;
 import com.meongnyangerang.meongnyangerang.dto.portone.PaymentInfo;
 import com.meongnyangerang.meongnyangerang.dto.portone.PaymentResponse;
 import com.meongnyangerang.meongnyangerang.dto.portone.TokenResponse;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/component/PortOneClient.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/component/PortOneClient.java
@@ -1,0 +1,76 @@
+package com.meongnyangerang.meongnyangerang.component;
+
+import com.meongnyangerang.meongnyangerang.dto.portone.PaymentInfo;
+import com.meongnyangerang.meongnyangerang.dto.portone.PaymentResponse;
+import com.meongnyangerang.meongnyangerang.dto.portone.TokenResponse;
+import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class PortOneClient {
+
+  private final RestTemplate restTemplate = new RestTemplate();
+
+  @Value("${PORTONE_API_KEY}")
+  private String apiKey;
+
+  @Value("${PORTONE_API_SECRET}")
+  private String apiSecret;
+
+  private static final String TOKEN_URL = "https://api.iamport.kr/users/getToken";
+  private static final String PAYMENT_URL = "https://api.iamport.kr/payments/";
+
+  private String getAccessToken() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+
+    Map<String, String> body = Map.of(
+        "imp_key", apiKey,
+        "imp_secret", apiSecret
+    );
+
+    HttpEntity<Map<String, String>> request = new HttpEntity<>(body, headers);
+
+    ResponseEntity<TokenResponse> response = restTemplate.postForEntity(
+        TOKEN_URL, request, TokenResponse.class);
+
+    if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+      throw new MeongnyangerangException(ErrorCode.PAYMENT_AUTHORIZATION_FAILED);
+    }
+
+    return response.getBody().getResponse().getAccessToken();
+  }
+
+  public PaymentInfo getPaymentByImpUid(String impUid) {
+    String accessToken = getAccessToken();
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", accessToken);
+
+    HttpEntity<Void> request = new HttpEntity<>(headers);
+
+    ResponseEntity<PaymentResponse> response = restTemplate.exchange(
+        PAYMENT_URL + impUid,
+        HttpMethod.GET,
+        request,
+        PaymentResponse.class
+    );
+
+    if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+      throw new MeongnyangerangException(ErrorCode.PAYMENT_NOT_FOUND);
+    }
+
+    return response.getBody().getResponse();
+  }
+}
+

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReservationController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReservationController.java
@@ -41,17 +41,6 @@ public class ReservationController {
     return ResponseEntity.ok().build();
   }
 
-  @PostMapping("/users/reservations")
-  public ResponseEntity<ReservationResponse> createReservation(
-      @AuthenticationPrincipal UserDetailsImpl userDetails,
-      @Valid @RequestBody ReservationRequest request) {
-
-    ReservationResponse response = reservationService.createReservation(userDetails.getId(),
-        request);
-
-    return ResponseEntity.ok(response);
-  }
-
   @GetMapping("/users/reservations")
   public ResponseEntity<PageResponse<UserReservationResponse>> getUserReservation(
       @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReservationController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReservationController.java
@@ -31,6 +31,7 @@ public class ReservationController {
 
   private final ReservationService reservationService;
 
+  // 예약 사전 검증 api
   @PostMapping("/users/reservations/validate")
   public ResponseEntity<Void> validateReservation(
       @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReservationController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReservationController.java
@@ -31,6 +31,15 @@ public class ReservationController {
 
   private final ReservationService reservationService;
 
+  @PostMapping("/users/reservations/validate")
+  public ResponseEntity<Void> validateReservation(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @Valid @RequestBody ReservationRequest request) {
+
+    reservationService.validateReservation(userDetails.getId(), request);
+    return ResponseEntity.ok().build();
+  }
+
   @PostMapping("/users/reservations")
   public ResponseEntity<ReservationResponse> createReservation(
       @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReservationController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReservationController.java
@@ -41,6 +41,16 @@ public class ReservationController {
     return ResponseEntity.ok().build();
   }
 
+  // 결제 검증 후 예약 처리 api
+  @PostMapping("/users/reservations/payment")
+  public ResponseEntity<ReservationResponse> payAndCreateReservation(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
+      @Valid @RequestBody PaymentReservationRequest request) {
+
+    return ResponseEntity.ok(reservationService.createReservationAfterPayment(
+        userDetails.getId(), request));
+  }
+
   @GetMapping("/users/reservations")
   public ResponseEntity<PageResponse<UserReservationResponse>> getUserReservation(
       @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReservationController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/ReservationController.java
@@ -6,6 +6,7 @@ import com.meongnyangerang.meongnyangerang.dto.ReservationRequest;
 import com.meongnyangerang.meongnyangerang.dto.ReservationResponse;
 import com.meongnyangerang.meongnyangerang.dto.UserReservationResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
+import com.meongnyangerang.meongnyangerang.dto.portone.PaymentReservationRequest;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.ReservationService;
 import jakarta.validation.Valid;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/portone/PaymentInfo.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/portone/PaymentInfo.java
@@ -1,0 +1,10 @@
+package com.meongnyangerang.meongnyangerang.dto.portone;
+
+import lombok.Getter;
+
+@Getter
+public class PaymentInfo {
+  private String status;
+  private Long amount;
+}
+

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/portone/PaymentReservationRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/portone/PaymentReservationRequest.java
@@ -1,0 +1,21 @@
+package com.meongnyangerang.meongnyangerang.dto.portone;
+
+import com.meongnyangerang.meongnyangerang.dto.ReservationRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class PaymentReservationRequest {
+  @NotBlank(message = "결제 고유번호(impUid)는 필수입니다.")
+  private String impUid;
+
+  @NotBlank(message = "주문 번호(merchantUid)는 필수입니다.")
+  private String merchantUid;
+
+  @Valid
+  @NotNull(message = "예약 정보는 필수입니다.")
+  private ReservationRequest reservationRequest;
+}
+

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/portone/PaymentReservationRequest.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/portone/PaymentReservationRequest.java
@@ -5,8 +5,10 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class PaymentReservationRequest {
   @NotBlank(message = "결제 고유번호(impUid)는 필수입니다.")
   private String impUid;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/portone/PaymentResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/portone/PaymentResponse.java
@@ -1,0 +1,9 @@
+package com.meongnyangerang.meongnyangerang.dto.portone;
+
+import lombok.Getter;
+
+@Getter
+public class PaymentResponse {
+  private PaymentInfo response;
+}
+

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/portone/TokenResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/portone/TokenResponse.java
@@ -1,0 +1,16 @@
+package com.meongnyangerang.meongnyangerang.dto.portone;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class TokenResponse {
+  private TokenData response;
+
+  @Getter
+  public static class TokenData {
+    @JsonProperty("access_token")
+    private String accessToken;
+  }
+}
+

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
   SOCIAL_ACCOUNT_LOGIN_ONLY(HttpStatus.BAD_REQUEST, "소셜 계정은 일반 로그인을 지원하지 않습니다."),
   INVALID_REPORTER_TYPE(HttpStatus.BAD_REQUEST, "신고자 유형이 올바르지 않습니다."),
   ALREADY_PROCESSED_REVIEW_REPORT(HttpStatus.BAD_REQUEST, "이미 처리된 신고입니다."),
+  PAYMENT_AUTHORIZATION_FAILED(HttpStatus.BAD_REQUEST, "결제 인증 실패"),
 
   // 400 BAD REQUEST (JWT 관련 요청 오류)
   INVALID_JWT_FORMAT(HttpStatus.BAD_REQUEST, "JWT 형식이 올바르지 않습니다."),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -39,6 +39,8 @@ public enum ErrorCode {
   INVALID_REPORTER_TYPE(HttpStatus.BAD_REQUEST, "신고자 유형이 올바르지 않습니다."),
   ALREADY_PROCESSED_REVIEW_REPORT(HttpStatus.BAD_REQUEST, "이미 처리된 신고입니다."),
   PAYMENT_AUTHORIZATION_FAILED(HttpStatus.BAD_REQUEST, "결제 인증 실패"),
+  PAYMENT_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "결제 완료 상태 아님"),
+  PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액 불일치"),
 
   // 400 BAD REQUEST (JWT 관련 요청 오류)
   INVALID_JWT_FORMAT(HttpStatus.BAD_REQUEST, "JWT 형식이 올바르지 않습니다."),

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -77,6 +77,7 @@ public enum ErrorCode {
   NOT_EXIST_NOTICE(HttpStatus.NOT_FOUND, "존재하지 않는 공지사항입니다."),
   NOT_EXIST_CHAT_ROOM(HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다."),
   NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "버킷에서 가져올 이미지가 없습니다."),
+  PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보 없음"),
 
 
   // 409 Conflict

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/PortOneService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/PortOneService.java
@@ -1,7 +1,10 @@
 package com.meongnyangerang.meongnyangerang.service;
 
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.*;
+
 import com.meongnyangerang.meongnyangerang.component.PortOneClient;
 import com.meongnyangerang.meongnyangerang.dto.portone.PaymentInfo;
+import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,11 +19,11 @@ public class PortOneService {
     PaymentInfo payment = portOneClient.getPaymentByImpUid(impUid);
 
     if (!payment.getStatus().equals("paid")) {
-      throw new MeongnyangerangException(ErrorCode.PAYMENT_NOT_COMPLETED);
+      throw new MeongnyangerangException(PAYMENT_NOT_COMPLETED);
     }
 
     if (!payment.getAmount().equals(expectedAmount)) {
-      throw new MeongnyangerangException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+      throw new MeongnyangerangException(PAYMENT_AMOUNT_MISMATCH);
     }
   }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/PortOneService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/PortOneService.java
@@ -1,0 +1,26 @@
+package com.meongnyangerang.meongnyangerang.service;
+
+import com.meongnyangerang.meongnyangerang.component.PortOneClient;
+import com.meongnyangerang.meongnyangerang.dto.portone.PaymentInfo;
+import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PortOneService {
+
+  private final PortOneClient portOneClient;
+
+  public void verifyPayment(String impUid, Long expectedAmount) {
+    PaymentInfo payment = portOneClient.getPaymentByImpUid(impUid);
+
+    if (!payment.getStatus().equals("paid")) {
+      throw new MeongnyangerangException(ErrorCode.PAYMENT_NOT_COMPLETED);
+    }
+
+    if (!payment.getAmount().equals(expectedAmount)) {
+      throw new MeongnyangerangException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+    }
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
@@ -61,36 +61,6 @@ public class ReservationService {
     checkRoomAvailability(room, request.getCheckInDate(), request.getCheckOutDate());
   }
 
-  /**
-   * 사용자와 객실 정보를 바탕으로 예약을 생성하는 메소드. 예약 가능한지 확인하고, 예약을 처리한 후 예약 정보를 DB에 저장합니다.
-   *
-   * @param userId  사용자 ID
-   * @param request 예약 요청 정보
-   */
-  @Transactional
-  public ReservationResponse createReservation(Long userId, ReservationRequest request) {
-    // 사용자 검증
-    User user = validateUser(userId);
-
-    // 객실 검증
-    Room room = validateRoom(request.getRoomId());
-
-    // 객실 예약 가능 여부 확인
-    checkRoomAvailability(room, request.getCheckInDate(),
-        request.getCheckOutDate());
-
-    // 예약 날짜에 대해 객실 예약 처리
-    bookRoomForDates(room, request.getCheckInDate(), request.getCheckOutDate());
-
-    // 예약 정보 생성 후 DB에 저장
-    Reservation savedReservation = saveReservation(user, room, request);
-
-    // 예약 알림 저장 및 전송 (사용자와 호스트에게 전송)
-    sendNotificationWhenReservationRegistered(savedReservation);
-
-    return new ReservationResponse(UUID.randomUUID().toString());
-  }
-
   // 사용자가 예약 상태(RESERVED, COMPLETED, CANCELED)에 따라 예약 목록을 조회합니다.
   public PageResponse<UserReservationResponse> getUserReservations(Long userId, Pageable pageable,
       ReservationStatus status) {

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
@@ -54,6 +54,13 @@ public class ReservationService {
       "%s 숙소 예약이 성공적으로 취소되었습니다.";
   private static final String RESERVATION_CANCELED_CONTENT = "%s님이 예약을 취소하였습니다.";
 
+  @Transactional(readOnly = true)
+  public void validateReservation(Long userId, ReservationRequest request) {
+    validateUser(userId);
+    Room room = validateRoom(request.getRoomId());
+    checkRoomAvailability(room, request.getCheckInDate(), request.getCheckOutDate());
+  }
+
   /**
    * 사용자와 객실 정보를 바탕으로 예약을 생성하는 메소드. 예약 가능한지 확인하고, 예약을 처리한 후 예약 정보를 DB에 저장합니다.
    *

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
@@ -200,7 +200,7 @@ class ReservationServiceTest {
 
     // when & then
     MeongnyangerangException e = assertThrows(MeongnyangerangException.class, () -> {
-      reservationService.createReservation(userId, request);
+      reservationService.validateReservation(userId, request);
     });
 
     assertEquals(ErrorCode.ROOM_NOT_FOUND, e.getErrorCode());

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
@@ -228,7 +228,7 @@ class ReservationServiceTest {
 
     // when & then
     MeongnyangerangException e = assertThrows(MeongnyangerangException.class, () -> {
-      reservationService.createReservation(userId, request);
+      reservationService.validateReservation(userId, request);
     });
 
     assertEquals(ErrorCode.ROOM_ALREADY_RESERVED, e.getErrorCode());

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
@@ -176,7 +176,7 @@ class ReservationServiceTest {
 
     // when & then
     MeongnyangerangException e = assertThrows(MeongnyangerangException.class, () -> {
-      reservationService.createReservation(userId, request);
+      reservationService.validateReservation(userId, request);
     });
 
     assertEquals(ErrorCode.USER_NOT_FOUND, e.getErrorCode());

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/ReservationServiceTest.java
@@ -249,18 +249,14 @@ class ReservationServiceTest {
 
     Room room = Room.builder().id(roomId).build();
 
-    ReservationSlot existingSlot = new ReservationSlot(room, checkInDate, true);
-
     when(userRepository.findById(userId)).thenReturn(Optional.of(user));
     when(roomRepository.findById(roomId)).thenReturn(Optional.of(room));
-    when(reservationSlotRepository.existsByRoomIdAndReservedDateBetweenAndIsReserved(roomId,
-        checkInDate, checkOutDate.minusDays(1), true)).thenReturn(false);
-    when(reservationSlotRepository.findByRoomIdAndReservedDate(roomId, checkInDate)).thenReturn(
-        Optional.of(existingSlot));
+    when(reservationSlotRepository.existsByRoomIdAndReservedDateBetweenAndIsReserved(
+        roomId, checkInDate, checkOutDate.minusDays(1), true)).thenReturn(true);
 
     // when & then
     MeongnyangerangException e = assertThrows(MeongnyangerangException.class, () -> {
-      reservationService.createReservation(userId, request);
+      reservationService.validateReservation(userId, request);
     });
 
     assertEquals(ErrorCode.ROOM_ALREADY_RESERVED, e.getErrorCode());


### PR DESCRIPTION
## 📌 관련 이슈
- close #259 

## 📝 변경 사항
### AS-IS
- 사용자가 예약 정보를 입력하면 별도 결제 없이 즉시 DB에 저장

### TO-BE
- 결제 전 사전 검증 후 → PortOne 결제 성공 → 결제 정보 검증 → DB에 저장되는 흐름으로 변경
- 단일 예약 생성 API 삭제
- `/validate`, `/payment` API로 분리하여 명확한 예약 흐름 제공

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## 📸 스크린샷
- 결제 전 예약 가능 여부 확인(성공)
![image](https://github.com/user-attachments/assets/6842588a-bb39-4bfe-a026-1aac236e2f03)

- 결제 전 예약 가능 여부 확인(실패)
![image](https://github.com/user-attachments/assets/45e520e3-57e9-445b-a6fe-560bc18c0564)

- 결제 실패(존재하지 않는 결제 정보)
** 오류 메시지 로그: org.springframework.web.client.HttpClientErrorException$NotFound: 404 Not Found: "{"code":-1,"message":"존재하지 않는 결제정보입니다.","response":null}"

![image](https://github.com/user-attachments/assets/95310fcd-5102-496e-bd73-dfa9b91b59b7)

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
결제 취소 기능은 추후 `impUid`, `merchantUid` DB 저장 이후 별도 브랜치에서 구현 예정입니다.
