### PR TITLE
[Feature] 찜 기능에 Redis 캐시 도입 및 조회 로직 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation 'software.amazon.awssdk:regions:2.20.26'
 
     // Redis
-//	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // Websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'

--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/JpaConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/JpaConfig.java
@@ -1,5 +1,0 @@
-package com.meongnyangerang.meongnyangerang.config;
-
-public class JpaConfig {
-
-}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/config/RedisConfig.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package com.meongnyangerang.meongnyangerang.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+  @Bean
+  public RedisTemplate<String, Long> redisTemplate(RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, Long> template = new RedisTemplate<>();
+    template.setConnectionFactory(connectionFactory);
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
+    return template;
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/WishlistRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/WishlistRepository.java
@@ -1,12 +1,10 @@
 package com.meongnyangerang.meongnyangerang.repository;
 
 import com.meongnyangerang.meongnyangerang.domain.user.Wishlist;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,7 +15,4 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
   Optional<Wishlist> findByUserIdAndAccommodationId(Long userId, Long accommodationId);
 
   Page<Wishlist> findByUserId(Long userId, Pageable pageable);
-
-  @Query("SELECT w.accommodation.id FROM Wishlist w WHERE w.user.id = :userId")
-  List<Long> findAccommodationIdsByUserId(Long userId);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
@@ -1,6 +1,6 @@
 package com.meongnyangerang.meongnyangerang.service;
 
-import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.*;
+import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.ACCOMMODATION_NOT_FOUND;
 import static com.meongnyangerang.meongnyangerang.exception.ErrorCode.SEARCH_FAILED;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
@@ -16,7 +16,6 @@ import com.meongnyangerang.meongnyangerang.domain.accommodation.AccommodationTyp
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchRequest;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearchResponse;
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
-import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.ReservationSlotRepository;
 import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
@@ -24,14 +23,10 @@ import com.meongnyangerang.meongnyangerang.repository.accommodation.Accommodatio
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
@@ -38,9 +38,7 @@ public class AccommodationSearchService {
 
   private final ElasticsearchClient elasticsearchClient;
   private final ReservationSlotRepository reservationSlotRepository;
-  private final WishlistRepository wishlistRepository;
   private final AccommodationRepository accommodationRepository;
-  private final RedisTemplate<String, Long> redisTemplate;
   private final WishlistService wishlistService;
 
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
@@ -18,7 +18,6 @@ import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearch
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.ReservationSlotRepository;
-import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
 import java.io.IOException;
 import java.time.LocalDate;
@@ -29,7 +28,6 @@ import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchService.java
@@ -46,6 +46,7 @@ public class AccommodationSearchService {
   private final WishlistRepository wishlistRepository;
   private final AccommodationRepository accommodationRepository;
   private final RedisTemplate<String, Long> redisTemplate;
+  private final WishlistService wishlistService;
 
 
   public PageResponse<AccommodationSearchResponse> searchAccommodation(Long userId,
@@ -114,16 +115,7 @@ public class AccommodationSearchService {
       }
 
       // 사용자가 찜한 숙소의 id를 Set에 저장
-      Set<Long> wishlistedIds = new HashSet<>();
-      if (userId != null) {
-        Set<Long> rawSet = redisTemplate.opsForSet().members("wishlist:" + userId);
-        if (rawSet != null) {
-          wishlistedIds = rawSet.stream()
-              .filter(Objects::nonNull)
-              .collect(Collectors.toSet());
-        }
-      }
-
+      Set<Long> wishlistedIds = wishlistService.getWishlistIdsFromRedis(userId);
 
       List<AccommodationSearchResponse> content = unique.values().stream()
           .map(doc -> {

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/AccommodationService.java
@@ -23,7 +23,6 @@ import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.HostRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
-import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationFacilityRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationImageRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationPetFacilityRepository;
@@ -53,7 +52,7 @@ public class AccommodationService {
   private final RoomRepository roomRepository;
   private final AccommodationRoomSearchService searchService;
   private final ReviewRepository reviewRepository;
-  private final WishlistRepository wishlistRepository;
+  private final WishlistService wishlistService;
 
   private static final int MAX_ADDITIONAL_IMAGE_COUNT = 3;
 
@@ -171,7 +170,7 @@ public class AccommodationService {
     // 찜 여부 확인(UserId 확인)
     boolean isWishlisted = false;
     if (userId != null) {
-      isWishlisted = wishlistRepository.existsByUserIdAndAccommodationId(userId, accommodationId);
+      isWishlisted = wishlistService.isWishlisted(userId, accommodationId);
     }
 
     accommodationRepository.incrementViewCount(accommodationId);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
@@ -14,6 +14,10 @@ import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -95,4 +99,15 @@ public class WishlistService {
   public boolean isWishlisted(Long userId, Long accommodationId) {
     return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(getWishlistKey(userId), accommodationId));
   }
+
+  // Redis에서 해당 사용자가 찜한 숙소 ID 목록을 조회
+  public Set<Long> getWishlistIdsFromRedis(Long userId) {
+    if (userId == null) return Collections.emptySet();
+
+    String key = getWishlistKey(userId);
+    Set<Long> redisIds = redisTemplate.opsForSet().members(key);
+
+    return redisIds != null ? redisIds : Collections.emptySet();
+  }
+
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
@@ -63,6 +63,9 @@ public class WishlistService {
     Wishlist wishlist = wishlistRepository.findByUserIdAndAccommodationId(userId, accommodationId)
         .orElseThrow(() -> new MeongnyangerangException(NOT_EXIST_WISHLIST));
 
+    // Redis에서 제거
+    redisTemplate.opsForSet().remove(getWishlistKey(userId), accommodationId);
+
     wishlistRepository.delete(wishlist);
   }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
@@ -15,9 +15,7 @@ import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
 import java.util.Collections;
-import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -97,12 +95,15 @@ public class WishlistService {
 
   // 찜 여부 확인
   public boolean isWishlisted(Long userId, Long accommodationId) {
-    return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(getWishlistKey(userId), accommodationId));
+    return Boolean.TRUE.equals(
+        redisTemplate.opsForSet().isMember(getWishlistKey(userId), accommodationId));
   }
 
   // Redis에서 해당 사용자가 찜한 숙소 ID 목록을 조회
   public Set<Long> getWishlistIdsFromRedis(Long userId) {
-    if (userId == null) return Collections.emptySet();
+    if (userId == null) {
+      return Collections.emptySet();
+    }
 
     String key = getWishlistKey(userId);
     Set<Long> redisIds = redisTemplate.opsForSet().members(key);

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
@@ -14,7 +14,9 @@ import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
+import jakarta.annotation.PostConstruct;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -111,4 +113,16 @@ public class WishlistService {
     return redisIds != null ? redisIds : Collections.emptySet();
   }
 
+  /**
+   * 서버 시작 시 DB에 저장된 찜 정보를 Redis에 로딩합니다.
+   * Redis가 비어 있는 경우를 대비하여 일관성을 유지합니다.(서버 재시작 등)
+   */
+  @PostConstruct
+  public void preloadWishlistToRedis() {
+    List<Wishlist> all = wishlistRepository.findAll();
+    for (Wishlist w : all) {
+      String key = getWishlistKey(w.getUser().getId());
+      redisTemplate.opsForSet().add(key, w.getAccommodation().getId());
+    }
+  }
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
@@ -51,6 +51,7 @@ public class WishlistService {
     // Redis에 추가 저장
     redisTemplate.opsForSet().add(getWishlistKey(userId), accommodationId);
 
+    // DB에 저장
     wishlistRepository.save(Wishlist.builder()
         .user(user)
         .accommodation(accommodation)
@@ -66,6 +67,7 @@ public class WishlistService {
     // Redis에서 제거
     redisTemplate.opsForSet().remove(getWishlistKey(userId), accommodationId);
 
+    // DB에서 삭제
     wishlistRepository.delete(wishlist);
   }
 

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/WishlistService.java
@@ -90,4 +90,9 @@ public class WishlistService {
 
     return PageResponse.from(responsePage);
   }
+
+  // 찜 여부 확인
+  public boolean isWishlisted(Long userId, Long accommodationId) {
+    return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(getWishlistKey(userId), accommodationId));
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,15 @@ spring:
   jwt:
     secret: ${JWT_SECRET}
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password:
+      timeout: 6000ms
+    cache:
+      type: redis
+
 # 이미지 압축 설정
 image:
   compression:

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationServiceTest.java
@@ -24,7 +24,6 @@ import com.meongnyangerang.meongnyangerang.domain.user.UserPet;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.PetRecommendationGroup;
 import com.meongnyangerang.meongnyangerang.dto.accommodation.RecommendationResponse;
 import com.meongnyangerang.meongnyangerang.repository.UserPetRepository;
-import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
 import com.meongnyangerang.meongnyangerang.repository.room.RoomRepository;
 import com.meongnyangerang.meongnyangerang.service.recommendation.AccommodationRecommendationService;
@@ -55,9 +54,6 @@ class AccommodationRecommendationServiceTest {
 
   @Mock
   private RoomRepository roomRepository;
-
-  @Mock
-  private WishlistRepository wishlistRepository;
 
   @Mock
   private WishlistService wishlistService;

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationServiceTest.java
@@ -28,7 +28,6 @@ import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
 import com.meongnyangerang.meongnyangerang.repository.room.RoomRepository;
 import com.meongnyangerang.meongnyangerang.service.recommendation.AccommodationRecommendationService;
-import com.meongnyangerang.meongnyangerang.service.recommendation.PetFacilityScoreService;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -59,9 +58,6 @@ class AccommodationRecommendationServiceTest {
 
   @Mock
   private WishlistRepository wishlistRepository;
-
-  @Mock
-  private PetFacilityScoreService petFacilityScoreService;
 
   @InjectMocks
   private AccommodationRecommendationService recommendationService;

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationServiceTest.java
@@ -59,6 +59,9 @@ class AccommodationRecommendationServiceTest {
   @Mock
   private WishlistRepository wishlistRepository;
 
+  @Mock
+  private WishlistService wishlistService;
+
   @InjectMocks
   private AccommodationRecommendationService recommendationService;
 
@@ -202,6 +205,7 @@ class AccommodationRecommendationServiceTest {
     List<AccommodationDocument> allDocs = List.of(doc1, doc2, doc3, doc4);
 
     when(userPetRepository.findAllByUserId(1L)).thenReturn(userPets);
+    when(wishlistService.getWishlistIdsFromRedis(1L)).thenReturn(Set.of(1L, 3L));
 
     when(elasticsearchClient.search(any(SearchRequest.class),
         eq(AccommodationDocument.class)))

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationRecommendationServiceTest.java
@@ -245,7 +245,7 @@ class AccommodationRecommendationServiceTest {
   void getMostViewedRecommendations_success() {
     // given
     Long userId = 1L;
-    List<Long> wishlisted = List.of(1L, 3L, 5L); // 찜한 숙소 ID
+    Set<Long> wishlisted = Set.of(1L, 3L, 5L); // 찜한 숙소 ID
 
     List<Accommodation> accommodations = new ArrayList<>();
     for (int i = 1; i <= 11; i++) {
@@ -277,7 +277,7 @@ class AccommodationRecommendationServiceTest {
           .thenReturn(room);
     }
 
-    when(wishlistRepository.findAccommodationIdsByUserId(userId)).thenReturn(wishlisted);
+    when(wishlistService.getWishlistIdsFromRedis(userId)).thenReturn(wishlisted);
 
     // when
     List<RecommendationResponse> result = recommendationService.getMostViewedRecommendations(
@@ -298,7 +298,7 @@ class AccommodationRecommendationServiceTest {
       assertEquals(wishlisted.contains(expected.getId()), res.isWishlisted());
 
       verify(accommodationRepository, times(1)).findTop10ByOrderByViewCountDescTotalRatingDesc();
-      verify(wishlistRepository, times(1)).findAccommodationIdsByUserId(userId);
+      verify(wishlistService, times(1)).getWishlistIdsFromRedis(userId);
       for (Accommodation a : top10) {
         verify(roomRepository).findFirstByAccommodationOrderByPriceAsc(a);
       }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationSearchServiceTest.java
@@ -19,12 +19,12 @@ import com.meongnyangerang.meongnyangerang.dto.accommodation.AccommodationSearch
 import com.meongnyangerang.meongnyangerang.dto.chat.PageResponse;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.ReservationSlotRepository;
-import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,7 +44,7 @@ class AccommodationSearchServiceTest {
   private ReservationSlotRepository reservationSlotRepository;
 
   @Mock
-  private WishlistRepository wishlistRepository;
+  private WishlistService wishlistService;
 
   @Mock
   private AccommodationRepository accommodationRepository;
@@ -135,16 +135,18 @@ class AccommodationSearchServiceTest {
         request.getCheckInDate(), request.getCheckOutDate().minusDays(1)))
         .willReturn(List.of());
 
-    given(wishlistRepository.findAccommodationIdsByUserId(userId))
-        .willReturn(List.of(1L));
+    given(wishlistService.getWishlistIdsFromRedis(userId))
+        .willReturn(Set.of(1L));
 
     given(accommodationRepository.findById(1L))
         .willReturn(
-            Optional.of(Accommodation.builder().id(1L).latitude(37.5665).longitude(126.9780).build()));
+            Optional.of(
+                Accommodation.builder().id(1L).latitude(37.5665).longitude(126.9780).build()));
 
     given(accommodationRepository.findById(2L))
         .willReturn(
-            Optional.of(Accommodation.builder().id(2L).latitude(37.5796).longitude(126.9770).build()));
+            Optional.of(
+                Accommodation.builder().id(2L).latitude(37.5796).longitude(126.9770).build()));
 
     given(elasticsearchClient.search(any(Function.class), eq(AccommodationRoomDocument.class)))
         .willReturn(mockResponse);

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/AccommodationServiceTest.java
@@ -29,7 +29,6 @@ import com.meongnyangerang.meongnyangerang.exception.ErrorCode;
 import com.meongnyangerang.meongnyangerang.exception.MeongnyangerangException;
 import com.meongnyangerang.meongnyangerang.repository.HostRepository;
 import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
-import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationFacilityRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationImageRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationPetFacilityRepository;
@@ -85,10 +84,7 @@ class AccommodationServiceTest {
   private ReviewRepository reviewRepository;
 
   @Mock
-  private WishlistRepository wishlistRepository;
-
-  @Mock
-  private AccommodationRoomSearchService searchService;
+  private WishlistService wishlistService;
 
   @InjectMocks
   private AccommodationService accommodationService;
@@ -528,7 +524,7 @@ class AccommodationServiceTest {
         .thenReturn(List.of(room));
     Mockito.when(reviewRepository.findTop5ByAccommodationIdOrderByCreatedAtDesc(1L))
         .thenReturn(List.of(review));
-    Mockito.when(wishlistRepository.existsByUserIdAndAccommodationId(userId, accommodationId))
+    Mockito.when(wishlistService.isWishlisted(userId, accommodationId))
         .thenReturn(true);
 
     // then

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
@@ -205,4 +205,19 @@ class WishlistServiceTest {
 
     assertThat(result).containsExactlyInAnyOrder(10L, 20L);
   }
+
+  @Test
+  @DisplayName("Redis에서 찜한 숙소 ID 조회 - 존재하지 않는 경우")
+  void getWishlistIdsFromRedis_Empty() {
+    Long userId = 2L;
+    String key = "wishlist:" + userId;
+    SetOperations<String, Long> setOps = mock(SetOperations.class);
+
+    when(redisTemplate.opsForSet()).thenReturn(setOps);
+    when(setOps.members(key)).thenReturn(null);
+
+    Set<Long> result = wishlistService.getWishlistIdsFromRedis(userId);
+
+    assertThat(result).isEmpty();
+  }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -32,6 +33,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
 
 @ExtendWith(MockitoExtension.class)
 class WishlistServiceTest {
@@ -48,6 +51,9 @@ class WishlistServiceTest {
   @Mock
   private AccommodationRepository accommodationRepository;
 
+  @Mock
+  private RedisTemplate<String, Long> redisTemplate;
+
   @Test
   @DisplayName("찜 등록 성공")
   void addWishlistSuccess() {
@@ -60,6 +66,7 @@ class WishlistServiceTest {
     when(userRepository.findById(1L)).thenReturn(Optional.of(user));
     when(accommodationRepository.findById(100L)).thenReturn(Optional.of(accommodation));
     when(wishlistRepository.existsByUserIdAndAccommodationId(1L, 100L)).thenReturn(false);
+    when(redisTemplate.opsForSet()).thenReturn(mock(SetOperations.class));
 
     // when
     assertDoesNotThrow(() -> wishlistService.addWishlist(1L, 100L));
@@ -76,10 +83,8 @@ class WishlistServiceTest {
   @Test
   @DisplayName("찜 등록 실패 - 이미 등록된 찜")
   void addWishlistAlreadyExists() {
-    // given
     Long userId = 1L;
     Long accommodationId = 100L;
-
     User user = User.builder().id(userId).email("user@example.com").build();
     Accommodation accommodation = Accommodation.builder().id(accommodationId).name("숙소").build();
 
@@ -88,7 +93,6 @@ class WishlistServiceTest {
     when(wishlistRepository.existsByUserIdAndAccommodationId(userId, accommodationId)).thenReturn(
         true);
 
-    // when & then
     MeongnyangerangException exception = assertThrows(
         MeongnyangerangException.class,
         () -> wishlistService.addWishlist(userId, accommodationId)
@@ -102,40 +106,30 @@ class WishlistServiceTest {
   @Test
   @DisplayName("찜 삭제 성공")
   void removeWishlistSuccess() {
-    // given
     Long userId = 1L;
     Long accommodationId = 100L;
-
     User user = User.builder().id(userId).email("user@example.com").build();
     Accommodation accommodation = Accommodation.builder().id(accommodationId).name("숙소").build();
-
-    Wishlist wishlist = Wishlist.builder()
-        .id(10L)
-        .user(user)
-        .accommodation(accommodation)
-        .build();
+    Wishlist wishlist = Wishlist.builder().id(10L).user(user).accommodation(accommodation).build();
 
     when(wishlistRepository.findByUserIdAndAccommodationId(userId, accommodationId)).thenReturn(
         Optional.of(wishlist));
+    when(redisTemplate.opsForSet()).thenReturn(mock(SetOperations.class));
 
-    // when
     wishlistService.removeWishlist(userId, accommodationId);
 
-    // then
     verify(wishlistRepository).delete(wishlist);
   }
 
   @Test
   @DisplayName("찜 삭제 실패 - 존재하지 않는 찜")
   void removeWishlistNotFound() {
-    // given
     Long userId = 1L;
     Long accommodationId = 100L;
 
     when(wishlistRepository.findByUserIdAndAccommodationId(userId, accommodationId)).thenReturn(
         Optional.empty());
 
-    // when & then
     MeongnyangerangException exception = assertThrows(
         MeongnyangerangException.class,
         () -> wishlistService.removeWishlist(userId, accommodationId)
@@ -149,44 +143,26 @@ class WishlistServiceTest {
   @Test
   @DisplayName("찜 목록 조회 - 페이징 성공")
   void getUserWishlists_PageableSuccess() {
-    // given
     Long userId = 1L;
     Pageable pageable = PageRequest.of(0, 2);
-
-    Accommodation acc1 = Accommodation.builder()
-        .id(100L)
-        .name("숙소1")
-        .thumbnailUrl("thumb1.jpg")
-        .address("서울시 강남구")
-        .totalRating(4.7)
-        .build();
-
-    Accommodation acc2 = Accommodation.builder()
-        .id(101L)
-        .name("숙소2")
-        .thumbnailUrl("thumb2.jpg")
-        .address("서울시 종로구")
-        .totalRating(4.8)
-        .build();
-
+    Accommodation acc1 = Accommodation.builder().id(100L).name("숙소1").thumbnailUrl("thumb1.jpg")
+        .address("서울시 강남구").totalRating(4.7).build();
+    Accommodation acc2 = Accommodation.builder().id(101L).name("숙소2").thumbnailUrl("thumb2.jpg")
+        .address("서울시 종로구").totalRating(4.8).build();
     Wishlist w1 = Wishlist.builder().id(1L).accommodation(acc1).build();
     Wishlist w2 = Wishlist.builder().id(2L).accommodation(acc2).build();
-
     Page<Wishlist> page = new PageImpl<>(List.of(w1, w2), pageable, 2);
 
     when(wishlistRepository.findByUserId(userId, pageable)).thenReturn(page);
 
-    // when
     PageResponse<WishlistResponse> result = wishlistService.getUserWishlists(userId, pageable);
 
-    // then
     assertThat(result.content()).hasSize(2);
     assertThat(result.totalElements()).isEqualTo(2);
     assertThat(result.totalPages()).isEqualTo(1);
     assertThat(result.page()).isEqualTo(0);
     assertThat(result.first()).isTrue();
     assertThat(result.last()).isTrue();
-
     assertThat(result.content().get(0).getAccommodationName()).isEqualTo("숙소1");
     assertThat(result.content().get(1).getAccommodationName()).isEqualTo("숙소2");
   }
@@ -194,27 +170,19 @@ class WishlistServiceTest {
   @Test
   @DisplayName("찜 목록 조회 - 여러 페이지 중 일부 조회")
   void getUserWishlists_MiddlePage() {
-    // given
     Long userId = 1L;
-    Pageable pageable = PageRequest.of(1, 2); // 두 번째 페이지
-
-    Accommodation acc1 = Accommodation.builder().id(1L).name("숙소1").address("서울시")
-        .thumbnailUrl("thumb1").build();
-    Accommodation acc2 = Accommodation.builder().id(2L).name("숙소2").address("부산시")
-        .thumbnailUrl("thumb2").build();
-
+    Pageable pageable = PageRequest.of(1, 2);
+    Accommodation acc1 = Accommodation.builder().id(1L).name("숙소1").address("서울시").thumbnailUrl("thumb1").build();
+    Accommodation acc2 = Accommodation.builder().id(2L).name("숙소2").address("부산시").thumbnailUrl("thumb2").build();
     Wishlist w1 = Wishlist.builder().id(101L).accommodation(acc1).build();
     Wishlist w2 = Wishlist.builder().id(102L).accommodation(acc2).build();
-
     List<Wishlist> wishlists = List.of(w1, w2);
-    Page<Wishlist> page = new PageImpl<>(wishlists, pageable, 6); // 총 6개, 총 3페이지
+    Page<Wishlist> page = new PageImpl<>(wishlists, pageable, 6);
 
     when(wishlistRepository.findByUserId(userId, pageable)).thenReturn(page);
 
-    // when
     PageResponse<WishlistResponse> response = wishlistService.getUserWishlists(userId, pageable);
 
-    // then
     assertThat(response.page()).isEqualTo(1);
     assertThat(response.totalPages()).isEqualTo(3);
     assertThat(response.first()).isFalse();

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
@@ -21,6 +21,7 @@ import com.meongnyangerang.meongnyangerang.repository.WishlistRepository;
 import com.meongnyangerang.meongnyangerang.repository.accommodation.AccommodationRepository;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -187,5 +188,21 @@ class WishlistServiceTest {
     assertThat(response.totalPages()).isEqualTo(3);
     assertThat(response.first()).isFalse();
     assertThat(response.last()).isFalse();
+  }
+
+  @Test
+  @DisplayName("Redis에서 찜한 숙소 ID 조회 - 존재하는 경우")
+  void getWishlistIdsFromRedis_Success() {
+    Long userId = 1L;
+    String key = "wishlist:" + userId;
+    Set<Long> ids = Set.of(10L, 20L);
+    SetOperations<String, Long> setOps = mock(SetOperations.class);
+
+    when(redisTemplate.opsForSet()).thenReturn(setOps);
+    when(setOps.members(key)).thenReturn(ids);
+
+    Set<Long> result = wishlistService.getWishlistIdsFromRedis(userId);
+
+    assertThat(result).containsExactlyInAnyOrder(10L, 20L);
   }
 }

--- a/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/service/WishlistServiceTest.java
@@ -173,8 +173,10 @@ class WishlistServiceTest {
   void getUserWishlists_MiddlePage() {
     Long userId = 1L;
     Pageable pageable = PageRequest.of(1, 2);
-    Accommodation acc1 = Accommodation.builder().id(1L).name("숙소1").address("서울시").thumbnailUrl("thumb1").build();
-    Accommodation acc2 = Accommodation.builder().id(2L).name("숙소2").address("부산시").thumbnailUrl("thumb2").build();
+    Accommodation acc1 = Accommodation.builder().id(1L).name("숙소1").address("서울시")
+        .thumbnailUrl("thumb1").build();
+    Accommodation acc2 = Accommodation.builder().id(2L).name("숙소2").address("부산시")
+        .thumbnailUrl("thumb2").build();
     Wishlist w1 = Wishlist.builder().id(101L).accommodation(acc1).build();
     Wishlist w2 = Wishlist.builder().id(102L).accommodation(acc2).build();
     List<Wishlist> wishlists = List.of(w1, w2);


### PR DESCRIPTION
## 📌 관련 이슈
- close #265 

## 📝 변경 사항
### AS-IS
- 찜 등록/삭제/조회 모든 로직이 DB 기반으로 작동
- 숙소 상세/추천 등에서 찜 여부 조회 시 매번 DB를 조회

### TO-BE
- Redis에 찜 정보를 저장하여 성능 개선  
  - 등록 시 Redis에도 `SADD`  
  - 삭제 시 Redis에서도 `SREM`  
- 찜 여부 확인 메서드: `isWishlisted` → Redis `SISMEMBER` 활용  
- 찜한 숙소 목록 조회 메서드: `getWishlistIdsFromRedis` → Redis `SMEMBERS` 활용  
- 서버 기동 시 `@PostConstruct preloadWishlistToRedis()`를 통해 DB → Redis 초기 데이터 로딩  
- `AccommodationService`, `AccommodationRecommendationService`에서 위 메서드 사용하도록 변경  
- 관련 테스트 코드에 `RedisTemplate` 및 `SetOperations` mocking 추가  

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?

## 🙋‍♂️ 리뷰어에게
리뷰 부탁드립니다.
