### PR TITLE
[Refactor] 관리자 신고 리뷰 상세 응답 및 처리 로직 개선

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/controller/AdminController.java
@@ -85,10 +85,10 @@ public class AdminController {
     return ResponseEntity.ok(reviewReportService.getReviewReportDetail(reviewReportId));
   }
 
-  @DeleteMapping("/reports/{reviewReportId}")
-  public ResponseEntity<Void> deleteReviewReport(@PathVariable Long reviewReportId) {
+  @PatchMapping("/reports/{reviewReportId}")
+  public ResponseEntity<Void> processReviewReport(@PathVariable Long reviewReportId) {
 
-    reviewReportService.deleteReviewReport(reviewReportId);
+    reviewReportService.processReviewReport(reviewReportId);
 
     return ResponseEntity.ok().build();
   }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportDetailResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportDetailResponse.java
@@ -9,10 +9,12 @@ import lombok.Getter;
 @Builder
 public class ReviewReportDetailResponse {
 
+  private Long reviewReportId;
   private Long reviewId;
   private String reviewerNickname;
   private String reporterNickname;
   private String reason;
+  private Integer reportCount;
   private String evidenceImageUrl;
   private String reportDate;
 
@@ -21,10 +23,12 @@ public class ReviewReportDetailResponse {
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     return ReviewReportDetailResponse.builder()
+        .reviewReportId(reviewReport.getId())
         .reviewId(reviewReport.getReview().getId())
         .reviewerNickname(reviewReport.getReviewerNickname())
         .reporterNickname(reporterNickname)
         .reason(reviewReport.getReason())
+        .reportCount(reviewReport.getReview().getReportCount())
         .evidenceImageUrl(reviewReport.getEvidenceImageUrl())
         .reportDate(reviewReport.getCreatedAt().format(formatter))
         .build();

--- a/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportResponse.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportResponse.java
@@ -6,7 +6,7 @@ import com.meongnyangerang.meongnyangerang.domain.review.ReviewReport;
 import java.time.LocalDateTime;
 
 public record ReviewReportResponse(
-    Long reviewId,
+    Long reviewReportId,
     Long reporterId,
     ReporterType reporterType,
     String reason,

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewReportRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewReportRepository.java
@@ -3,6 +3,7 @@ package com.meongnyangerang.meongnyangerang.repository;
 import com.meongnyangerang.meongnyangerang.domain.review.ReportStatus;
 import com.meongnyangerang.meongnyangerang.domain.review.Review;
 import com.meongnyangerang.meongnyangerang.domain.review.ReviewReport;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,4 +15,8 @@ public interface ReviewReportRepository extends JpaRepository<ReviewReport, Long
   Page<ReviewReport> findAllByStatus(Pageable pageable, ReportStatus reportStatus);
 
   boolean existsByReporterIdAndReview(Long reporterId, Review review);
+
+  void deleteAllByReview_Id(Long reviewId);
+
+  List<ReviewReport> findAllByReviewId(Long reviewId);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewRepository.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/repository/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.meongnyangerang.meongnyangerang.repository;
 
 import com.meongnyangerang.meongnyangerang.domain.review.Review;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,4 +27,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   List<Review> findTop5ByAccommodationIdOrderByCreatedAtDesc(Long accommodationId);
 
   List<Review> findTop10ByOrderByCreatedAtDesc();
+
+  List<Review> findByHiddenTrueAndHiddenAtBefore(LocalDateTime cutoff);
 }

--- a/src/main/java/com/meongnyangerang/meongnyangerang/scheduler/ReviewReportScheduler.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/scheduler/ReviewReportScheduler.java
@@ -1,0 +1,35 @@
+package com.meongnyangerang.meongnyangerang.scheduler;
+
+import com.meongnyangerang.meongnyangerang.domain.review.Review;
+import com.meongnyangerang.meongnyangerang.repository.ReviewReportRepository;
+import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
+import com.meongnyangerang.meongnyangerang.service.ReviewDeletionService;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewReportScheduler {
+
+  private final ReviewRepository reviewRepository;
+  private final ReviewReportRepository reviewReportRepository;
+  private final ReviewDeletionService reviewDeletionService;
+
+  // 매일 새벽 3시에 실행
+  @Scheduled(cron = "0 0 3 * * ?")
+  public void deleteOldHiddenReviews() {
+    LocalDateTime cutoff = LocalDateTime.now().minusDays(7);
+
+    // 숨김 처리된 리뷰 중, 숨김 시간이 7일 이상 경과한 리뷰 조회
+    List<Review> oldHiddenReviews = reviewRepository.findByHiddenTrueAndHiddenAtBefore(cutoff);
+
+    // 관련된 리뷰 신고 삭제 후, 리뷰 이미지 및 리뷰 삭제
+    for (Review review : oldHiddenReviews) {
+      reviewReportRepository.deleteAllByReview_Id(review.getId());
+      reviewDeletionService.deleteReviewCompletely(review);
+    }
+  }
+}

--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/ReviewReportService.java
@@ -18,6 +18,8 @@ import com.meongnyangerang.meongnyangerang.repository.ReviewRepository;
 import com.meongnyangerang.meongnyangerang.repository.UserRepository;
 import com.meongnyangerang.meongnyangerang.security.UserDetailsImpl;
 import com.meongnyangerang.meongnyangerang.service.image.ImageService;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -33,7 +35,6 @@ public class ReviewReportService {
   private final ReviewRepository reviewRepository;
   private final UserRepository userRepository;
   private final HostRepository hostRepository;
-  private final ReviewDeletionService reviewDeletionService;
   private final ImageService imageService;
 
   // 리뷰 신고 생성
@@ -79,13 +80,19 @@ public class ReviewReportService {
   }
 
   @Transactional
-  public void deleteReviewReport(Long reviewReportId) {
+  public void processReviewReport(Long reviewReportId) {
     ReviewReport reviewReport = reviewReportRepository.findById(reviewReportId)
         .orElseThrow(() -> new MeongnyangerangException(ErrorCode.NOT_EXIST_REVIEW_REPORT));
 
-    reviewReportRepository.delete(reviewReport);
+    Review review = reviewReport.getReview();
+    review.setHidden(true);
+    review.setHiddenAt(LocalDateTime.now());
 
-    reviewDeletionService.deleteReviewCompletely(reviewReport.getReview());
+    // 해당 리뷰에 달린 모든 신고 상태를 COMPLETED 로 처리
+    List<ReviewReport> allReports = reviewReportRepository.findAllByReviewId(review.getId());
+    for (ReviewReport report : allReports) {
+      report.setStatus(ReportStatus.COMPLETED);
+    }
   }
 
   private String getReporterNickname(Long reporterId, ReporterType type) {

--- a/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
+++ b/src/test/java/com/meongnyangerang/meongnyangerang/dto/ReviewReportServiceTest.java
@@ -1,7 +1,9 @@
 package com.meongnyangerang.meongnyangerang.dto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,6 +27,7 @@ import com.meongnyangerang.meongnyangerang.service.ReviewDeletionService;
 import com.meongnyangerang.meongnyangerang.service.ReviewReportService;
 import com.meongnyangerang.meongnyangerang.service.image.ImageService;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -169,31 +172,55 @@ class ReviewReportServiceTest {
   }
 
   @Test
-  @DisplayName("신고 리뷰 삭제 - 성공")
-  void deleteReviewReport_success() {
+  @DisplayName("신고 리뷰 처리 - 성공")
+  void processReviewReport_success() {
     // given
     Review review = Review.builder().id(1L).build();
-    ReviewReport reviewReport = ReviewReport.builder().id(1L).review(review).build();
 
-    when(reviewReportRepository.findById(1L)).thenReturn(Optional.ofNullable(reviewReport));
+    ReviewReport reviewReport = ReviewReport.builder()
+        .id(1L)
+        .review(review)
+        .status(ReportStatus.PENDING)
+        .build();
+
+    ReviewReport report1 = ReviewReport.builder()
+        .id(2L)
+        .review(review)
+        .status(ReportStatus.PENDING)
+        .build();
+
+    ReviewReport report2 = ReviewReport.builder()
+        .id(3L)
+        .review(review)
+        .status(ReportStatus.PENDING)
+        .build();
+
+    List<ReviewReport> allReports = List.of(reviewReport, report1, report2);
+
+    when(reviewReportRepository.findById(1L)).thenReturn(Optional.of(reviewReport));
+    when(reviewReportRepository.findAllByReviewId(1L)).thenReturn(allReports);
 
     // when
-    reviewReportService.deleteReviewReport(1L);
+    reviewReportService.processReviewReport(1L);
 
     // then
-    verify(reviewDeletionService, times(1)).deleteReviewCompletely(review);
-    verify(reviewReportRepository, times(1)).delete(reviewReport);
+    assertTrue(review.getHidden());
+    assertNotNull(review.getHiddenAt());
+
+    for (ReviewReport report : allReports) {
+      assertEquals(ReportStatus.COMPLETED, report.getStatus());
+    }
   }
 
   @Test
-  @DisplayName("신고 리뷰 삭제 - 실패: 신고 리뷰가 없는 경우")
-  void deleteReviewReport_not_exists_review_report() {
+  @DisplayName("신고 리뷰 처리 - 실패: 신고 리뷰가 없는 경우")
+  void processReviewReport_not_exists_review_report() {
     // given
     when(reviewReportRepository.findById(999L)).thenReturn(Optional.empty());
 
     // when
     MeongnyangerangException e = assertThrows(MeongnyangerangException.class, () -> {
-      reviewReportService.deleteReviewReport(999L);
+      reviewReportService.processReviewReport(999L);
     });
 
     // then


### PR DESCRIPTION
## 📝 변경 사항
### AS-IS
- 기존에 리뷰 목록 응답 필드명이 reviewId 으로 되어있고, 응답하는 값은 reviewReportId 였음.
- ReviewReport 엔티티의 Status 필드의 PENDING만 사용하고 COMPLETED 를 사용하지 않고 있었음.

### TO-BE
- 리뷰 목록 응답 필드명 수정 (reviewId -> reviewReportId)
- 신고 리뷰 상세 보기 응답에 누락된 reviewReportId 추가
- 신고된 리뷰 삭제 -> 신고된 리뷰 처리 후 삭제로 로직 개선
- 관리자가 처리한 신고 리뷰 및 리뷰를 삭제할 스케줄러 추가
- 테스트 코드 수정

## 🔍 테스트
- [x] 테스트 코드 작성
- [x] API 테스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?