### PR TITLE
[Feature] 예약 취소 시 포트원 결제 자동 취소 기능 통합

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/component/PortOneClient.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/component/PortOneClient.java
@@ -5,6 +5,7 @@ import com.meongnyangerang.meongnyangerang.dto.portone.PaymentResponse;
 import com.meongnyangerang.meongnyangerang.dto.portone.TokenResponse;
 import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -73,5 +74,28 @@ public class PortOneClient {
 
     return response.getBody().getResponse();
   }
+
+  public void cancelPayment(String impUid, String reason, Long amount) {
+    String accessToken = getAccessToken();
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", accessToken);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+
+    Map<String, Object> body = new HashMap<>();
+    body.put("imp_uid", impUid);
+    body.put("reason", reason);
+    body.put("checksum", amount); // 실제 결제 금액과 일치해야 함
+
+    HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+
+    ResponseEntity<String> response = restTemplate.postForEntity(
+        "https://api.iamport.kr/payments/cancel", request, String.class);
+
+    if (!response.getStatusCode().is2xxSuccessful()) {
+      throw new MeongnyangerangException(ErrorCode.PAYMENT_CANCELLATION_FAILED);
+    }
+  }
+
 }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/component/PortOneClient.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/component/PortOneClient.java
@@ -1,5 +1,7 @@
 package com.meongnyangerang.meongnyangerang.component;
 
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.*;
+
 import com.meongnyangerang.meongnyangerang.dto.portone.PaymentInfo;
 import com.meongnyangerang.meongnyangerang.dto.portone.PaymentResponse;
 import com.meongnyangerang.meongnyangerang.dto.portone.TokenResponse;
@@ -47,7 +49,7 @@ public class PortOneClient {
         TOKEN_URL, request, TokenResponse.class);
 
     if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
-      throw new MeongnyangerangException(ErrorCode.PAYMENT_AUTHORIZATION_FAILED);
+      throw new MeongnyangerangException(PAYMENT_AUTHORIZATION_FAILED);
     }
 
     return response.getBody().getResponse().getAccessToken();
@@ -69,7 +71,7 @@ public class PortOneClient {
     );
 
     if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
-      throw new MeongnyangerangException(ErrorCode.PAYMENT_NOT_FOUND);
+      throw new MeongnyangerangException(PAYMENT_NOT_FOUND);
     }
 
     return response.getBody().getResponse();
@@ -93,7 +95,7 @@ public class PortOneClient {
         "https://api.iamport.kr/payments/cancel", request, String.class);
 
     if (!response.getStatusCode().is2xxSuccessful()) {
-      throw new MeongnyangerangException(ErrorCode.PAYMENT_CANCELLATION_FAILED);
+      throw new MeongnyangerangException(PAYMENT_CANCELLATION_FAILED);
     }
   }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
   PAYMENT_AUTHORIZATION_FAILED(HttpStatus.BAD_REQUEST, "결제 인증 실패"),
   PAYMENT_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "결제 완료 상태 아님"),
   PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액 불일치"),
+  PAYMENT_CANCELLATION_FAILED(HttpStatus.BAD_REQUEST, "결제 취소에 실패했습니다."),
   ROOM_TEMPORARILY_HELD(HttpStatus.BAD_REQUEST, "해당 기간은 다른 사용자가 결제 진행 중인 상태입니다. 잠시 후 다시 시도해 주세요."),
   RESERVATION_SLOT_EXPIRED(HttpStatus.BAD_REQUEST, "예약 보류 시간이 만료되었습니다. 다시 시도해 주세요."),
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/scheduler/ReservationSlotScheduler.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/scheduler/ReservationSlotScheduler.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class ReservationSlotScheduler {
 
-  private ReservationSlotRepository reservationSlotRepository;
+  private final ReservationSlotRepository reservationSlotRepository;
 
   /**
    * 만료된 hold 슬롯 초기화 (5분마다 실행)

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/PortOneService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/PortOneService.java
@@ -26,4 +26,9 @@ public class PortOneService {
       throw new MeongnyangerangException(PAYMENT_AMOUNT_MISMATCH);
     }
   }
+
+  public void cancelPayment(String impUid, Long amount, String reason) {
+    portOneClient.cancelPayment(impUid, reason, amount);
+  }
+
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
@@ -140,8 +140,9 @@ public class ReservationService {
 
     updateReservationSlot(reservation);
 
-    // 예약 상태 변경
     reservation.setStatus(ReservationStatus.CANCELED);
+    reservation.setCanceledAt(LocalDateTime.now());
+
     sendNotificationWhenReservationCanceled(reservation); // 사용자와 호스트에게 알림 발송
   }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
@@ -138,8 +138,10 @@ public class ReservationService {
     // 1. 포트원 결제 취소 요청
     portOneService.cancelPayment(reservation.getImpUid(), reservation.getTotalPrice(), "사용자 예약 취소");
 
+    // 2. 예약 슬롯 해제
     updateReservationSlot(reservation);
 
+    // 3. 예약 상태 변경 및 취소 시각 기록
     reservation.setStatus(ReservationStatus.CANCELED);
     reservation.setCanceledAt(LocalDateTime.now());
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReservationService.java
@@ -135,6 +135,9 @@ public class ReservationService {
       throw new MeongnyangerangException(RESERVATION_ALREADY_CANCELED);
     }
 
+    // 1. 포트원 결제 취소 요청
+    portOneService.cancelPayment(reservation.getImpUid(), reservation.getTotalPrice(), "사용자 예약 취소");
+
     updateReservationSlot(reservation);
 
     // 예약 상태 변경


### PR DESCRIPTION
## 📌 관련 이슈
- close #263 

## 📝 변경 사항
### AS-IS
- 예약 취소 시, 결제 취소는 별도로 처리하지 않았음
- 포트원 결제 취소 API 연동 미구현

### TO-BE
- `PortOneClient`에 결제 취소 API 연동 (`POST /payments/cancel`)
- `PortOneService`에 `cancelPayment()` 메서드 구현
- 기존 `ReservationService.cancelReservation()` 로직에 결제 취소 포함
  - impUid, amount 기반 포트원 결제 취소 요청
  - 취소 성공 시 예약 슬롯 해제 및 상태 업데이트
  - `canceledAt` 시각 기록

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
- 프론트와 연동하기 전에는 테스트가 아직 어려운 상황이라, 로직 중심으로 리뷰 부탁드립니다.
- 포트원 테스트 결제 impUid 확보 시 실제 API 테스트를 바로 진행할 예정입니다.
