### PR TITLE
fix: ClassLoader 기반으로 JSON 파일 로딩 방식 수정

### DIFF
--- a/src/main/java/com/meongnyangerang/meongnyangerang/service/recommendation/PetFacilityScoreService.java
+++ b/src/main/java/com/meongnyangerang/meongnyangerang/service/recommendation/PetFacilityScoreService.java
@@ -3,8 +3,9 @@ package com.meongnyangerang.meongnyangerang.service.recommendation;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
-import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -23,10 +24,15 @@ public class PetFacilityScoreService {
 
   @PostConstruct
   public void loadScoresFromJson() {
-    try {
+    try (InputStream inputStream = getClass().getClassLoader()
+        .getResourceAsStream("pet_facility_scores.json")) {
+      if (inputStream == null) {
+        throw new FileNotFoundException("Resource not found: pet_facility_scores.json");
+      }
+
       ObjectMapper objectMapper = new ObjectMapper();
       List<PetFacilityScoreEntry> scoreEntries = objectMapper.readValue(
-          new File(JSON_FILE_PATH),
+          inputStream,
           new TypeReference<>() {
           }
       );
@@ -36,10 +42,12 @@ public class PetFacilityScoreService {
             entry.getPersonality());
         scoreMap.put(key, new ScoreDetail(entry.getAccommodationScores(), entry.getRoomScores()));
       }
+
     } catch (IOException e) {
       throw new RuntimeException("Error loading pet facility scores from JSON", e);
     }
   }
+
 
   public Map<String, Integer> getAccommodationScore(String petType, String activityLevel,
       String personality) {


### PR DESCRIPTION
## 📌 관련 이슈
- JAR 파일 실행 시 `pet_facility_scores.json` 파일을 찾지 못해 애플리케이션 실행 실패

## 📝 변경 사항
### AS-IS
- `new File("src/main/resources/...")` 방식으로 JSON 파일 로딩

### TO-BE
- `getClass().getClassLoader().getResourceAsStream(...)` 방식으로 변경하여 JAR 내부에서도 정상 로딩 가능

## 🔍 테스트
- [x] API 테스트
- [x] 로컬 테스트
- 로컬 및 EC2 환경에서 애플리케이션 실행 테스트 완료

## ✅ 체크리스트
- [x] main/develop 브랜치가 아닌 feature 브랜치에서 작성했나요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 테스트는 완료했나요?
